### PR TITLE
Add with_thread_local helper for efficient PerfContext reuse

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub use crate::{
     ffi_util::CStrLike,
     iter_range::{IterateBounds, PrefixRange},
     merge_operator::MergeOperands,
-    perf::{PerfContext, PerfMetric, PerfStatsLevel},
+    perf::{PerfContext, PerfMetric, PerfStatsLevel, set_perf_stats, with_thread_local},
     slice_transform::SliceTransform,
     snapshot::{Snapshot, SnapshotWithThreadMode},
     sst_file_manager::SstFileManager,


### PR DESCRIPTION
Add a `with_thread_local` function that provides access to a thread-local PerfContext, automatically resetting it before each use. This avoids the overhead of creating and destroying PerfContext instances on each call, which involves FFI calls to rocksdb_perfcontext_create and rocksdb_perfcontext_destroy.
Also export `set_perf_stats` from the crate root for convenience.