### PR TITLE
manually generate Cargo.lock to fix sec audit

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -22,6 +22,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: generate Cargo.lock
+        run: cargo generate-lockfile
+
       - name: Audit Check
         # https://github.com/rustsec/audit-check/issues/2
         uses: rustsec/audit-check@master


### PR DESCRIPTION
This was broken in the latest release https://github.com/rustsec/audit-check/releases/tag/v2.0.0 specifically becasue of https://github.com/rustsec/audit-check/pull/20 . We now manually generated the lockfile when running the audit check