### PR TITLE
Release 0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.48.0 (2026-05-04)
+
+- upgrade RocksDB to 11.1.1 (zaidoon1)
+
 ## 0.47.0 (2026-04-08)
 
 - upgrade RocksDB to 11.0.4 (zaidoon1)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.47.0"
+version = "0.48.0"
 edition = "2024"
 rust-version = "1.89.0"
 authors = [


### PR DESCRIPTION
## Summary
- Bump version to 0.48.0
- Add CHANGELOG.md entry for all changes since 0.47.0