### PR TITLE
fix: gcc15 build support

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -337,6 +337,7 @@ fn build_rocksdb() {
     } else if !target.contains("windows") {
         config.cpp_link_stdlib("c++");
     }
+    config.flag("-include").flag("cstdint");
     config.compile("librocksdb.a");
 }
 


### PR DESCRIPTION
stolen from https://github.com/rust-rocksdb/rust-rocksdb/pull/1007/commits/7d3889271a6de0afd51fbcfa95184958c9fa9761

see https://github.com/rust-rocksdb/rust-rocksdb/issues/991
and https://github.com/rust-rocksdb/rust-rocksdb/pull/1007