### PR TITLE
add ROCKSDB_AUXV_GETAUXVAL_PRESENT for supported Linux systems

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -51,7 +51,10 @@ tikv-jemalloc-sys = { version = "0.6", features = [
     "unprefixed_malloc_on_supported_platforms",
 ], optional = true }
 lz4-sys = { version = "1.10", optional = true }
-zstd-sys = { version = "2.0", features = ["zdict_builder", "experimental"], optional = true }
+zstd-sys = { version = "2.0", features = [
+    "zdict_builder",
+    "experimental",
+], optional = true }
 libz-sys = { version = "1.1", default-features = false, optional = true }
 bzip2-sys = { version = "0.1", default-features = false, optional = true }
 
@@ -64,3 +67,4 @@ cc = { version = "1.0", features = ["parallel"] }
 bindgen = { version = "0.69", default-features = false }
 glob = "0.3"
 pkg-config = { version = "0.3", optional = true }
+libc = "0.2"


### PR DESCRIPTION
This lets RocksDB know that getauxval is supported which is needed to enable hardware accelerated crc32c for ARM on Linux. This still won't work until we update to a rocksdb version that has this commit: https://github.com/facebook/rocksdb/commit/1d6c33d2a59f6f9dd23e7db61618a0f0aa3c1600
 