### PR TITLE
[write_batch] Add support for WriteBatch::put_log_data

### DIFF
--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -370,6 +370,28 @@ impl WriteBatchWithTransaction<false> {
             );
         }
     }
+
+    // Append a blob of arbitrary size to the records in this batch. The blob will
+    // be stored in the transaction log but not in any other file. In particular,
+    // it will not be persisted to the SST files. When iterating over this
+    // WriteBatch, WriteBatch::Handler::LogData will be called with the contents
+    // of the blob as it is encountered. Blobs, puts, deletes, and merges will be
+    // encountered in the same order in which they were inserted. The blob will
+    // NOT consume sequence number(s) and will NOT increase the count of the batch
+    //
+    // Example application: add timestamps to the transaction log for use in
+    // replication.
+    pub fn put_log_data<V: AsRef<[u8]>>(&mut self, log_data: V) {
+        let log_data = log_data.as_ref();
+
+        unsafe {
+            ffi::rocksdb_writebatch_put_log_data(
+                self.inner,
+                log_data.as_ptr() as *const c_char,
+                log_data.len() as size_t,
+            );
+        }
+    }
 }
 
 impl<const TRANSACTION: bool> Default for WriteBatchWithTransaction<TRANSACTION> {


### PR DESCRIPTION
What does this PR do?
---------------------
- Add support for `WriteBatch::put_log_data`

Motivation
----------
Have `put_log_data` available to handle some replication use cases.