### PR TITLE
make ColumnFamily Sync

### DIFF
--- a/src/column_family.rs
+++ b/src/column_family.rs
@@ -146,6 +146,7 @@ impl<'a> AsColumnFamilyRef for Arc<BoundColumnFamily<'a>> {
 }
 
 unsafe impl Send for ColumnFamily {}
+unsafe impl Sync for ColumnFamily {}
 unsafe impl Send for UnboundColumnFamily {}
 unsafe impl Sync for UnboundColumnFamily {}
 unsafe impl<'a> Send for BoundColumnFamily<'a> {}

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -217,16 +217,13 @@ pub(crate) struct OptionsMustOutliveDB {
 impl OptionsMustOutliveDB {
     pub(crate) fn clone(&self) -> Self {
         Self {
-            env: self.env.as_ref().map(Env::clone),
-            row_cache: self.row_cache.as_ref().map(Cache::clone),
+            env: self.env.clone(),
+            row_cache: self.row_cache.clone(),
             block_based: self
                 .block_based
                 .as_ref()
                 .map(BlockBasedOptionsMustOutliveDB::clone),
-            write_buffer_manager: self
-                .write_buffer_manager
-                .as_ref()
-                .map(WriteBufferManager::clone),
+            write_buffer_manager: self.write_buffer_manager.clone(),
         }
     }
 }
@@ -239,7 +236,7 @@ struct BlockBasedOptionsMustOutliveDB {
 impl BlockBasedOptionsMustOutliveDB {
     fn clone(&self) -> Self {
         Self {
-            block_cache: self.block_cache.as_ref().map(Cache::clone),
+            block_cache: self.block_cache.clone(),
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -299,6 +299,7 @@ mod test {
         is_sync::<PlainTableFactoryOptions>();
         is_sync::<UnboundColumnFamily>();
         is_sync::<ColumnFamilyDescriptor>();
+        is_sync::<ColumnFamily>();
         is_sync::<SstFileWriter>();
         is_sync::<Cache>();
         is_sync::<CacheWrapper>();

--- a/src/statistics.rs
+++ b/src/statistics.rs
@@ -495,8 +495,6 @@ iterable_named_enum! {
 
         /// The counters for error handler, not that, bg_io_error is the subset of
         /// bg_error and bg_retryable_io_error is the subset of bg_io_error.
-        /// The misspelled versions are deprecated and only kept for compatibility.
-        /// ToDO: remove the misspelled tickers in the next major release.
         ErrorHandlerBgErrorCount("rocksdb.error.handler.bg.error.count"),
         ErrorHandlerBgIoErrorCount("rocksdb.error.handler.bg.io.error.count"),
         ErrorHandlerBgRetryableIoErrorCount("rocksdb.error.handler.bg.retryable.io.error.count"),


### PR DESCRIPTION
This resolves a long standing issue https://github.com/rust-rocksdb/rust-rocksdb/issues/407 where because ColumnFamily is not Sync, we are not able to fetch all the cfs on startup and use them directly, instead, we are currently forced to call `cf_handle` on every operation to get the cf which adds unnecessary overhead 