### PR TITLE
Bump jemalloc and allow musl unprefixed jemalloc

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -44,7 +44,7 @@ zstd-static-linking-only = []
 
 [dependencies]
 libc = "0.2"
-tikv-jemalloc-sys = { version = "0.5", features = [
+tikv-jemalloc-sys = { version = "0.6", features = [
     "unprefixed_malloc_on_supported_platforms",
 ], optional = true }
 lz4-sys = { version = "1.9", optional = true }

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -3,8 +3,8 @@ use std::{env, fs, path::PathBuf, process::Command};
 
 // On these platforms jemalloc-sys will use a prefixed jemalloc which cannot be linked together
 // with RocksDB.
-// See https://github.com/tikv/jemallocator/blob/tikv-jemalloc-sys-0.5.3/jemalloc-sys/src/env.rs#L25
-const NO_JEMALLOC_TARGETS: &[&str] = &["android", "dragonfly", "musl", "darwin"];
+// See https://github.com/tikv/jemallocator/blob/f7adfca5aff272b43fd3ad896252b57fbbd9c72a/jemalloc-sys/src/env.rs#L24
+const NO_JEMALLOC_TARGETS: &[&str] = &["android", "dragonfly", "darwin"];
 
 fn link(name: &str, bundled: bool) {
     use std::env::var;


### PR DESCRIPTION
jemallocator 0.6.0 was released: https://github.com/tikv/jemallocator/blob/HEAD/CHANGELOG.md#060---2024-07-14

Also musl has been allowed as an unprefixed target here: https://github.com/tikv/jemallocator/commit/f7adfca5aff272b43fd3ad896252b57fbbd9c72a