### PR TITLE
Add support for set_prepopulate_blob_cache

### DIFF
--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3708,6 +3708,22 @@ impl Options {
         self.outlive.blob_cache = Some(cache.clone());
     }
 
+    /// If enabled, prepopulate warm/hot blocks (data, uncompressed dict, index and
+    /// filter blocks) which are already in memory into block cache at the time of
+    /// flush. On a flush, the block that is in memory (in memtables) get flushed
+    /// to the device. If using Direct IO, additional IO is incurred to read this
+    /// data back into memory again, which is avoided by enabling this option. This
+    /// further helps if the workload exhibits high temporal locality, where most
+    /// of the reads go to recently written data. This also helps in case of
+    /// Distributed FileSystem.
+    ///
+    /// Default: `PrepopulateBlockCache::Disable`
+    pub fn set_prepopulate_blob_cache(&mut self, t: PrepopulateBlockCache) {
+        unsafe {
+            ffi::rocksdb_options_set_prepopulate_blob_cache(self.inner, t as c_int);
+        }
+    }
+
     /// Set this option to true during creation of database if you want
     /// to be able to ingest behind (call IngestExternalFile() skipping keys
     /// that already exist, rather than overwriting matching keys).
@@ -4599,6 +4615,16 @@ pub enum BlockBasedPinningTier {
     None = ffi::rocksdb_block_based_k_none_pinning_tier as isize,
     FlushAndSimilar = ffi::rocksdb_block_based_k_flush_and_similar_pinning_tier as isize,
     All = ffi::rocksdb_block_based_k_all_pinning_tier as isize,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde1", derive(serde::Serialize, serde::Deserialize))]
+/// Controls whether blobs are inserted into block cache on blob flush.
+pub enum PrepopulateBlockCache {
+    /// Disable prepopulate block cache.
+    Disable = ffi::rocksdb_prepopulate_blob_disable as isize,
+    /// Prepopulate blocks during flush only.
+    FlushOnly = ffi::rocksdb_prepopulate_blob_flush_only as isize,
 }
 
 pub struct FifoCompactOptions {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -126,7 +126,7 @@ pub use crate::{
         Cache, ChecksumType, CompactOptions, CuckooTableOptions, DBCompactionPri,
         DBCompactionStyle, DBCompressionType, DBPath, DBRecoveryMode, DataBlockIndexType,
         FifoCompactOptions, FlushOptions, IngestExternalFileOptions, KeyEncodingType, LogLevel,
-        LruCacheOptions, MemtableFactory, Options, PlainTableFactoryOptions, RateLimiterMode,
+        LruCacheOptions, MemtableFactory, Options, PlainTableFactoryOptions, PrepopulateBlockCache, RateLimiterMode,
         ReadOptions, ReadTier, UniversalCompactOptions, UniversalCompactionStopStyle,
         WaitForCompactOptions, WriteBufferManager, WriteOptions,
     },


### PR DESCRIPTION
Expose `set_prepopulate_blob_cache` in the `Options` struct.

Mirrors this PR: https://github.com/rust-rocksdb/rust-rocksdb/pull/986
