### PR TITLE
Release 0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 0.47.0 (2026-04-08)
+
+- upgrade RocksDB to 11.0.4 (zaidoon1)
+- feat: add flush, flush_wal, flush_cf, flush_cf_opt, flush_cfs_opt to TransactionDB (gdorsi)
+- feat: add timestamp() to DBRawIteratorWithThreadMode (asumpster)
+- feat: add IngestExternalFileOptions AsRawPtr impl (asumpster)
+- feat: add Iterator::Refresh() bindings (joshsend)
+- fix: memory leak in Options.set_info_logger (evanj)
+- fix: sync build.rs defines with RocksDB; pass through -Ctarget-cpu and set aarch64 CRC32 flags (evanj)
+- breaking: remove set_skip_checking_sst_file_sizes_on_db_open (removed from RocksDB 11.0 C API) (zaidoon1)
+- chore: replace trybuild with compile_fail doctests, removing trybuild dev-dependency (zaidoon1)
+
 ## 0.46.0 (2026-02-03)
 
 - upgrade RocksDB to 10.10.1 (zaidoon1)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.46.0"
+version = "0.47.0"
 edition = "2024"
 rust-version = "1.89.0"
 authors = [


### PR DESCRIPTION
## Summary
- Bump version to 0.47.0
- Add CHANGELOG.md entry for all changes since 0.46.0