### PR TITLE
don't use system jemalloc

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -109,10 +109,6 @@ jobs:
       - name: Install dependencies
         if: runner.os == 'Windows'
         run: choco install llvm -y
-      
-      - name: Install dependencies (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get install libjemalloc-dev
 
       - name: Run rocksdb tests
         run: |

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -29,7 +29,7 @@ exclude = [
 
 [features]
 default = ["static"]
-jemalloc = ["tikv-jemalloc-sys", "pkg-config"]
+jemalloc = ["tikv-jemalloc-sys"]
 static = ["libz-sys?/static", "bzip2-sys?/static"]
 io-uring = ["pkg-config"]
 snappy = []

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1,6 +1,11 @@
 use std::path::Path;
 use std::{env, fs, path::PathBuf, process::Command};
 
+// On these platforms jemalloc-sys will use a prefixed jemalloc which cannot be linked together
+// with RocksDB.
+// See https://github.com/tikv/jemallocator/blob/tikv-jemalloc-sys-0.5.3/jemalloc-sys/src/env.rs#L25
+const NO_JEMALLOC_TARGETS: &[&str] = &["android", "dragonfly", "musl", "darwin"];
+
 fn link(name: &str, bundled: bool) {
     use std::env::var;
     let target = var("TARGET").unwrap();
@@ -218,18 +223,11 @@ fn build_rocksdb() {
 
     config.define("ROCKSDB_SUPPORT_THREAD_LOCAL", None);
 
-    #[cfg(feature = "jemalloc")]
-    {
-        if target.contains("linux") {
-            pkg_config::probe_library("jemalloc")
-                .expect("The jemalloc feature was requested but jemalloc is not installed");
-            config.define("ROCKSDB_JEMALLOC", Some("1"));
-            config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
-        } else {
-            // this doesn't actually enable jemalloc, but mac/windows needs more
-            // work to make it work (statically link tikv-jemalloc). For now,
-            // I'll keep this as is.
-            config.define("WITH_JEMALLOC", "ON");
+    if cfg!(feature = "jemalloc") && NO_JEMALLOC_TARGETS.iter().all(|i| !target.contains(i)) {
+        config.define("ROCKSDB_JEMALLOC", Some("1"));
+        config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
+        if let Some(jemalloc_root) = env::var_os("DEP_JEMALLOC_ROOT") {
+            config.include(Path::new(&jemalloc_root).join("include"));
         }
     }
 


### PR DESCRIPTION
See https://github.com/rust-rocksdb/rust-rocksdb/issues/863 for more info. 

TLDR:  
before my change in https://github.com/zaidoon1/rust-rocksdb/commit/a2ca8cf1090f35a80ba072c4e8c547b31284833b rust rocksdb would force rocksdb to use jemalloc when the jemalloc feature is enabled because of the use of https://github.com/zaidoon1/rust-rocksdb/blob/master/librocksdb-sys/Cargo.toml#L46 in tikv jemalloc. However, because we were not passing the right flags introduced in that commit, rocksdb didn't know that jemalloc is usable so it didn't enable various optimizations that are gated behind jemalloc being enabled and also didn't allow dump memory stats option to work. While my change fixed that and allowed rocksdb to find jemalloc and enable the optimizations, it required linux systems to install jemalloc so that rocksdb can find jemalloc. Thanks to [Cristian Vîjdea](https://github.com/cvijdea-bd) we no longer need to install jemalloc on the system to have rocksdb recognize that jemalloc is installed.