### PR TITLE
Add TransactionDB checkpoint support

### DIFF
--- a/src/checkpoint.rs
+++ b/src/checkpoint.rs
@@ -18,7 +18,9 @@
 //! [1]: https://github.com/facebook/rocksdb/wiki/Checkpoints
 
 use crate::db::{DBInner, ExportImportFilesMetaData};
-use crate::{AsColumnFamilyRef, DBCommon, Error, ThreadMode, ffi, ffi_util::to_cpath};
+use crate::{
+    AsColumnFamilyRef, DBCommon, Error, ThreadMode, TransactionDB, ffi, ffi_util::to_cpath,
+};
 use std::{marker::PhantomData, path::Path};
 
 /// Default value for the `log_size_for_flush` parameter passed to
@@ -196,6 +198,114 @@ impl<'db> Checkpoint<'db> {
 }
 
 impl Drop for Checkpoint<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_checkpoint_object_destroy(self.inner);
+        }
+    }
+}
+
+/// TransactionDB's checkpoint object.
+/// Used to create checkpoints of the specified TransactionDB from time to time.
+///
+/// A `TransactionDBCheckpoint` must not outlive the `TransactionDB` it was created from:
+///
+/// ```compile_fail,E0597
+/// use rust_rocksdb::{checkpoint::TransactionDBCheckpoint, SingleThreaded, TransactionDB};
+///
+/// let _checkpoint = {
+///     let db = TransactionDB::<SingleThreaded>::open_default("foo").unwrap();
+///     TransactionDBCheckpoint::new(&db)
+/// };
+/// ```
+///
+/// `TransactionDBCheckpoint` does not expose `create_checkpoint_with_log_size`
+/// because RocksDB TransactionDB checkpoints are expected to flush regardless
+/// of that setting:
+///
+/// ```compile_fail,E0599
+/// use rust_rocksdb::{checkpoint::TransactionDBCheckpoint, TransactionDB};
+///
+/// let db: TransactionDB = TransactionDB::open_default("foo").unwrap();
+/// let checkpoint = TransactionDBCheckpoint::new(&db).unwrap();
+/// checkpoint
+///     .create_checkpoint_with_log_size("foo-checkpoint", u64::MAX)
+///     .unwrap();
+/// ```
+pub struct TransactionDBCheckpoint<'db> {
+    inner: *mut ffi::rocksdb_checkpoint_t,
+    _db: PhantomData<&'db ()>,
+}
+
+impl<'db> TransactionDBCheckpoint<'db> {
+    /// Creates new checkpoint object for a specific TransactionDB.
+    ///
+    /// Does not actually produce checkpoints, call `.create_checkpoint()` to produce
+    /// a TransactionDB checkpoint.
+    pub fn new<T: ThreadMode>(db: &'db TransactionDB<T>) -> Result<Self, Error> {
+        let checkpoint: *mut ffi::rocksdb_checkpoint_t;
+
+        unsafe {
+            checkpoint = ffi_try!(ffi::rocksdb_transactiondb_checkpoint_object_create(
+                db.inner
+            ));
+        }
+
+        if checkpoint.is_null() {
+            return Err(Error::new("Could not create checkpoint object.".to_owned()));
+        }
+
+        Ok(Self {
+            inner: checkpoint,
+            _db: PhantomData,
+        })
+    }
+
+    /// Creates a new physical RocksDB checkpoint in the directory specified by `path`.
+    ///
+    /// This method uses the default `log_size_for_flush` value (`0`), which instructs
+    /// RocksDB to flush memtables as needed before creating the checkpoint.
+    pub fn create_checkpoint<P: AsRef<Path>>(&self, path: P) -> Result<(), Error> {
+        let c_path = to_cpath(path)?;
+        unsafe {
+            ffi_try!(ffi::rocksdb_checkpoint_create(
+                self.inner,
+                c_path.as_ptr(),
+                DEFAULT_LOG_SIZE_FOR_FLUSH,
+            ));
+        }
+        Ok(())
+    }
+
+    /// Export a specified Column Family.
+    ///
+    /// Creates copies of the live SST files at the specified export path.
+    ///
+    /// - SST files will be created as hard links when the directory specified
+    ///   is in the same partition as the db directory, copied otherwise.
+    /// - the path must not yet exist - a new directory will be created as part of the export.
+    /// - Always triggers a flush.
+    ///
+    /// See also: [`DB::create_column_family_with_import`](crate::DB::create_column_family_with_import).
+    pub fn export_column_family<P: AsRef<Path>>(
+        &self,
+        column_family: &impl AsColumnFamilyRef,
+        path: P,
+    ) -> Result<ExportImportFilesMetaData, Error> {
+        let c_path = to_cpath(path)?;
+        let column_family_handle = column_family.inner();
+        let metadata = unsafe {
+            ffi_try!(ffi::rocksdb_checkpoint_export_column_family(
+                self.inner,
+                column_family_handle,
+                c_path.as_ptr(),
+            ))
+        };
+        Ok(ExportImportFilesMetaData { inner: metadata })
+    }
+}
+
+impl Drop for TransactionDBCheckpoint<'_> {
     fn drop(&mut self) {
         unsafe {
             ffi::rocksdb_checkpoint_object_destroy(self.inner);

--- a/tests/test_checkpoint.rs
+++ b/tests/test_checkpoint.rs
@@ -17,10 +17,10 @@ mod util;
 use pretty_assertions::assert_eq;
 use std::path::Path;
 
-use rust_rocksdb::checkpoint::Checkpoint;
+use rust_rocksdb::checkpoint::{Checkpoint, TransactionDBCheckpoint};
 use rust_rocksdb::{
     DB, DBWithThreadMode, ExportImportFilesMetaData, ImportColumnFamilyOptions, IteratorMode,
-    MultiThreaded, OptimisticTransactionDB, Options,
+    MultiThreaded, OptimisticTransactionDB, Options, TransactionDB, TransactionDBOptions,
 };
 use std::fs;
 use util::DBPath;
@@ -284,6 +284,65 @@ pub fn test_optimistic_transaction_db_checkpoint_with_log_size_zero_forces_flush
     );
 }
 
+/// Test `create_checkpoint` on TransactionDB flushes memtables before creating the checkpoint.
+///
+/// TransactionDB enables two-phase commit internally, so RocksDB flushes even when
+/// the checkpoint API's log size setting would otherwise allow WAL replay.
+#[test]
+pub fn test_transaction_db_checkpoint_create_checkpoint_forces_flush() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_txn_cp_flush_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db"));
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    let db: TransactionDB =
+        TransactionDB::open(&opts, &TransactionDBOptions::default(), &db_path).unwrap();
+
+    // Write some initial data and flush it explicitly to ensure we have
+    // some materialized state in SST files.
+    db.put(b"flushed_key", b"flushed_value").unwrap();
+    db.flush().unwrap();
+
+    // Write additional data that will remain in the memtable unless the
+    // checkpoint creation flushes it.
+    db.put(b"memtable_key", b"memtable_value").unwrap();
+
+    let cp = TransactionDBCheckpoint::new(&db).unwrap();
+    let cp_path = DBPath::new(&format!("{PATH_PREFIX}cp"));
+    cp.create_checkpoint(&cp_path).unwrap();
+
+    // Verify there is exactly one WAL file and it is empty, proving the
+    // memtable data was flushed to SST instead of relying on WAL replay.
+    let wal_files: Vec<_> = fs::read_dir((&cp_path).as_ref())
+        .unwrap()
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.path().extension().is_some_and(|ext| ext == "log"))
+        .collect();
+    assert_eq!(
+        wal_files.len(),
+        1,
+        "Checkpoint should contain exactly one WAL file"
+    );
+    let wal_metadata = wal_files[0].metadata().unwrap();
+    assert_eq!(
+        wal_metadata.len(),
+        0,
+        "WAL file should be empty when TransactionDB checkpoint creation flushes"
+    );
+
+    let cp_db: TransactionDB = TransactionDB::open_default(&cp_path).unwrap();
+
+    assert_eq!(
+        cp_db.get(b"flushed_key").unwrap().unwrap(),
+        b"flushed_value"
+    );
+    assert_eq!(
+        cp_db.get(b"memtable_key").unwrap().unwrap(),
+        b"memtable_value"
+    );
+}
+
 /// Test `create_checkpoint_with_log_size` on OptimisticTransactionDB with a large log_size_for_flush value.
 /// A non-zero value means RocksDB skips flushing memtables if the WAL is smaller
 /// than the threshold. However, the checkpoint still includes WAL files, so when
@@ -345,6 +404,161 @@ pub fn test_optimistic_transaction_db_checkpoint_with_large_log_size_skips_flush
     assert_eq!(
         cp_db.get(b"memtable_key").unwrap().unwrap(),
         b"memtable_value"
+    );
+}
+
+/// Test that TransactionDB checkpoints include both direct writes and committed transaction writes.
+#[test]
+pub fn test_transaction_db_checkpoint_includes_direct_and_committed_writes() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_txn_cp_basic_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db"));
+    let db: TransactionDB = TransactionDB::open_default(&db_path).unwrap();
+
+    db.put(b"direct_key", b"direct_value").unwrap();
+
+    let txn = db.transaction();
+    txn.put(b"txn_key", b"txn_value").unwrap();
+    txn.commit().unwrap();
+
+    let cp = TransactionDBCheckpoint::new(&db).unwrap();
+    let cp_path = DBPath::new(&format!("{PATH_PREFIX}cp"));
+    cp.create_checkpoint(&cp_path).unwrap();
+
+    let cp_db: TransactionDB = TransactionDB::open_default(&cp_path).unwrap();
+
+    assert_eq!(cp_db.get(b"direct_key").unwrap().unwrap(), b"direct_value");
+    assert_eq!(cp_db.get(b"txn_key").unwrap().unwrap(), b"txn_value");
+}
+
+/// Test that TransactionDB checkpoints do not include uncommitted transaction writes.
+#[test]
+pub fn test_transaction_db_checkpoint_excludes_uncommitted_writes() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_txn_cp_uncommitted_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db"));
+    let db: TransactionDB = TransactionDB::open_default(&db_path).unwrap();
+
+    db.put(b"committed_key", b"committed_value").unwrap();
+
+    let txn = db.transaction();
+    txn.put(b"uncommitted_key", b"uncommitted_value").unwrap();
+
+    let cp = TransactionDBCheckpoint::new(&db).unwrap();
+    let cp_path = DBPath::new(&format!("{PATH_PREFIX}cp"));
+    cp.create_checkpoint(&cp_path).unwrap();
+
+    let cp_db: TransactionDB = TransactionDB::open_default(&cp_path).unwrap();
+
+    assert_eq!(
+        cp_db.get(b"committed_key").unwrap().unwrap(),
+        b"committed_value"
+    );
+    assert!(cp_db.get(b"uncommitted_key").unwrap().is_none());
+
+    txn.rollback().unwrap();
+}
+
+/// Test that the same TransactionDB checkpoint object can create multiple checkpoints.
+#[test]
+pub fn test_transaction_db_checkpoint_object_can_create_multiple_checkpoints() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_txn_cp_multi_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db"));
+    let db: TransactionDB = TransactionDB::open_default(&db_path).unwrap();
+
+    db.put(b"k1", b"v1").unwrap();
+
+    let cp = TransactionDBCheckpoint::new(&db).unwrap();
+    let cp1_path = DBPath::new(&format!("{PATH_PREFIX}cp1"));
+    cp.create_checkpoint(&cp1_path).unwrap();
+
+    db.put(b"k2", b"v2").unwrap();
+
+    let cp2_path = DBPath::new(&format!("{PATH_PREFIX}cp2"));
+    cp.create_checkpoint(&cp2_path).unwrap();
+
+    let cp1_db: TransactionDB = TransactionDB::open_default(&cp1_path).unwrap();
+    assert_eq!(cp1_db.get(b"k1").unwrap().unwrap(), b"v1");
+    assert!(cp1_db.get(b"k2").unwrap().is_none());
+
+    let cp2_db: TransactionDB = TransactionDB::open_default(&cp2_path).unwrap();
+    assert_eq!(cp2_db.get(b"k1").unwrap().unwrap(), b"v1");
+    assert_eq!(cp2_db.get(b"k2").unwrap().unwrap(), b"v2");
+}
+
+/// Test that TransactionDB checkpoints preserve column family data.
+#[test]
+pub fn test_transaction_db_checkpoint_preserves_column_families() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_txn_cp_cf_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db"));
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let db: TransactionDB = TransactionDB::open_cf(
+        &opts,
+        &TransactionDBOptions::default(),
+        &db_path,
+        ["cf1", "cf2"],
+    )
+    .unwrap();
+
+    let cf1 = db.cf_handle("cf1").unwrap();
+    let cf2 = db.cf_handle("cf2").unwrap();
+
+    db.put(b"default_key", b"default_value").unwrap();
+    db.put_cf(&cf1, b"cf1_key", b"cf1_value").unwrap();
+    db.put_cf(&cf2, b"cf2_key", b"cf2_value").unwrap();
+
+    let cp = TransactionDBCheckpoint::new(&db).unwrap();
+    let cp_path = DBPath::new(&format!("{PATH_PREFIX}cp"));
+    cp.create_checkpoint(&cp_path).unwrap();
+
+    let cp_db: TransactionDB = TransactionDB::open_cf(
+        &Options::default(),
+        &TransactionDBOptions::default(),
+        &cp_path,
+        ["cf1", "cf2"],
+    )
+    .unwrap();
+
+    let cp_cf1 = cp_db.cf_handle("cf1").unwrap();
+    let cp_cf2 = cp_db.cf_handle("cf2").unwrap();
+
+    assert_eq!(
+        cp_db.get(b"default_key").unwrap().unwrap(),
+        b"default_value"
+    );
+    assert_eq!(
+        cp_db.get_cf(&cp_cf1, b"cf1_key").unwrap().unwrap(),
+        b"cf1_value"
+    );
+    assert_eq!(
+        cp_db.get_cf(&cp_cf2, b"cf2_key").unwrap().unwrap(),
+        b"cf2_value"
+    );
+}
+
+/// Test that TransactionDB checkpoint creation returns an error if the destination exists.
+#[test]
+pub fn test_transaction_db_checkpoint_fails_if_path_exists() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_txn_cp_existing_path_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db"));
+    let db: TransactionDB = TransactionDB::open_default(&db_path).unwrap();
+
+    db.put(b"k1", b"v1").unwrap();
+
+    let cp_path = DBPath::new(&format!("{PATH_PREFIX}cp"));
+    fs::create_dir_all((&cp_path).as_ref()).unwrap();
+
+    let cp = TransactionDBCheckpoint::new(&db).unwrap();
+    let err = cp.create_checkpoint(&cp_path).unwrap_err();
+
+    assert!(
+        !err.to_string().is_empty(),
+        "checkpoint error should include RocksDB failure details"
     );
 }
 
@@ -558,6 +772,121 @@ pub fn test_export_checkpoint_column_family() {
 
     export_files.iter().for_each(|export_file| {
         assert!(export_file.column_family_name.is_empty()); // CF export does not have the CF name
+        assert!(!export_file.name.is_empty());
+        assert!(!export_file.directory.is_empty());
+    });
+
+    let mut import_metadata = ExportImportFilesMetaData::default();
+    import_metadata.set_db_comparator_name(&export_metadata.get_db_comparator_name());
+    import_metadata.set_files(&export_files.to_vec()).unwrap();
+
+    let cf_opts = Options::default();
+    let mut import_opts = ImportColumnFamilyOptions::default();
+    import_opts.set_move_files(true);
+    db_new
+        .create_column_family_with_import(&cf_opts, "cf1-new", &import_opts, &import_metadata)
+        .unwrap();
+
+    assert!(export_files.iter().all(|export_file| {
+        !Path::new(&export_file.directory)
+            .join(&export_file.name)
+            .exists()
+    }));
+
+    let cf1_new = db_new.cf_handle("cf1-new").unwrap();
+    let imported_data: Vec<_> = db_new
+        .iterator_cf(&cf1_new, IteratorMode::Start)
+        .map(Result::unwrap)
+        .map(|(k, v)| {
+            (
+                String::from_utf8_lossy(&k).into_owned(),
+                String::from_utf8_lossy(&v).into_owned(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        vec![
+            ("k1".to_string(), "v1".to_string()),
+            ("k3".to_string(), "v3".to_string()),
+        ],
+        imported_data,
+    );
+
+    let cf0 = db_new.cf_handle("cf0").unwrap();
+    let original_data: Vec<_> = db_new
+        .iterator_cf(&cf0, IteratorMode::Start)
+        .map(Result::unwrap)
+        .map(|(k, v)| {
+            (
+                String::from_utf8_lossy(&k).into_owned(),
+                String::from_utf8_lossy(&v).into_owned(),
+            )
+        })
+        .collect();
+    assert_eq!(
+        vec![
+            ("k1".to_string(), "v0".to_string()),
+            ("k5".to_string(), "v5".to_string()),
+        ],
+        original_data,
+    );
+}
+
+#[test]
+pub fn test_export_transaction_db_checkpoint_column_family() {
+    const PATH_PREFIX: &str = "_rust_rocksdb_txn_cf_export_";
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db-src"));
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    opts.create_missing_column_families(true);
+    let db: TransactionDB = TransactionDB::open_cf(
+        &opts,
+        &TransactionDBOptions::default(),
+        &db_path,
+        ["cf1", "cf2"],
+    )
+    .unwrap();
+
+    let cf1 = db.cf_handle("cf1").unwrap();
+    db.put_cf(&cf1, b"k1", b"v1").unwrap();
+    db.put_cf(&cf1, b"k2", b"v2").unwrap();
+
+    let cf2 = db.cf_handle("cf2").unwrap();
+    db.put_cf(&cf2, b"k1", b"v1_cf2").unwrap();
+
+    let cp = TransactionDBCheckpoint::new(&db).unwrap();
+
+    db.flush_cf(&cf1).expect("flush succeeds");
+    db.delete_cf(&cf1, b"k2").unwrap();
+    db.put_cf(&cf1, b"k3", b"v3").unwrap();
+
+    let cf1_export_path = DBPath::new(&format!("{PATH_PREFIX}cf1-export"));
+    let export_metadata = cp.export_column_family(&cf1, &cf1_export_path).unwrap();
+
+    db.put_cf(&cf1, b"k4", b"v4").unwrap();
+    db.delete_cf(&cf1, b"k1").unwrap();
+
+    let db_path = DBPath::new(&format!("{PATH_PREFIX}db-dest"));
+
+    let mut opts = Options::default();
+    opts.create_if_missing(true);
+    let db_new = DBWithThreadMode::<MultiThreaded>::open(&opts, &db_path).unwrap();
+
+    // Prepopulate some data in the destination DB - this should remain intact after import
+    {
+        db_new.create_cf("cf0", &opts).unwrap();
+        let cf0 = db_new.cf_handle("cf0").unwrap();
+        db_new.put_cf(&cf0, b"k1", b"v0").unwrap();
+        db_new.put_cf(&cf0, b"k5", b"v5").unwrap();
+    }
+
+    let export_files = export_metadata.get_files();
+    assert!(!export_files.is_empty());
+
+    export_files.iter().for_each(|export_file| {
+        assert!(export_file.column_family_name.is_empty());
         assert!(!export_file.name.is_empty());
         assert!(!export_file.directory.is_empty());
     });


### PR DESCRIPTION
This adds `checkpoint::TransactionDBCheckpoint`, a checkpoint object for `TransactionDB` that follows the same usage pattern as the existing `checkpoint::Checkpoint` type.

This uses a dedicated TransactionDBCheckpoint type instead of extending Checkpoint to accept TransactionDB, because TransactionDB checkpoints are created through a separate RocksDB API and have a narrower supported surface. Keeping this as its own type avoids making TransactionDB fit the DBCommon abstraction just for checkpoint creation, while preserving the same usage pattern as the existing Checkpoint API.

Example usage:

```rust
use rust_rocksdb::{checkpoint::TransactionDBCheckpoint, TransactionDB};

let db: TransactionDB = TransactionDB::open_default(path)?;
let checkpoint = TransactionDBCheckpoint::new(&db)?;

checkpoint.create_checkpoint(checkpoint_path)?;
```

The new type is exposed through the existing `checkpoint` module, matching `Checkpoint`, and is tied to the lifetime of the source `TransactionDB`.

This intentionally does not add `create_checkpoint_with_log_size` for `TransactionDBCheckpoint`. RocksDB enables two-phase commit internally for `TransactionDB`, so the log-size setting does not provide the same "skip flush when WAL is small" behavior that it can provide for a regular `DB`.

Supersedes https://github.com/zaidoon1/rust-rocksdb/pull/177
Fixes https://github.com/zaidoon1/rust-rocksdb/issues/176