### PR TITLE
Fix C++ linking (#981)

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -312,6 +312,11 @@ fn build_rocksdb() {
 
     config.cpp(true);
     config.flag_if_supported("-std=c++17");
+    if target.contains("linux") {
+        config.cpp_link_stdlib("stdc++");
+    } else if !target.contains("windows") {
+        config.cpp_link_stdlib("c++");
+    }
     config.compile("librocksdb.a");
 }
 
@@ -424,16 +429,6 @@ fn main() {
         println!("cargo:rerun-if-changed=rocksdb/");
         fail_on_empty_directory("rocksdb");
         build_rocksdb();
-    } else {
-        // according to https://github.com/alexcrichton/cc-rs/blob/master/src/lib.rs#L2189
-        if target.contains("apple") || target.contains("freebsd") || target.contains("openbsd") {
-            println!("cargo:rustc-link-lib=dylib=c++");
-        } else if target.contains("linux") {
-            println!("cargo:rustc-link-lib=dylib=stdc++");
-        } else if target.contains("aix") {
-            println!("cargo:rustc-link-lib=dylib=c++");
-            println!("cargo:rustc-link-lib=dylib=c++abi");
-        }
     }
     if cfg!(feature = "snappy") && !try_to_find_and_link_lib("SNAPPY") {
         println!("cargo:rerun-if-changed=snappy/");


### PR DESCRIPTION
* Fix C++ linking

Hard-coding the C++ library linking is bad practice, and instead this crate needs to follow the practices as described under https://docs.rs/cc/1.2.14/cc/index.html#c-support.

Without doing so, this crate will not compile on when using libc++ instead of libstdc++.

This change will keep the existing behaviour, while allowing downstream consumers of this crate to override the C++ library with the `CXXSTDLIB` which is respected by the cc crate.