### PR TITLE
Add opt-in coroutines feature for multi-level async MultiGet

### DIFF
--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -53,11 +53,32 @@ jobs:
       - name: Install build dependencies
         run: |
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-            build-essential cmake ninja-build python3 python3-pip pkg-config patchelf \
+            build-essential gcc-14 g++-14 \
+            cmake ninja-build python3 python3-pip pkg-config patchelf \
             wget \
             libdouble-conversion-dev libssl-dev liburing-dev \
             zlib1g-dev libbz2-dev autoconf automake libtool \
             clang llvm
+
+      # Force gcc-14 instead of ubuntu:25.10's default gcc-15. folly's pinned
+      # libunwind commit (f081cf4...) was written pre-C23 and uses legacy
+      # K&R-style function declarations (`func()` meaning "unspecified
+      # arguments"). gcc-15 defaults to `-std=gnu23` for C, where `func()`
+      # means "no arguments", so calls like `func(s)` in libunwind's tests
+      # become hard errors. gcc-14 still defaults to `-std=gnu17`, which
+      # preserves the legacy semantic.
+      #
+      # gcc-14 and gcc-15 share the same libstdc++ ABI, so the subsequent
+      # `cargo build` (which uses gcc-14 here too via cc/c++ alternatives)
+      # links cleanly against folly's output.
+      - name: Switch default compiler to gcc-14
+        run: |
+          update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100
+          update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-14 100
+          update-alternatives --install /usr/bin/cc  cc  /usr/bin/gcc-14 100
+          update-alternatives --install /usr/bin/c++ c++ /usr/bin/g++-14 100
+          gcc --version
+          g++ --version
 
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -15,7 +15,15 @@ env:
 jobs:
   build-and-test:
     name: Build & test with coroutines feature
-    runs-on: ubuntu-latest
+    # Pin to a specific Ubuntu image, NOT `ubuntu-latest`. Folly is built
+    # against the host's glibc, libstdc++ and apt-installed system packages
+    # (libdouble-conversion-dev, libssl-dev, etc.). If `ubuntu-latest` rolls
+    # forward (e.g. 24.04 -> 26.04) while the folly cache still hits, the
+    # cached binaries would link/run against a different ABI than the user's
+    # `cargo build` step expects, with confusing symptoms. The cache key
+    # below also encodes the image name so an explicit image bump invalidates
+    # the cache.
+    runs-on: ubuntu-24.04
     # Folly's getdeps build can take 30-60+ minutes on a cold cache on
     # standard GHA runners (small core count, no parallelism flags). 90
     # minutes is a comfortable upper bound. With a warm cache the whole
@@ -31,7 +39,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y \
-            cmake ninja-build python3 python3-pip pkg-config \
+            cmake ninja-build python3 python3-pip pkg-config patchelf \
             libdouble-conversion-dev libssl-dev liburing-dev \
             zlib1g-dev libbz2-dev autoconf automake libtool
 
@@ -41,9 +49,13 @@ jobs:
           cache-key: "v1-rust-coroutines"
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
-      # Folly takes 15-30 minutes to build from scratch. Cache it keyed on
-      # the exact FOLLY_COMMIT_HASH pinned by RocksDB's folly.mk so any
-      # upstream submodule bump invalidates the cache.
+      # The folly build's correctness depends on three independent inputs:
+      #   1. The folly commit (pinned by RocksDB's folly.mk:FOLLY_COMMIT_HASH).
+      #   2. The exact host OS image (glibc + libstdc++ + apt package versions).
+      #   3. The CPU arch (x86_64 vs aarch64).
+      # All three are encoded in the cache key. The `-v2` suffix lets us bump
+      # the cache manually if the build script changes in a way that
+      # invalidates prior caches.
       - name: Determine folly commit hash
         id: folly-hash
         run: |
@@ -56,8 +68,17 @@ jobs:
         id: cache-folly
         uses: actions/cache@v4
         with:
-          path: librocksdb-sys/rocksdb/third-party/folly
-          key: folly-${{ runner.os }}-${{ steps.folly-hash.outputs.hash }}-v1
+          # `build_folly.sh` uses --scratch-path so install artifacts live
+          # inside the workspace at a predictable location. Cache both that
+          # and the folly source checkout so a warm hit avoids both the
+          # clone and the build. Files written by the build:
+          #   librocksdb-sys/folly-build/installed/{folly,boost,...}-*/
+          #   librocksdb-sys/folly-build/{downloads,build,extracted,shipit}/
+          #   librocksdb-sys/rocksdb/third-party/folly/   (source + patches)
+          path: |
+            librocksdb-sys/folly-build
+            librocksdb-sys/rocksdb/third-party/folly
+          key: folly-${{ runner.os }}-${{ runner.arch }}-ubuntu-24.04-${{ steps.folly-hash.outputs.hash }}-v2
 
       - name: Build folly
         if: steps.cache-folly.outputs.cache-hit != 'true'
@@ -65,10 +86,14 @@ jobs:
 
       - name: Export ROCKSDB_FOLLY_INSTALL_PATH
         run: |
-          INST_PATH=$(cd librocksdb-sys/rocksdb/third-party/folly \
-                      && python3 build/fbcode_builder/getdeps.py show-inst-dir)
-          ROOT=$(dirname "$INST_PATH")
-          echo "ROCKSDB_FOLLY_INSTALL_PATH=$ROOT" >> "$GITHUB_ENV"
+          INSTALL_ROOT="$PWD/librocksdb-sys/folly-build/installed"
+          if [ ! -d "$INSTALL_ROOT" ]; then
+            echo "Error: $INSTALL_ROOT does not exist after cache restore." >&2
+            echo "Cache may have been corrupted or build_folly.sh failed." >&2
+            ls -la librocksdb-sys/folly-build/ || true
+            exit 1
+          fi
+          echo "ROCKSDB_FOLLY_INSTALL_PATH=$INSTALL_ROOT" >> "$GITHUB_ENV"
 
       - uses: taiki-e/install-action@nextest
 

--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -54,6 +54,7 @@ jobs:
         run: |
           DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
             build-essential cmake ninja-build python3 python3-pip pkg-config patchelf \
+            wget \
             libdouble-conversion-dev libssl-dev liburing-dev \
             zlib1g-dev libbz2-dev autoconf automake libtool \
             clang llvm

--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -1,0 +1,77 @@
+name: Coroutines build
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-and-test:
+    name: Build & test with coroutines feature
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build python3 python3-pip pkg-config \
+            libdouble-conversion-dev libssl-dev liburing-dev \
+            zlib1g-dev libbz2-dev autoconf automake libtool
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: "v1-rust-coroutines"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # Folly takes 15-30 minutes to build from scratch. Cache it keyed on
+      # the exact FOLLY_COMMIT_HASH pinned by RocksDB's folly.mk so any
+      # upstream submodule bump invalidates the cache.
+      - name: Determine folly commit hash
+        id: folly-hash
+        run: |
+          HASH=$(grep -E '^FOLLY_COMMIT_HASH = ' \
+                       librocksdb-sys/rocksdb/folly.mk \
+                  | sed -E 's/^FOLLY_COMMIT_HASH = //')
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Cache folly install
+        id: cache-folly
+        uses: actions/cache@v4
+        with:
+          path: librocksdb-sys/rocksdb/third-party/folly
+          key: folly-${{ runner.os }}-${{ steps.folly-hash.outputs.hash }}-v1
+
+      - name: Build folly
+        if: steps.cache-folly.outputs.cache-hit != 'true'
+        run: ./scripts/build_folly.sh
+
+      - name: Export ROCKSDB_FOLLY_INSTALL_PATH
+        run: |
+          INST_PATH=$(cd librocksdb-sys/rocksdb/third-party/folly \
+                      && python3 build/fbcode_builder/getdeps.py show-inst-dir)
+          ROOT=$(dirname "$INST_PATH")
+          echo "ROCKSDB_FOLLY_INSTALL_PATH=$ROOT" >> "$GITHUB_ENV"
+
+      - uses: taiki-e/install-action@nextest
+
+      - name: cargo build --features coroutines,io-uring
+        run: cargo build --release --features coroutines,io-uring
+
+      - name: Run tests with coroutines feature
+        run: cargo nextest run --release --features coroutines,io-uring
+
+      - name: Run doctests with coroutines feature
+        run: cargo test --doc --release --features coroutines,io-uring

--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -123,7 +123,7 @@ jobs:
         if: steps.cache-folly.outputs.cache-hit != 'true'
         run: ./scripts/build_folly.sh
 
-      - name: Export ROCKSDB_FOLLY_INSTALL_PATH
+      - name: Export ROCKSDB_FOLLY_INSTALL_PATH and LD_LIBRARY_PATH
         run: |
           INSTALL_ROOT="$PWD/librocksdb-sys/folly-build/installed"
           if [ ! -d "$INSTALL_ROOT" ]; then
@@ -133,6 +133,32 @@ jobs:
             exit 1
           fi
           echo "ROCKSDB_FOLLY_INSTALL_PATH=$INSTALL_ROOT" >> "$GITHUB_ENV"
+
+          # folly's getdeps produces libglog and libgflags as shared libs only
+          # (no static archives). librocksdb-sys/build.rs links them dynamically.
+          # `cargo:rustc-link-arg` for rpath would only apply to this crate's
+          # own test binaries (rust-lang/cargo#9554), not to the rust-rocksdb
+          # crate's test binaries that nextest actually runs - so set
+          # LD_LIBRARY_PATH for the rest of the job. This matches the
+          # "Set LD_LIBRARY_PATH" guidance in the README's runtime constraints
+          # section.
+          locate_libdir() {
+            local dep_dir
+            dep_dir=$(find "$INSTALL_ROOT" -maxdepth 1 -type d -name "$1-*" \
+                       | head -1)
+            if [ -z "$dep_dir" ]; then
+              echo "Error: could not find $1-* under $INSTALL_ROOT" >&2
+              exit 1
+            fi
+            if [ -d "$dep_dir/lib64" ]; then
+              echo "$dep_dir/lib64"
+            else
+              echo "$dep_dir/lib"
+            fi
+          }
+          GLOG_LIBDIR=$(locate_libdir glog)
+          GFLAGS_LIBDIR=$(locate_libdir gflags)
+          echo "LD_LIBRARY_PATH=$GLOG_LIBDIR:$GFLAGS_LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
 
       - uses: taiki-e/install-action@nextest
 

--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -16,6 +16,11 @@ jobs:
   build-and-test:
     name: Build & test with coroutines feature
     runs-on: ubuntu-latest
+    # Folly's getdeps build can take 30-60+ minutes on a cold cache on
+    # standard GHA runners (small core count, no parallelism flags). 90
+    # minutes is a comfortable upper bound. With a warm cache the whole
+    # job finishes in ~15 minutes.
+    timeout-minutes: 90
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5

--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -15,21 +15,36 @@ env:
 jobs:
   build-and-test:
     name: Build & test with coroutines feature
-    # Pin to a specific Ubuntu image, NOT `ubuntu-latest`. Folly is built
-    # against the host's glibc, libstdc++ and apt-installed system packages
-    # (libdouble-conversion-dev, libssl-dev, etc.). If `ubuntu-latest` rolls
-    # forward (e.g. 24.04 -> 26.04) while the folly cache still hits, the
-    # cached binaries would link/run against a different ABI than the user's
-    # `cargo build` step expects, with confusing symptoms. The cache key
-    # below also encodes the image name so an explicit image bump invalidates
-    # the cache.
+    # The host runner just hosts the container; the actual build happens
+    # inside `ubuntu:25.10` (see `container:` below). We pin a specific host
+    # image rather than using `ubuntu-latest` so a GHA runner image rollover
+    # doesn't silently change anything visible to the build.
     runs-on: ubuntu-24.04
+    container:
+      # The pinned folly commit (see librocksdb-sys/rocksdb/folly.mk) requires
+      # liburing >= 2.7 for the io_uring_zcrx_* zero-copy receive APIs used
+      # in folly/io/async/IoUringZeroCopyBufferPool.cpp. Ubuntu 24.04 LTS
+      # only ships liburing 2.5, which fails to compile folly with errors
+      # about `io_uring_zcrx_*` being incomplete types. Ubuntu 25.10 ships
+      # liburing 2.11, which is sufficient. The cache key below encodes the
+      # image so changing this invalidates the folly cache.
+      image: ubuntu:25.10
     # Folly's getdeps build can take 30-60+ minutes on a cold cache on
     # standard GHA runners (small core count, no parallelism flags). 90
     # minutes is a comfortable upper bound. With a warm cache the whole
     # job finishes in ~15 minutes.
     timeout-minutes: 90
     steps:
+      # Containers start minimal. `actions/checkout` needs git + ca-certs and
+      # the rust toolchain installer needs curl, so install bootstrap tooling
+      # before any subsequent action runs. Done in a single apt invocation to
+      # avoid hitting apt-get's lock or paying for two `update`s.
+      - name: Bootstrap container
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            ca-certificates curl git sudo
+
       - name: Checkout sources
         uses: actions/checkout@v5
         with:
@@ -37,25 +52,27 @@ jobs:
 
       - name: Install build dependencies
         run: |
-          sudo apt-get update
-          sudo apt-get install -y \
-            cmake ninja-build python3 python3-pip pkg-config patchelf \
+          DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+            build-essential cmake ninja-build python3 python3-pip pkg-config patchelf \
             libdouble-conversion-dev libssl-dev liburing-dev \
-            zlib1g-dev libbz2-dev autoconf automake libtool
+            zlib1g-dev libbz2-dev autoconf automake libtool \
+            clang llvm
 
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-coroutines"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          # The correct input name on this action is `cache-save-if`. We only
+          # want to populate the cache from master runs, not from PR runs.
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # The folly build's correctness depends on three independent inputs:
       #   1. The folly commit (pinned by RocksDB's folly.mk:FOLLY_COMMIT_HASH).
-      #   2. The exact host OS image (glibc + libstdc++ + apt package versions).
+      #   2. The exact container image (glibc + libstdc++ + apt package versions).
       #   3. The CPU arch (x86_64 vs aarch64).
-      # All three are encoded in the cache key. The `-v2` suffix lets us bump
+      # All three are encoded in the cache key. The `-v3` suffix lets us bump
       # the cache manually if the build script changes in a way that
-      # invalidates prior caches.
+      # invalidates prior caches (v2 was the previous ubuntu-24.04-host build).
       - name: Determine folly commit hash
         id: folly-hash
         run: |
@@ -78,7 +95,7 @@ jobs:
           path: |
             librocksdb-sys/folly-build
             librocksdb-sys/rocksdb/third-party/folly
-          key: folly-${{ runner.os }}-${{ runner.arch }}-ubuntu-24.04-${{ steps.folly-hash.outputs.hash }}-v2
+          key: folly-${{ runner.os }}-${{ runner.arch }}-ubuntu-25.10-${{ steps.folly-hash.outputs.hash }}-v3
 
       - name: Build folly
         if: steps.cache-folly.outputs.cache-hit != 'true'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ members = ["librocksdb-sys"]
 default = ["snappy", "lz4", "zstd", "zlib", "bzip2", "bindgen-runtime"]
 jemalloc = ["rust-librocksdb-sys/jemalloc"]
 io-uring = ["rust-librocksdb-sys/io-uring"]
+# Build RocksDB with folly + C++20 coroutines. See `librocksdb-sys/Cargo.toml`
+# and the "Coroutines / async MultiGet" section of the README for build
+# prerequisites. Linux only.
+coroutines = ["rust-librocksdb-sys/coroutines"]
 valgrind = []
 snappy = ["rust-librocksdb-sys/snappy"]
 lz4 = ["rust-librocksdb-sys/lz4"]

--- a/README.md
+++ b/README.md
@@ -286,7 +286,26 @@ Trades ~6-15% extra CPU for ~30% lower MultiGet latency on IO-bound workloads. T
 
 **Runtime constraints:**
 
-- Folly's build produces `libglog.so` and `libgflags.so` (not `.a`) — these cannot be statically linked. Your final binary will have dynamic dependencies on them. Their paths are embedded via `rpath`, so the binary will work from its build location; if you move it, also move (or system-install) those two `.so` files.
+- Folly's build produces `libglog.so` and `libgflags.so` (not `.a`) — these cannot be statically linked. Your final binary will have **runtime dynamic dependencies** on them. Cargo's `rustc-link-arg` does not propagate from a transitive `-sys` crate to a downstream binary ([rust-lang/cargo#9554](https://github.com/rust-lang/cargo/issues/9554)), so this crate cannot embed `rpath` on your binary for you. You must make these two libraries discoverable at runtime by one of the following:
+
+  - **Set `LD_LIBRARY_PATH`** before running your binary:
+    ```bash
+    export LD_LIBRARY_PATH="$ROCKSDB_FOLLY_INSTALL_PATH/glog-<hash>/lib64:$ROCKSDB_FOLLY_INSTALL_PATH/gflags-<hash>/lib:${LD_LIBRARY_PATH:-}"
+    ```
+  - **Embed `rpath` in your own binary's `build.rs`.** This crate exports the discovered glog and gflags lib directories as `cargo:folly_glog_libdir` and `cargo:folly_gflags_libdir`, available in your build script as `DEP_ROCKSDB_FOLLY_GLOG_LIBDIR` and `DEP_ROCKSDB_FOLLY_GFLAGS_LIBDIR`:
+    ```rust
+    // your-app/build.rs
+    fn main() {
+        if let Ok(d) = std::env::var("DEP_ROCKSDB_FOLLY_GLOG_LIBDIR") {
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{d}");
+        }
+        if let Ok(d) = std::env::var("DEP_ROCKSDB_FOLLY_GFLAGS_LIBDIR") {
+            println!("cargo:rustc-link-arg=-Wl,-rpath,{d}");
+        }
+    }
+    ```
+  - **System-install the `.so` files** (e.g. copy them into `/usr/local/lib` and run `ldconfig`).
+
 - Not compatible with `mt_static`.
 - The `optimize_multiget_for_io` flag controlling whether to use the multi-level path defaults to `true` in `ReadOptions` and currently cannot be set from Rust until [facebook/rocksdb#14752](https://github.com/facebook/rocksdb/pull/14752) merges and we bump the submodule. For coroutine builds the default is the right choice for most workloads anyway.
 

--- a/README.md
+++ b/README.md
@@ -292,9 +292,9 @@ Trades ~6-15% extra CPU for ~30% lower MultiGet latency on IO-bound workloads. T
     ```bash
     export LD_LIBRARY_PATH="$ROCKSDB_FOLLY_INSTALL_PATH/glog-<hash>/lib64:$ROCKSDB_FOLLY_INSTALL_PATH/gflags-<hash>/lib:${LD_LIBRARY_PATH:-}"
     ```
-  - **Embed `rpath` in your own binary's `build.rs`.** This crate exports the discovered glog and gflags lib directories as `cargo:folly_glog_libdir` and `cargo:folly_gflags_libdir`, available in your build script as `DEP_ROCKSDB_FOLLY_GLOG_LIBDIR` and `DEP_ROCKSDB_FOLLY_GFLAGS_LIBDIR`:
+  - **Embed `rpath` in your final binary crate's `build.rs`.** Note: this must live in the crate that produces the binary you're shipping (a `[[bin]]` target), NOT in an intermediate library crate — `cargo:rustc-link-arg` does not propagate through transitive library dependencies, so adding this to a library crate would have the same problem as embedding rpath here in rust-rocksdb. This crate exports the discovered glog and gflags lib directories as `cargo:folly_glog_libdir` and `cargo:folly_gflags_libdir`, available in your build script as `DEP_ROCKSDB_FOLLY_GLOG_LIBDIR` and `DEP_ROCKSDB_FOLLY_GFLAGS_LIBDIR`:
     ```rust
-    // your-app/build.rs
+    // your-binary-crate/build.rs
     fn main() {
         if let Ok(d) = std::env::var("DEP_ROCKSDB_FOLLY_GLOG_LIBDIR") {
             println!("cargo:rustc-link-arg=-Wl,-rpath,{d}");

--- a/README.md
+++ b/README.md
@@ -259,15 +259,17 @@ features = ["coroutines", "io-uring"]
 
 Builds RocksDB with `USE_COROUTINES=1` and links against [folly](https://github.com/facebook/folly). This enables the **multi-level parallel `MultiGet` path** described in the RocksDB [Asynchronous IO blog post](https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html). When you then call `ReadOptions::set_async_io(true)` on a `MultiGet`, RocksDB will issue parallel `io_uring` reads across SST files in different LSM levels, not just within a single level.
 
-**Performance — read this carefully before adopting.** Meta's [October 2022 benchmark](https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html#results) was run on their internal **remote/warm-storage flash** (`ws.flash.ftw3preprod1`), where storage round-trip latency is roughly two to three orders of magnitude higher than a local NVMe random read:
+**Performance — read this carefully before adopting.** The RocksDB team's [October 2022 benchmark](https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html#results) was run on their internal **remote/warm-storage flash** (`ws.flash.ftw3preprod1`), where storage round-trip latency is roughly two to three orders of magnitude higher than a local NVMe random read:
 
-| Configuration (Meta's remote flash) | μs/op |
+| Configuration (remote/warm-storage flash) | μs/op |
 |---|---|
-| `async_io=false` (default) | 1292 |
-| `async_io=true`, single-level parallel reads (works without this feature) | 775 |
-| `async_io=true` + `coroutines` feature, multi-level parallel reads | 508 |
+| `async_io=false` (baseline — no `coroutines` feature needed) | 1292 |
+| `async_io=true` + `coroutines`, `optimize_multiget_for_io=false` (single-level parallel) | 775 |
+| `async_io=true` + `coroutines`, `optimize_multiget_for_io=true` (multi-level parallel, default) | 508 |
 
-The Meta team **has not published** an equivalent benchmark for local NVMe. The mechanism (`async_io` hides per-read latency by overlapping multiple reads in flight) implies the relative gain should be smaller on local NVMe, where per-read latency is already low — but the actual numbers there could be anywhere from "still meaningful" to "noise". **Treat the table above as remote-flash-only and measure on your hardware before deciding.** A reasonable rule of thumb: this feature is most likely to pay off when (a) your storage is network-attached or remote, (b) your `MultiGet` batches commonly span many SST files across multiple LSM levels, or (c) both. Trades ~6–15% extra CPU per the same blog post.
+Both the 775 and 508 numbers require the `coroutines` feature. Without it, even setting `async_io=true` only buys you within-single-SST-file block prefetching (no parallel reads across files); you stay near the 1292 baseline for cross-file workloads.
+
+The RocksDB team **has not published** an equivalent benchmark for local NVMe. The mechanism (`async_io` hides per-read latency by overlapping multiple reads in flight) implies the relative gain should be smaller on local NVMe, where per-read latency is already low — but the actual numbers there could be anywhere from "still meaningful" to "noise". **Treat the table above as remote-flash-only and measure on your hardware before deciding.** A reasonable rule of thumb: this feature is most likely to pay off when (a) your storage is network-attached or remote, (b) your `MultiGet` batches commonly span many SST files across multiple LSM levels, or (c) both. Trades ~6–15% extra CPU per the same blog post.
 
 ##### Prerequisites
 
@@ -327,7 +329,7 @@ This feature is harder to build than the rest of the crate. Read all of the cons
   - **System-install the `.so` files** (copy them into `/usr/local/lib` and run `ldconfig`).
 
 - **Not compatible with `mt_static`.** Folly's build precludes producing a fully static link.
-- **`optimize_multiget_for_io` cannot be set from Rust yet.** It defaults to `true` in `ReadOptions`, which is the right choice for coroutine builds anyway. Once [facebook/rocksdb#14752](https://github.com/facebook/rocksdb/pull/14752) merges and we bump the submodule, a setter will be exposed for users who want to opt out of the multi-level path (e.g. to reduce CPU at the cost of slightly higher MultiGet latency).
+- **`optimize_multiget_for_io` is a tuning knob within the coroutine-enabled space, not an on/off switch for coroutines.** The flag controls whether `MultiGet` parallelizes reads *across* LSM levels (`true`, default) or only *within* a single level (`false`). Both rely on the coroutine machinery this feature compiles in; without the `coroutines` feature, neither path runs and `MultiGet` falls back to the synchronous one-file-at-a-time loop. Per the performance table above, turning it off keeps ~40% of the latency reduction (1292→775 μs/op) at lower CPU cost than the multi-level path (1292→508). The flag currently cannot be set from Rust until [facebook/rocksdb#14752](https://github.com/facebook/rocksdb/pull/14752) merges and we bump the submodule; the C++ default of `true` is the right starting point for most workloads.
 - **The folly install is large and slow to rebuild.** ~2 GB on disk. Cache `librocksdb-sys/folly-build/` between CI runs (see `.github/workflows/coroutines.yml` for an `actions/cache` example with a cache key that pins the OS image, arch, and `FOLLY_COMMIT_HASH`).
 
 ##### Verifying the feature is active

--- a/README.md
+++ b/README.md
@@ -250,7 +250,7 @@ Holds digested dictionaries in block cache for read-heavy workloads. Uses experi
 
 #### Async MultiGet with C++20 Coroutines
 
-> **⚠️ Experimental, Linux only**
+> **⚠️ Experimental, Linux only.** The feature builds and tests in CI but has not been exercised on real production workloads from this crate. Benchmark your specific workload before adopting.
 
 ```toml
 [dependencies.rust-rocksdb]
@@ -259,40 +259,59 @@ features = ["coroutines", "io-uring"]
 
 Builds RocksDB with `USE_COROUTINES=1` and links against [folly](https://github.com/facebook/folly). This enables the **multi-level parallel `MultiGet` path** described in the RocksDB [Asynchronous IO blog post](https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html). When you then call `ReadOptions::set_async_io(true)` on a `MultiGet`, RocksDB will issue parallel `io_uring` reads across SST files in different LSM levels, not just within a single level.
 
-**Performance**: per Meta's [own benchmark](https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html#results) on remote flash:
+**Performance — read this carefully before adopting.** Meta's [October 2022 benchmark](https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html#results) was run on their internal **remote/warm-storage flash** (`ws.flash.ftw3preprod1`), where storage round-trip latency is roughly two to three orders of magnitude higher than a local NVMe random read:
 
-| Configuration | μs/op |
+| Configuration (Meta's remote flash) | μs/op |
 |---|---|
 | `async_io=false` (default) | 1292 |
-| `async_io=true` (this crate today, single-level parallel reads) | 775 |
-| `async_io=true` + `coroutines` feature (multi-level parallel reads) | 508 |
+| `async_io=true`, single-level parallel reads (works without this feature) | 775 |
+| `async_io=true` + `coroutines` feature, multi-level parallel reads | 508 |
 
-Trades ~6-15% extra CPU for ~30% lower MultiGet latency on IO-bound workloads. The gain shrinks on local NVMe; benchmark before adopting in production.
+The Meta team **has not published** an equivalent benchmark for local NVMe. The mechanism (`async_io` hides per-read latency by overlapping multiple reads in flight) implies the relative gain should be smaller on local NVMe, where per-read latency is already low — but the actual numbers there could be anywhere from "still meaningful" to "noise". **Treat the table above as remote-flash-only and measure on your hardware before deciding.** A reasonable rule of thumb: this feature is most likely to pay off when (a) your storage is network-attached or remote, (b) your `MultiGet` batches commonly span many SST files across multiple LSM levels, or (c) both. Trades ~6–15% extra CPU per the same blog post.
 
-**Prerequisites:**
+##### Prerequisites
 
-1. **Linux** (any glibc-based distro). macOS and Windows are not supported.
-2. **GCC ≥ 11 or Clang ≥ 14** with `-std=c++20` support.
-3. **folly + 8 transitive dependencies** built at the exact commit pinned by `librocksdb-sys/rocksdb/folly.mk`. Use the included helper:
+This feature is harder to build than the rest of the crate. Read all of the constraints below before starting.
+
+1. **Linux only.** macOS and Windows are not supported. Folly's build (`getdeps.py`) doesn't reliably work on macOS, and RocksDB's coroutine code path needs `io_uring`.
+2. **liburing ≥ 2.7.** The pinned folly commit references `io_uring_zcrx_*` symbols from liburing 2.7 (`IoUringZeroCopyBufferPool.cpp`) and `IOU_PBUF_RING_INC` / `io_uring_buf_ring_head` from liburing 2.6 (`IoUringProvidedBufferRing.cpp`). Distro coverage:
+   - Ubuntu 25.10+ (`liburing-dev` 2.11): works out of the box.
+   - Ubuntu 24.04 LTS (`liburing-dev` 2.5): too old. `scripts/build_folly.sh` auto-detects this and builds liburing 2.9 from source under the scratch directory, then exports `PKG_CONFIG_PATH` so folly and rust-rocksdb's `io-uring` feature both pick it up.
+   - Debian, RHEL, etc.: check `pkg-config --modversion liburing`; the script handles either case.
+3. **A C/C++ compiler that is not GCC 15.** Folly's pinned libunwind dependency contains test code using legacy K&R-style empty parameter lists, which GCC 15 rejects under its default `-std=gnu23`. GCC 11–14 and Clang ≥ 14 all work. On Ubuntu 25.10 you can install `gcc-14`/`g++-14` from apt and switch via `update-alternatives` (see the CI workflow at `.github/workflows/coroutines.yml` for the exact commands).
+4. **Build dependencies.** On Ubuntu / Debian:
+   ```bash
+   apt-get install -y build-essential cmake ninja-build python3 python3-pip \
+     pkg-config patchelf wget \
+     libdouble-conversion-dev libssl-dev liburing-dev \
+     zlib1g-dev libbz2-dev autoconf automake libtool
+   ```
+   `wget` is needed because folly's getdeps shells out to it (`GETDEPS_USE_WGET=1`, inherited from RocksDB's own `folly.mk`).
+5. **Build folly + its 8 transitive deps** (boost, fmt, glog, gflags, double-conversion, libevent, libsodium, fast_float, xz, lz4, zstd, snappy, libdwarf, libiberty, ...):
    ```bash
    ./scripts/build_folly.sh
    ```
-   This wraps RocksDB's own `make build_folly` target. Allow 15-30 minutes for a clean build. It produces an install directory under `librocksdb-sys/rocksdb/third-party/folly/build/fbcode_builder/installed/`.
-4. Set the install path env var before building:
+   The script invokes folly's `getdeps.py` directly with `--scratch-path`, clones folly at the commit pinned by `librocksdb-sys/rocksdb/folly.mk:FOLLY_COMMIT_HASH`, applies the two upstream patches RocksDB's own `folly.mk` applies, and runs the build. Allow ~20–30 minutes on a cold cache. Outputs land under `librocksdb-sys/folly-build/installed/`.
+6. **Build the crate**:
    ```bash
-   export ROCKSDB_FOLLY_INSTALL_PATH=/path/printed/by/build_folly.sh
+   export ROCKSDB_FOLLY_INSTALL_PATH="$PWD/librocksdb-sys/folly-build/installed"
    cargo build --release --features coroutines,io-uring
    ```
 
-**Runtime constraints:**
+##### Runtime constraints
 
-- Folly's build produces `libglog.so` and `libgflags.so` (not `.a`) — these cannot be statically linked. Your final binary will have **runtime dynamic dependencies** on them. Cargo's `rustc-link-arg` does not propagate from a transitive `-sys` crate to a downstream binary ([rust-lang/cargo#9554](https://github.com/rust-lang/cargo/issues/9554)), so this crate cannot embed `rpath` on your binary for you. You must make these two libraries discoverable at runtime by one of the following:
+- **Dynamic dependencies on `libglog.so` and `libgflags.so`.** Folly's `getdeps` produces these two as shared libraries only (no static archives). Your final binary therefore has runtime `.so` dependencies on them. Cargo's `rustc-link-arg` does not propagate from a transitive `-sys` crate to a downstream binary ([rust-lang/cargo#9554](https://github.com/rust-lang/cargo/issues/9554)), so rust-rocksdb cannot embed `rpath` on your binary for you. Pick one of:
 
-  - **Set `LD_LIBRARY_PATH`** before running your binary:
+  - **Set `LD_LIBRARY_PATH`** when running the binary. Concretely:
     ```bash
-    export LD_LIBRARY_PATH="$ROCKSDB_FOLLY_INSTALL_PATH/glog-<hash>/lib64:$ROCKSDB_FOLLY_INSTALL_PATH/gflags-<hash>/lib:${LD_LIBRARY_PATH:-}"
+    GLOG_LIBDIR=$(ls -d "$ROCKSDB_FOLLY_INSTALL_PATH"/glog-*/lib* | head -1)
+    GFLAGS_LIBDIR=$(ls -d "$ROCKSDB_FOLLY_INSTALL_PATH"/gflags-*/lib* | head -1)
+    export LD_LIBRARY_PATH="$GLOG_LIBDIR:$GFLAGS_LIBDIR${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+    ./your-binary
     ```
-  - **Embed `rpath` in your final binary crate's `build.rs`.** Note: this must live in the crate that produces the binary you're shipping (a `[[bin]]` target), NOT in an intermediate library crate — `cargo:rustc-link-arg` does not propagate through transitive library dependencies, so adding this to a library crate would have the same problem as embedding rpath here in rust-rocksdb. This crate exports the discovered glog and gflags lib directories as `cargo:folly_glog_libdir` and `cargo:folly_gflags_libdir`, available in your build script as `DEP_ROCKSDB_FOLLY_GLOG_LIBDIR` and `DEP_ROCKSDB_FOLLY_GFLAGS_LIBDIR`:
+    This is what `.github/workflows/coroutines.yml` does for test binaries; reference it for a working example.
+
+  - **Embed `rpath` in your final binary crate's `build.rs`.** This must live in the crate that produces the binary you're shipping (a `[[bin]]` target), **NOT** in an intermediate library crate — `cargo:rustc-link-arg` does not propagate through transitive library dependencies, so adding this to a library crate would have the same problem as embedding rpath here in rust-rocksdb. This crate exports the discovered glog and gflags lib directories via the `links` metadata, available in your binary's build script as `DEP_ROCKSDB_FOLLY_GLOG_LIBDIR` and `DEP_ROCKSDB_FOLLY_GFLAGS_LIBDIR`:
     ```rust
     // your-binary-crate/build.rs
     fn main() {
@@ -304,16 +323,22 @@ Trades ~6-15% extra CPU for ~30% lower MultiGet latency on IO-bound workloads. T
         }
     }
     ```
-  - **System-install the `.so` files** (e.g. copy them into `/usr/local/lib` and run `ldconfig`).
 
-- Not compatible with `mt_static`.
-- The `optimize_multiget_for_io` flag controlling whether to use the multi-level path defaults to `true` in `ReadOptions` and currently cannot be set from Rust until [facebook/rocksdb#14752](https://github.com/facebook/rocksdb/pull/14752) merges and we bump the submodule. For coroutine builds the default is the right choice for most workloads anyway.
+  - **System-install the `.so` files** (copy them into `/usr/local/lib` and run `ldconfig`).
 
-**Verifying the feature is active at runtime:**
+- **Not compatible with `mt_static`.** Folly's build precludes producing a fully static link.
+- **`optimize_multiget_for_io` cannot be set from Rust yet.** It defaults to `true` in `ReadOptions`, which is the right choice for coroutine builds anyway. Once [facebook/rocksdb#14752](https://github.com/facebook/rocksdb/pull/14752) merges and we bump the submodule, a setter will be exposed for users who want to opt out of the multi-level path (e.g. to reduce CPU at the cost of slightly higher MultiGet latency).
+- **The folly install is large and slow to rebuild.** ~2 GB on disk. Cache `librocksdb-sys/folly-build/` between CI runs (see `.github/workflows/coroutines.yml` for an `actions/cache` example with a cache key that pins the OS image, arch, and `FOLLY_COMMIT_HASH`).
+
+##### Verifying the feature is active
+
+At runtime:
 
 ```rust
 assert!(rust_rocksdb::built_with_coroutines());
 ```
+
+Note: this reflects how rust-rocksdb was *compiled* (i.e. whether the `coroutines` feature was on). If you used `ROCKSDB_LIB_DIR` to link against an externally-built `librocksdb.a`, the answer here may not match what that library was actually built with.
 
 #### Link-Time Optimization (LTO)
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,54 @@ features = ["zstd", "zstd-static-linking-only"]
 
 Holds digested dictionaries in block cache for read-heavy workloads. Uses experimental APIs but is production-tested at Facebook. See [Dictionary Compression Blog](https://rocksdb.org/blog/2021/05/31/dictionary-compression.html).
 
+#### Async MultiGet with C++20 Coroutines
+
+> **⚠️ Experimental, Linux only**
+
+```toml
+[dependencies.rust-rocksdb]
+features = ["coroutines", "io-uring"]
+```
+
+Builds RocksDB with `USE_COROUTINES=1` and links against [folly](https://github.com/facebook/folly). This enables the **multi-level parallel `MultiGet` path** described in the RocksDB [Asynchronous IO blog post](https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html). When you then call `ReadOptions::set_async_io(true)` on a `MultiGet`, RocksDB will issue parallel `io_uring` reads across SST files in different LSM levels, not just within a single level.
+
+**Performance**: per Meta's [own benchmark](https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html#results) on remote flash:
+
+| Configuration | μs/op |
+|---|---|
+| `async_io=false` (default) | 1292 |
+| `async_io=true` (this crate today, single-level parallel reads) | 775 |
+| `async_io=true` + `coroutines` feature (multi-level parallel reads) | 508 |
+
+Trades ~6-15% extra CPU for ~30% lower MultiGet latency on IO-bound workloads. The gain shrinks on local NVMe; benchmark before adopting in production.
+
+**Prerequisites:**
+
+1. **Linux** (any glibc-based distro). macOS and Windows are not supported.
+2. **GCC ≥ 11 or Clang ≥ 14** with `-std=c++20` support.
+3. **folly + 8 transitive dependencies** built at the exact commit pinned by `librocksdb-sys/rocksdb/folly.mk`. Use the included helper:
+   ```bash
+   ./scripts/build_folly.sh
+   ```
+   This wraps RocksDB's own `make build_folly` target. Allow 15-30 minutes for a clean build. It produces an install directory under `librocksdb-sys/rocksdb/third-party/folly/build/fbcode_builder/installed/`.
+4. Set the install path env var before building:
+   ```bash
+   export ROCKSDB_FOLLY_INSTALL_PATH=/path/printed/by/build_folly.sh
+   cargo build --release --features coroutines,io-uring
+   ```
+
+**Runtime constraints:**
+
+- Folly's build produces `libglog.so` and `libgflags.so` (not `.a`) — these cannot be statically linked. Your final binary will have dynamic dependencies on them. Their paths are embedded via `rpath`, so the binary will work from its build location; if you move it, also move (or system-install) those two `.so` files.
+- Not compatible with `mt_static`.
+- The `optimize_multiget_for_io` flag controlling whether to use the multi-level path defaults to `true` in `ReadOptions` and currently cannot be set from Rust until [facebook/rocksdb#14752](https://github.com/facebook/rocksdb/pull/14752) merges and we bump the submodule. For coroutine builds the default is the right choice for most workloads anyway.
+
+**Verifying the feature is active at runtime:**
+
+```rust
+assert!(rust_rocksdb::built_with_coroutines());
+```
+
 #### Link-Time Optimization (LTO)
 
 ```toml

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -35,6 +35,14 @@ bindgen-runtime = ["bindgen/runtime"]
 bindgen-static = ["bindgen/static"]
 mt_static = []
 io-uring = ["pkg-config"]
+# Build RocksDB with `USE_COROUTINES=1 USE_FOLLY=1` and link against a folly
+# install. Enables the multi-level parallel `MultiGet` async-IO path described
+# in the RocksDB blog post "Asynchronous IO in RocksDB". Linux only. Requires
+# the `ROCKSDB_FOLLY_INSTALL_PATH` env var to point at a folly install built
+# by `scripts/build_folly.sh` (or equivalent). Adds a runtime dependency on
+# `libglog.so` and `libgflags.so` because folly's build does not produce
+# static archives for those two.
+coroutines = []
 snappy = []
 lz4 = ["lz4-sys"]
 zstd = ["zstd-sys"]

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -379,6 +379,9 @@ fn build_rocksdb() {
         config.define("ROCKSDB_IOURING_PRESENT", Some("1"));
     }
 
+    #[cfg(feature = "coroutines")]
+    coroutines_compile_config(&mut config, &target);
+
     if &target != "armv7-linux-androideabi"
         && env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap() != "64"
     {
@@ -536,6 +539,9 @@ fn main() {
     bindgen_rocksdb();
     let target = env::var("TARGET").unwrap();
 
+    #[cfg(feature = "coroutines")]
+    validate_coroutines_target(&target);
+
     if !try_to_find_and_link_lib("ROCKSDB") {
         // rocksdb only works with the prebuilt rocksdb system lib on freebsd.
         // we dont need to rebuild rocksdb
@@ -556,6 +562,15 @@ fn main() {
     } else {
         cpp_link_stdlib(&target);
     }
+
+    // Folly + transitive deps must be linked after rocksdb itself so the
+    // linker resolves rocksdb's coroutine references against folly. Done
+    // outside `build_rocksdb()` so it also applies when ROCKSDB_LIB_DIR
+    // points at an externally-built librocksdb that was compiled with
+    // USE_COROUTINES.
+    #[cfg(feature = "coroutines")]
+    coroutines_link_config();
+
     if cfg!(feature = "snappy") && !try_to_find_and_link_lib("SNAPPY") {
         println!("cargo:rerun-if-changed=snappy/");
         fail_on_empty_directory("snappy");
@@ -570,4 +585,190 @@ fn main() {
         env::var("CARGO_MANIFEST_DIR").unwrap()
     );
     println!("cargo:out_dir={}", env::var("OUT_DIR").unwrap());
+}
+
+/// Validates that the requested target is one we can build the `coroutines`
+/// feature for. Folly only ships a working build for Linux; on macOS, Windows,
+/// and the BSDs the folly toolchain is missing pieces (notably the io_uring
+/// async file system, and folly's getdeps build itself is flaky).
+#[cfg(feature = "coroutines")]
+fn validate_coroutines_target(target: &str) {
+    if !target.contains("linux") {
+        panic!(
+            "the `coroutines` feature is only supported on Linux \
+             (target was `{target}`)"
+        );
+    }
+}
+
+/// Compile-time configuration for the coroutines build: defines, compiler
+/// flags, and include paths for folly + its dependencies. Mirrors the logic
+/// in RocksDB's own `CMakeLists.txt` (lines 607-667) and `Makefile`
+/// (`USE_COROUTINES=1` branch around line 147).
+#[cfg(feature = "coroutines")]
+fn coroutines_compile_config(config: &mut cc::Build, target: &str) {
+    validate_coroutines_target(target);
+
+    config.define("USE_COROUTINES", None);
+    config.define("USE_FOLLY", None);
+    config.define("FOLLY_NO_CONFIG", None);
+    config.define("HAVE_CXX11_ATOMIC", None);
+
+    // GCC needs explicit -fcoroutines to enable coroutine support; clang
+    // enables coroutines under -std=c++20 by default.
+    if !config.get_compiler().is_like_clang() {
+        config.flag("-fcoroutines");
+    }
+    // Folly's headers trip warnings that RocksDB's stricter build flags
+    // would otherwise treat as significant.
+    config.flag_if_supported("-Wno-deprecated");
+    config.flag_if_supported("-Wno-redundant-move");
+    config.flag_if_supported("-Wno-maybe-uninitialized");
+    config.flag_if_supported("-Wno-invalid-memory-model");
+
+    let install_root = coroutines_install_root();
+    for dep in [
+        "folly",
+        "boost",
+        "fmt",
+        "glog",
+        "gflags",
+        "double-conversion",
+        "libevent",
+        "libsodium",
+    ] {
+        let dir = resolve_folly_dep(&install_root, dep);
+        config.include(dir.join("include"));
+    }
+}
+
+/// Link-time configuration for the coroutines build: emits the
+/// `cargo:rustc-link-*` directives for folly and its transitive dependencies.
+/// Order matters - folly must come after `librocksdb.a` on the linker command
+/// line so symbols resolve forward.
+#[cfg(feature = "coroutines")]
+fn coroutines_link_config() {
+    println!("cargo:rerun-if-env-changed=ROCKSDB_FOLLY_INSTALL_PATH");
+
+    let install_root = coroutines_install_root();
+
+    let folly = resolve_folly_dep(&install_root, "folly");
+    let boost = resolve_folly_dep(&install_root, "boost");
+    let fmt = resolve_folly_dep(&install_root, "fmt");
+    let glog = resolve_folly_dep(&install_root, "glog");
+    let gflags = resolve_folly_dep(&install_root, "gflags");
+    let dbl_conv = resolve_folly_dep(&install_root, "double-conversion");
+    let libevent = resolve_folly_dep(&install_root, "libevent");
+    let libsodium = resolve_folly_dep(&install_root, "libsodium");
+
+    // Folly itself.
+    println!(
+        "cargo:rustc-link-search=native={}",
+        folly.join("lib").display()
+    );
+    println!("cargo:rustc-link-lib=static=folly");
+
+    // Boost components folly uses.
+    println!(
+        "cargo:rustc-link-search=native={}",
+        boost.join("lib").display()
+    );
+    for lib in [
+        "context",
+        "filesystem",
+        "atomic",
+        "program_options",
+        "regex",
+        "system",
+        "thread",
+    ] {
+        println!("cargo:rustc-link-lib=static=boost_{lib}");
+    }
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        dbl_conv.join("lib").display()
+    );
+    println!("cargo:rustc-link-lib=static=double-conversion");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        libevent.join("lib").display()
+    );
+    println!("cargo:rustc-link-lib=static=event");
+
+    println!(
+        "cargo:rustc-link-search=native={}",
+        libsodium.join("lib").display()
+    );
+    println!("cargo:rustc-link-lib=static=sodium");
+
+    // glog and gflags only build as shared libs from folly's getdeps, so we
+    // link them dynamically. Embed rpaths so the final binary can find the
+    // .so files at runtime without LD_LIBRARY_PATH gymnastics.
+    let glog_libdir = lib_or_lib64(&glog);
+    let gflags_libdir = lib_or_lib64(&gflags);
+    println!("cargo:rustc-link-search=native={}", glog_libdir.display());
+    println!("cargo:rustc-link-search=native={}", gflags_libdir.display());
+    println!("cargo:rustc-link-lib=dylib=glog");
+    println!("cargo:rustc-link-lib=dylib=gflags");
+    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", glog_libdir.display());
+    println!(
+        "cargo:rustc-link-arg=-Wl,-rpath,{}",
+        gflags_libdir.display()
+    );
+
+    let fmt_libdir = lib_or_lib64(&fmt);
+    println!("cargo:rustc-link-search=native={}", fmt_libdir.display());
+    println!("cargo:rustc-link-lib=static=fmt");
+
+    // libdl, needed by folly.
+    println!("cargo:rustc-link-lib=dylib=dl");
+}
+
+/// Returns the install root containing folly and its sibling dependency
+/// directories (e.g. `<root>/folly-<hash>`, `<root>/boost-<hash>`, etc).
+#[cfg(feature = "coroutines")]
+fn coroutines_install_root() -> PathBuf {
+    let raw = env::var("ROCKSDB_FOLLY_INSTALL_PATH").unwrap_or_else(|_| {
+        panic!(
+            "the `coroutines` feature requires the env var \
+             ROCKSDB_FOLLY_INSTALL_PATH to point at a folly install \
+             produced by `scripts/build_folly.sh` (or equivalent)."
+        )
+    });
+    PathBuf::from(raw)
+}
+
+/// Resolves a versioned folly-deps subdirectory (e.g. `boost-1.83.0_xyz`)
+/// by globbing under the install root.
+#[cfg(feature = "coroutines")]
+fn resolve_folly_dep(install_root: &Path, name: &str) -> PathBuf {
+    let pattern = install_root.join(format!("{name}-*"));
+    let pattern_str = pattern
+        .to_str()
+        .expect("ROCKSDB_FOLLY_INSTALL_PATH must be valid UTF-8");
+    glob::glob(pattern_str)
+        .unwrap_or_else(|e| panic!("invalid glob `{pattern_str}`: {e}"))
+        .filter_map(Result::ok)
+        .next()
+        .unwrap_or_else(|| {
+            panic!(
+                "could not find `{name}-*` under {}; \
+                 did `scripts/build_folly.sh` finish successfully?",
+                install_root.display()
+            )
+        })
+}
+
+/// folly's getdeps installs some libraries under `lib/` and others under
+/// `lib64/`. Prefer `lib64/` when it exists.
+#[cfg(feature = "coroutines")]
+fn lib_or_lib64(prefix: &Path) -> PathBuf {
+    let candidate = prefix.join("lib64");
+    if candidate.exists() {
+        candidate
+    } else {
+        prefix.join("lib")
+    }
 }

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -568,6 +568,12 @@ fn main() {
     // outside `build_rocksdb()` so it also applies when ROCKSDB_LIB_DIR
     // points at an externally-built librocksdb that was compiled with
     // USE_COROUTINES.
+    //
+    // Note: the freebsd branch above returns early, but
+    // `validate_coroutines_target()` (called before this block) already
+    // panics on non-Linux targets, so the early return is unreachable when
+    // the `coroutines` feature is enabled. If we ever relax the target
+    // validation, this branch will need to handle freebsd explicitly.
     #[cfg(feature = "coroutines")]
     coroutines_link_config();
 
@@ -605,17 +611,22 @@ fn validate_coroutines_target(target: &str) {
 /// flags, and include paths for folly + its dependencies. Mirrors the logic
 /// in RocksDB's own `CMakeLists.txt` (lines 607-667) and `Makefile`
 /// (`USE_COROUTINES=1` branch around line 147).
+///
+/// Assumes `validate_coroutines_target()` has already been called by `main()`
+/// and the target is Linux.
 #[cfg(feature = "coroutines")]
-fn coroutines_compile_config(config: &mut cc::Build, target: &str) {
-    validate_coroutines_target(target);
-
+fn coroutines_compile_config(config: &mut cc::Build, _target: &str) {
     config.define("USE_COROUTINES", None);
     config.define("USE_FOLLY", None);
     config.define("FOLLY_NO_CONFIG", None);
     config.define("HAVE_CXX11_ATOMIC", None);
 
     // GCC needs explicit -fcoroutines to enable coroutine support; clang
-    // enables coroutines under -std=c++20 by default.
+    // enables coroutines under -std=c++20 by default. We use `flag()` not
+    // `flag_if_supported()` here: on a too-old GCC we want the build to
+    // fail loudly with "unrecognized option -fcoroutines" rather than
+    // silently drop the flag and produce a confusing C++ compile error
+    // deep inside folly headers that depend on coroutine support.
     if !config.get_compiler().is_like_clang() {
         config.flag("-fcoroutines");
     }
@@ -668,7 +679,13 @@ fn coroutines_link_config() {
     );
     println!("cargo:rustc-link-lib=static=folly");
 
-    // Boost components folly uses.
+    // Boost components. This list mirrors the static archives that RocksDB's
+    // own `folly.mk` links against (PLATFORM_LDFLAGS, ~line 50). The set is
+    // larger than what folly *strictly* needs because RocksDB's dependency
+    // chain reaches into more boost components than folly alone. If
+    // FOLLY_COMMIT_HASH is bumped and a component is no longer produced by
+    // the build, the link step will fail with "cannot find -lboost_<x>";
+    // that's the signal to trim this list.
     println!(
         "cargo:rustc-link-search=native={}",
         boost.join("lib").display()
@@ -712,8 +729,8 @@ fn coroutines_link_config() {
     // covers our own test binaries would be misleading. Downstream users must
     // handle runtime discovery of libglog/libgflags themselves - see the
     // "Async MultiGet with C++20 Coroutines" section in the top-level README.
-    let glog_libdir = lib_or_lib64(&glog);
-    let gflags_libdir = lib_or_lib64(&gflags);
+    let glog_libdir = libdir_containing(&glog, "glog");
+    let gflags_libdir = libdir_containing(&gflags, "gflags");
     println!("cargo:rustc-link-search=native={}", glog_libdir.display());
     println!("cargo:rustc-link-search=native={}", gflags_libdir.display());
     println!("cargo:rustc-link-lib=dylib=glog");
@@ -726,7 +743,7 @@ fn coroutines_link_config() {
     println!("cargo:folly_glog_libdir={}", glog_libdir.display());
     println!("cargo:folly_gflags_libdir={}", gflags_libdir.display());
 
-    let fmt_libdir = lib_or_lib64(&fmt);
+    let fmt_libdir = libdir_containing(&fmt, "fmt");
     println!("cargo:rustc-link-search=native={}", fmt_libdir.display());
     println!("cargo:rustc-link-lib=static=fmt");
 
@@ -786,19 +803,44 @@ fn resolve_folly_dep(install_root: &Path, name: &str) -> PathBuf {
     }
 }
 
-/// folly's getdeps installs some libraries under `lib/` and others under
-/// `lib64/` depending on the OS distribution conventions. As of the
-/// `FOLLY_COMMIT_HASH` pinned by `librocksdb-sys/rocksdb/folly.mk`, glog and
-/// fmt are typically under `lib64/` on RHEL-family distros and under `lib/`
-/// on Debian-family distros; gflags is consistently under `lib/`. Prefer
-/// `lib64/` when present since that's the more specific path; only one of
-/// the two ever contains the library for a given dep.
+/// Returns whichever of `<prefix>/lib` or `<prefix>/lib64` actually contains
+/// the named library (matching `lib<lib_name>.{so,a}*`). Panics with a clear
+/// error if neither does.
+///
+/// Folly's getdeps install layout sometimes creates an empty `lib64/` as a
+/// side effect of CMake's `GNUInstallDirs` probing (or vice-versa), so a
+/// plain `.exists()` check on the directory is not enough - we'd point the
+/// linker at an empty directory and get a confusing "cannot find -l<name>"
+/// later. Probing for the actual library file catches this at config time
+/// with a useful error message.
 #[cfg(feature = "coroutines")]
-fn lib_or_lib64(prefix: &Path) -> PathBuf {
-    let candidate = prefix.join("lib64");
-    if candidate.exists() {
-        candidate
-    } else {
-        prefix.join("lib")
+fn libdir_containing(prefix: &Path, lib_name: &str) -> PathBuf {
+    // Prefer `lib64/` when it has the library (more specific on RHEL-family
+    // distros); fall back to `lib/` (Debian-family).
+    for subdir in ["lib64", "lib"] {
+        let candidate = prefix.join(subdir);
+        if !candidate.is_dir() {
+            continue;
+        }
+        let glob_pattern = candidate.join(format!("lib{lib_name}.*"));
+        let pattern_str = match glob_pattern.to_str() {
+            Some(s) => s,
+            None => continue,
+        };
+        let mut iter = match glob::glob(pattern_str) {
+            Ok(it) => it,
+            Err(_) => continue,
+        };
+        if iter.any(|r| r.is_ok()) {
+            return candidate;
+        }
     }
+    panic!(
+        "could not find `lib{lib_name}.{{so,a}}*` in either `{}/lib/` or `{}/lib64/`. \
+         The folly install at `{}` looks incomplete - rerun `scripts/build_folly.sh` \
+         to rebuild from scratch.",
+        prefix.display(),
+        prefix.display(),
+        prefix.display()
+    );
 }

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -765,14 +765,29 @@ fn coroutines_install_root() -> PathBuf {
     PathBuf::from(raw)
 }
 
-/// Resolves a versioned folly-deps subdirectory (e.g. `boost-1.83.0_xyz`)
-/// by globbing under the install root. Panics if zero or more than one
-/// directory matches - multiple matches typically indicate a stale install
-/// from a prior `FOLLY_COMMIT_HASH` mixed with the current one, which would
-/// otherwise be resolved non-deterministically and could link the wrong
-/// version.
+/// Resolves a dependency directory under folly's `installed/` tree.
+///
+/// getdeps uses two naming conventions:
+///
+/// 1. The project being built (folly itself, in our case) installs to
+///    `<install_root>/<name>` with no version/hash suffix.
+/// 2. Its dependencies install to `<install_root>/<name>-<hash>` where the
+///    hash captures the manifest+ctx so changes to either reset the install.
+///
+/// We check (1) first - so `resolve_folly_dep(root, "folly")` returns
+/// `<root>/folly` directly when present - and fall back to globbing (2).
+/// Panics if zero or more than one directory matches in case (2): multiple
+/// matches typically indicate a stale install from a prior FOLLY_COMMIT_HASH
+/// mixed with the current one, which would otherwise be resolved
+/// non-deterministically and could link the wrong version.
 #[cfg(feature = "coroutines")]
 fn resolve_folly_dep(install_root: &Path, name: &str) -> PathBuf {
+    // Case 1: unsuffixed directory (used for the project being built).
+    let bare = install_root.join(name);
+    if bare.is_dir() {
+        return bare;
+    }
+    // Case 2: glob for the hashed dependency directory.
     let pattern = install_root.join(format!("{name}-*"));
     let pattern_str = pattern
         .to_str()
@@ -783,7 +798,7 @@ fn resolve_folly_dep(install_root: &Path, name: &str) -> PathBuf {
         .collect();
     match matches.as_slice() {
         [] => panic!(
-            "could not find `{name}-*` under {}; \
+            "could not find `{name}` or `{name}-*` under {}; \
              did `scripts/build_folly.sh` finish successfully?",
             install_root.display()
         ),

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -704,19 +704,27 @@ fn coroutines_link_config() {
     println!("cargo:rustc-link-lib=static=sodium");
 
     // glog and gflags only build as shared libs from folly's getdeps, so we
-    // link them dynamically. Embed rpaths so the final binary can find the
-    // .so files at runtime without LD_LIBRARY_PATH gymnastics.
+    // link them dynamically. We deliberately do NOT emit `cargo:rustc-link-arg`
+    // for rpath here: per `cargo:rustc-link-arg` semantics, those args only
+    // apply to artifacts of the crate that emits them (tests/examples/benches
+    // of `rust-librocksdb-sys` itself), not to downstream binaries that depend
+    // on this crate (see rust-lang/cargo#9554). Embedding rpath that only
+    // covers our own test binaries would be misleading. Downstream users must
+    // handle runtime discovery of libglog/libgflags themselves - see the
+    // "Async MultiGet with C++20 Coroutines" section in the top-level README.
     let glog_libdir = lib_or_lib64(&glog);
     let gflags_libdir = lib_or_lib64(&gflags);
     println!("cargo:rustc-link-search=native={}", glog_libdir.display());
     println!("cargo:rustc-link-search=native={}", gflags_libdir.display());
     println!("cargo:rustc-link-lib=dylib=glog");
     println!("cargo:rustc-link-lib=dylib=gflags");
-    println!("cargo:rustc-link-arg=-Wl,-rpath,{}", glog_libdir.display());
-    println!(
-        "cargo:rustc-link-arg=-Wl,-rpath,{}",
-        gflags_libdir.display()
-    );
+    // Export the discovered directories for downstream build scripts so they
+    // can set rpath on their own crate's binaries without re-globbing folly's
+    // install layout. Accessible as `DEP_ROCKSDB_FOLLY_GLOG_LIBDIR` and
+    // `DEP_ROCKSDB_FOLLY_GFLAGS_LIBDIR` in dependent crates' build scripts
+    // (via the `links = "rocksdb"` metadata).
+    println!("cargo:folly_glog_libdir={}", glog_libdir.display());
+    println!("cargo:folly_gflags_libdir={}", gflags_libdir.display());
 
     let fmt_libdir = lib_or_lib64(&fmt);
     println!("cargo:rustc-link-search=native={}", fmt_libdir.display());
@@ -741,28 +749,50 @@ fn coroutines_install_root() -> PathBuf {
 }
 
 /// Resolves a versioned folly-deps subdirectory (e.g. `boost-1.83.0_xyz`)
-/// by globbing under the install root.
+/// by globbing under the install root. Panics if zero or more than one
+/// directory matches - multiple matches typically indicate a stale install
+/// from a prior `FOLLY_COMMIT_HASH` mixed with the current one, which would
+/// otherwise be resolved non-deterministically and could link the wrong
+/// version.
 #[cfg(feature = "coroutines")]
 fn resolve_folly_dep(install_root: &Path, name: &str) -> PathBuf {
     let pattern = install_root.join(format!("{name}-*"));
     let pattern_str = pattern
         .to_str()
         .expect("ROCKSDB_FOLLY_INSTALL_PATH must be valid UTF-8");
-    glob::glob(pattern_str)
+    let matches: Vec<PathBuf> = glob::glob(pattern_str)
         .unwrap_or_else(|e| panic!("invalid glob `{pattern_str}`: {e}"))
         .filter_map(Result::ok)
-        .next()
-        .unwrap_or_else(|| {
-            panic!(
-                "could not find `{name}-*` under {}; \
-                 did `scripts/build_folly.sh` finish successfully?",
-                install_root.display()
-            )
-        })
+        .collect();
+    match matches.as_slice() {
+        [] => panic!(
+            "could not find `{name}-*` under {}; \
+             did `scripts/build_folly.sh` finish successfully?",
+            install_root.display()
+        ),
+        [only] => only.clone(),
+        many => panic!(
+            "found {} `{name}-*` directories under {}:\n  {}\n\
+             this usually means a stale install from a prior FOLLY_COMMIT_HASH \
+             is mixed with the current one. Remove the stale entries or point \
+             ROCKSDB_FOLLY_INSTALL_PATH at a clean install.",
+            many.len(),
+            install_root.display(),
+            many.iter()
+                .map(|p| p.display().to_string())
+                .collect::<Vec<_>>()
+                .join("\n  ")
+        ),
+    }
 }
 
 /// folly's getdeps installs some libraries under `lib/` and others under
-/// `lib64/`. Prefer `lib64/` when it exists.
+/// `lib64/` depending on the OS distribution conventions. As of the
+/// `FOLLY_COMMIT_HASH` pinned by `librocksdb-sys/rocksdb/folly.mk`, glog and
+/// fmt are typically under `lib64/` on RHEL-family distros and under `lib/`
+/// on Debian-family distros; gflags is consistently under `lib/`. Prefer
+/// `lib64/` when present since that's the more specific path; only one of
+/// the two ever contains the library for a given dep.
 #[cfg(feature = "coroutines")]
 fn lib_or_lib64(prefix: &Path) -> PathBuf {
     let candidate = prefix.join("lib64");

--- a/scripts/build_folly.sh
+++ b/scripts/build_folly.sh
@@ -62,6 +62,66 @@ FOLLY_DIR="$ROCKSDB_DIR/third-party/folly"
 mkdir -p "$ROCKSDB_DIR/third-party"
 mkdir -p "$SCRATCH_DIR"
 
+# The pinned folly commit needs liburing >= 2.7 - it references the
+# `io_uring_zcrx_*` zero-copy receive API in
+# `folly/io/async/IoUringZeroCopyBufferPool.cpp`, plus `IOU_PBUF_RING_INC` and
+# `io_uring_buf_ring_head` from liburing 2.6 in `IoUringProvidedBufferRing.cpp`.
+# folly's getdeps does not fetch liburing as a managed dep, so we must ensure
+# a sufficiently new version is on the system include/lib paths before
+# invoking it.
+#
+# Ubuntu 25.10+ and Debian trixie+ already package liburing >= 2.11 via apt.
+# Older distros (notably Ubuntu 24.04 LTS, which ships 2.5) need a manual
+# build. The check below is a no-op on hosts that are already up to date.
+need_liburing_build=yes
+if command -v pkg-config >/dev/null 2>&1 && pkg-config --exists liburing; then
+    sys_version="$(pkg-config --modversion liburing)"
+    sys_major="${sys_version%%.*}"
+    sys_rest="${sys_version#*.}"
+    sys_minor="${sys_rest%%.*}"
+    if [ "${sys_major:-0}" -gt 2 ] \
+       || { [ "${sys_major:-0}" -eq 2 ] && [ "${sys_minor:-0}" -ge 7 ]; }; then
+        echo ">>> System liburing $sys_version is sufficient (need >= 2.7); skipping source build."
+        need_liburing_build=no
+    else
+        echo ">>> System liburing $sys_version is too old (need >= 2.7)."
+    fi
+else
+    echo ">>> liburing not found via pkg-config."
+fi
+
+if [ "$need_liburing_build" = "yes" ]; then
+    if ! command -v make >/dev/null 2>&1 || ! command -v cc >/dev/null 2>&1; then
+        echo "Error: liburing source build requires 'make' and a C compiler." >&2
+        echo "Either install them, or upgrade your system liburing to 2.7+" >&2
+        echo "(Ubuntu 25.10+, Debian trixie+, etc)." >&2
+        exit 1
+    fi
+    liburing_version="2.9"
+    liburing_prefix="$SCRATCH_DIR/liburing-$liburing_version"
+    if [ ! -f "$liburing_prefix/lib/pkgconfig/liburing.pc" ]; then
+        echo ">>> Building liburing $liburing_version from source..."
+        liburing_src="$SCRATCH_DIR/liburing-src-$liburing_version"
+        if [ ! -d "$liburing_src" ]; then
+            git clone --quiet --depth 1 \
+                --branch "liburing-$liburing_version" \
+                https://github.com/axboe/liburing.git "$liburing_src"
+        fi
+        (
+            cd "$liburing_src"
+            ./configure --prefix="$liburing_prefix" >/dev/null
+            make -j"$(nproc 2>/dev/null || echo 2)" >/dev/null
+            make install >/dev/null
+        )
+    fi
+    # Expose the freshly-built liburing to folly's CMake and to any subsequent
+    # build (rust-rocksdb's `io-uring` feature uses pkg-config too).
+    export PKG_CONFIG_PATH="$liburing_prefix/lib/pkgconfig:${PKG_CONFIG_PATH:-}"
+    export CPATH="$liburing_prefix/include:${CPATH:-}"
+    export LIBRARY_PATH="$liburing_prefix/lib:${LIBRARY_PATH:-}"
+    export LD_LIBRARY_PATH="$liburing_prefix/lib:${LD_LIBRARY_PATH:-}"
+fi
+
 echo ">>> Cloning folly @ $FOLLY_COMMIT_HASH..."
 if [ -d "$FOLLY_DIR/.git" ]; then
     (cd "$FOLLY_DIR" && git fetch --quiet origin)

--- a/scripts/build_folly.sh
+++ b/scripts/build_folly.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build folly + all its transitive dependencies for the `coroutines` cargo
+# feature.
+#
+# This wraps RocksDB's own `make build_folly` target, which invokes folly's
+# getdeps.py to build folly and its dependency chain (boost, fmt, glog,
+# gflags, double-conversion, libevent, libsodium, xz) at the exact commit
+# pinned by `librocksdb-sys/rocksdb/folly.mk:FOLLY_COMMIT_HASH`.
+#
+# The build is slow (15-30 minutes on a clean machine, longer on CI). It
+# downloads several hundred MB of source archives. Results live under
+# `librocksdb-sys/rocksdb/third-party/folly/build/fbcode_builder/installed/`
+# and are reusable across rust-rocksdb builds.
+#
+# On success, prints the path to set `ROCKSDB_FOLLY_INSTALL_PATH` to, then
+# subsequent `cargo build --features coroutines` will find folly.
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+ROCKSDB_DIR="$REPO_ROOT/librocksdb-sys/rocksdb"
+
+if [ ! -f "$ROCKSDB_DIR/folly.mk" ]; then
+    echo "Error: $ROCKSDB_DIR does not look like a RocksDB checkout." >&2
+    echo "Did you clone with --recursive? Try:" >&2
+    echo "    git submodule update --init --recursive" >&2
+    exit 1
+fi
+
+case "$(uname -s)" in
+    Linux*) ;;
+    *)
+        echo "Error: the coroutines feature is only supported on Linux." >&2
+        echo "Folly's build (getdeps.py) does not reliably support" >&2
+        echo "$(uname -s) and RocksDB's coroutine code path is Linux-only" >&2
+        echo "(needs io_uring)." >&2
+        exit 1
+        ;;
+esac
+
+cd "$ROCKSDB_DIR"
+
+echo ">>> Cloning and pinning folly..."
+make checkout_folly
+
+echo ">>> Building folly + dependencies (this may take 15-30 minutes)..."
+make build_folly
+
+# getdeps.py's `show-inst-dir` prints folly's own install dir, e.g.
+# `.../installed/folly-<hash>`. Its sibling directories (boost-*, fmt-*, etc)
+# hold the rest of folly's deps. The install root is one level up.
+FOLLY_INST_PATH="$(cd third-party/folly \
+                    && python3 build/fbcode_builder/getdeps.py show-inst-dir)"
+INSTALL_ROOT="$(dirname "$FOLLY_INST_PATH")"
+
+cat <<EOF
+
+==============================================================
+Folly and its dependencies are installed under:
+    $INSTALL_ROOT
+
+To build rust-rocksdb with the coroutines feature:
+    export ROCKSDB_FOLLY_INSTALL_PATH="$INSTALL_ROOT"
+    cargo build --release --features coroutines,io-uring
+==============================================================
+EOF

--- a/scripts/build_folly.sh
+++ b/scripts/build_folly.sh
@@ -43,9 +43,11 @@ case "$(uname -s)" in
         ;;
 esac
 
-for tool in git python3 patchelf perl; do
+for tool in git python3 patchelf perl wget; do
     if ! command -v "$tool" >/dev/null 2>&1; then
         echo "Error: required tool '$tool' is not on PATH." >&2
+        echo "Hint: on Debian/Ubuntu, install with:" >&2
+        echo "    apt-get install -y git python3 patchelf perl wget" >&2
         exit 1
     fi
 done

--- a/scripts/build_folly.sh
+++ b/scripts/build_folly.sh
@@ -2,23 +2,28 @@
 # Build folly + all its transitive dependencies for the `coroutines` cargo
 # feature.
 #
-# This wraps RocksDB's own `make build_folly` target, which invokes folly's
-# getdeps.py to build folly and its dependency chain (boost, fmt, glog,
-# gflags, double-conversion, libevent, libsodium, xz) at the exact commit
-# pinned by `librocksdb-sys/rocksdb/folly.mk:FOLLY_COMMIT_HASH`.
+# We do NOT use RocksDB's `make build_folly` target, because that runs
+# `getdeps.py` without `--scratch-path`. With no `--scratch-path`, getdeps
+# falls back to a `/tmp/fbcode_builder_getdeps-<munged-cwd>` directory
+# (see folly's `build/fbcode_builder/getdeps/buildopts.py:setup_build_options`),
+# which is unstable across machines and impossible to cache cleanly in CI.
+# Instead, we replicate the few things `make build_folly` does (clone + pin
+# folly, apply two upstream patches, run getdeps, patchelf libglog) and pass
+# `--scratch-path` so the install lands at a predictable location.
 #
-# The build is slow (15-30 minutes on a clean machine, longer on CI). It
-# downloads several hundred MB of source archives. Results live under
-# `librocksdb-sys/rocksdb/third-party/folly/build/fbcode_builder/installed/`
-# and are reusable across rust-rocksdb builds.
+# Usage:
+#   ./scripts/build_folly.sh                       # builds to default scratch dir
+#   ROCKSDB_FOLLY_SCRATCH_DIR=/path scripts/...    # explicit scratch dir
 #
-# On success, prints the path to set `ROCKSDB_FOLLY_INSTALL_PATH` to, then
-# subsequent `cargo build --features coroutines` will find folly.
+# The build is slow (~15-30 minutes on a clean machine, longer on CI). It
+# downloads several hundred MB of source archives. On a warm cache the script
+# is a near no-op.
 
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ROCKSDB_DIR="$REPO_ROOT/librocksdb-sys/rocksdb"
+SCRATCH_DIR="${ROCKSDB_FOLLY_SCRATCH_DIR:-$REPO_ROOT/librocksdb-sys/folly-build}"
 
 if [ ! -f "$ROCKSDB_DIR/folly.mk" ]; then
     echo "Error: $ROCKSDB_DIR does not look like a RocksDB checkout." >&2
@@ -38,29 +43,77 @@ case "$(uname -s)" in
         ;;
 esac
 
-cd "$ROCKSDB_DIR"
+for tool in git python3 patchelf perl; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+        echo "Error: required tool '$tool' is not on PATH." >&2
+        exit 1
+    fi
+done
 
-echo ">>> Cloning and pinning folly..."
-make checkout_folly
+# Extract the pinned folly commit from RocksDB's folly.mk
+FOLLY_COMMIT_HASH="$(grep -E '^FOLLY_COMMIT_HASH = ' "$ROCKSDB_DIR/folly.mk" \
+                       | sed -E 's/^FOLLY_COMMIT_HASH = //')"
+if [ -z "$FOLLY_COMMIT_HASH" ]; then
+    echo "Error: could not parse FOLLY_COMMIT_HASH from folly.mk." >&2
+    exit 1
+fi
 
-echo ">>> Building folly + dependencies (this may take 15-30 minutes)..."
-make build_folly
+FOLLY_DIR="$ROCKSDB_DIR/third-party/folly"
+mkdir -p "$ROCKSDB_DIR/third-party"
+mkdir -p "$SCRATCH_DIR"
 
-# getdeps.py's `show-inst-dir` prints folly's own install dir, e.g.
-# `.../installed/folly-<hash>`. Its sibling directories (boost-*, fmt-*, etc)
-# hold the rest of folly's deps. The install root is one level up.
-FOLLY_INST_PATH="$(cd third-party/folly \
-                    && python3 build/fbcode_builder/getdeps.py show-inst-dir)"
-INSTALL_ROOT="$(dirname "$FOLLY_INST_PATH")"
+echo ">>> Cloning folly @ $FOLLY_COMMIT_HASH..."
+if [ -d "$FOLLY_DIR/.git" ]; then
+    (cd "$FOLLY_DIR" && git fetch --quiet origin)
+else
+    git clone --quiet https://github.com/facebook/folly.git "$FOLLY_DIR"
+fi
+(cd "$FOLLY_DIR" && git reset --hard --quiet "$FOLLY_COMMIT_HASH")
+
+echo ">>> Applying upstream patches..."
+# These match the two `perl -pi -e` invocations in RocksDB's folly.mk
+# `checkout_folly` target; the upstream folly commit needs them to compile
+# cleanly against a modern toolchain. They are idempotent across re-runs.
+perl -pi -e 's/(#include <atomic>)/$1\n#include <cstring>/ unless /#include <cstring>/' \
+    "$FOLLY_DIR/folly/lang/Exception.h"
+perl -pi -e 's/: environ/: (const char**)(environ)/ unless /\(const char\*\*\)\(environ\)/' \
+    "$FOLLY_DIR/folly/Subprocess.cpp"
+
+echo ">>> Building folly + dependencies into $SCRATCH_DIR..."
+echo "    (allow 15-30 minutes on a cold cache)"
+cd "$FOLLY_DIR"
+GETDEPS_USE_WGET=1 \
+CXXFLAGS=" -DHAVE_CXX11_ATOMIC " \
+python3 build/fbcode_builder/getdeps.py \
+    --scratch-path "$SCRATCH_DIR" \
+    build --no-tests
+
+# RocksDB's folly.mk patchelfs libglog.so to embed an rpath pointing at
+# gflags, because folly's getdeps build links libglog -> libgflags but
+# doesn't bake the lookup path in. Without this, ld.so cannot resolve
+# libgflags when loading libglog at runtime, even if the user's binary has
+# an rpath to libglog.
+INSTALLED_DIR="$SCRATCH_DIR/installed"
+GFLAGS_DIR="$(ls -d "$INSTALLED_DIR/gflags-"* 2>/dev/null | head -1)"
+GLOG_DIR="$(ls -d "$INSTALLED_DIR/glog-"* 2>/dev/null | head -1)"
+if [ -n "$GLOG_DIR" ] && [ -n "$GFLAGS_DIR" ]; then
+    GLOG_SO="$(ls "$GLOG_DIR"/lib*/libglog.so.*.*.* 2>/dev/null | head -1 || true)"
+    if [ -n "$GLOG_SO" ]; then
+        echo ">>> Patching $GLOG_SO to find libgflags via rpath..."
+        patchelf --add-rpath "$GFLAGS_DIR/lib" "$GLOG_SO"
+    else
+        echo "Warning: could not locate libglog shared object to patchelf." >&2
+    fi
+fi
 
 cat <<EOF
 
 ==============================================================
 Folly and its dependencies are installed under:
-    $INSTALL_ROOT
+    $INSTALLED_DIR
 
 To build rust-rocksdb with the coroutines feature:
-    export ROCKSDB_FOLLY_INSTALL_PATH="$INSTALL_ROOT"
+    export ROCKSDB_FOLLY_INSTALL_PATH="$INSTALLED_DIR"
     cargo build --release --features coroutines,io-uring
 ==============================================================
 EOF

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,9 +165,8 @@ use rust_librocksdb_sys as ffi;
 ///
 /// When `true`, calling [`ReadOptions::set_async_io(true)`][async-io] on a
 /// `MultiGet` activates the multi-level parallel-read path described in the
-/// RocksDB [Asynchronous IO blog post]. When `false`, `async_io=true` still
-/// works for scans and parallelizes reads within a single LSM level for
-/// `MultiGet`, but cannot parallelize across levels.
+/// RocksDB [Asynchronous IO blog post]. When `false`, `MultiGet` with
+/// `async_io=true` can only parallelize reads within a single LSM level.
 ///
 /// Note: this reflects how this crate was configured, not what is in the
 /// linked `librocksdb`. If you used `ROCKSDB_LIB_DIR` to link against an

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,6 +159,28 @@ pub use crate::{
 
 use rust_librocksdb_sys as ffi;
 
+/// Returns `true` if this crate was built with the `coroutines` feature, in
+/// which case librocksdb was compiled with `USE_COROUTINES` and linked
+/// against folly.
+///
+/// When `true`, calling [`ReadOptions::set_async_io(true)`][async-io] on a
+/// `MultiGet` activates the multi-level parallel-read path described in the
+/// RocksDB [Asynchronous IO blog post]. When `false`, `async_io=true` still
+/// works for scans and parallelizes reads within a single LSM level for
+/// `MultiGet`, but cannot parallelize across levels.
+///
+/// Note: this reflects how this crate was configured, not what is in the
+/// linked `librocksdb`. If you used `ROCKSDB_LIB_DIR` to link against an
+/// externally-built `librocksdb.a`, the answer here may not match what that
+/// library was actually compiled with.
+///
+/// [async-io]: ReadOptions::set_async_io
+/// [Asynchronous IO blog post]: https://rocksdb.org/blog/2022/10/07/asynchronous-io-in-rocksdb.html
+#[must_use]
+pub fn built_with_coroutines() -> bool {
+    cfg!(feature = "coroutines")
+}
+
 #[cfg(feature = "raw-ptr")]
 mod raw_ptr;
 

--- a/tests/test_coroutines.rs
+++ b/tests/test_coroutines.rs
@@ -49,17 +49,22 @@ fn level_layout(db: &DB, max_levels: usize) -> (usize, Vec<u64>) {
     (non_empty, counts)
 }
 
+/// Verifies that `built_with_coroutines()` agrees with the crate's `coroutines`
+/// cargo feature.
+///
+/// This is intentionally tautological at the source level - the function is
+/// implemented as `cfg!(feature = "coroutines")` - but it's not pointless. If
+/// the function is ever refactored to read its answer from a runtime symbol
+/// (for example, after the upstream PR adding `rocksdb_compiled_with_coroutines`
+/// is merged and we bump the submodule), this test would catch a wiring bug
+/// where the runtime value disagrees with the build feature.
 #[test]
-fn built_with_coroutines_helper_is_callable() {
-    // We can't meaningfully assert equality with `cfg!(feature = ...)` here
-    // because `built_with_coroutines()` is implemented as exactly that - the
-    // assertion would be tautological. Just verify it's callable and stable
-    // within a single process. The real value of `built_with_coroutines()`
-    // is documentation: it gives callers a single source of truth they can
-    // log or surface in diagnostics.
-    let a = rust_rocksdb::built_with_coroutines();
-    let b = rust_rocksdb::built_with_coroutines();
-    assert_eq!(a, b);
+fn built_with_coroutines_matches_feature_flag() {
+    assert_eq!(
+        rust_rocksdb::built_with_coroutines(),
+        cfg!(feature = "coroutines"),
+        "built_with_coroutines() must match the cargo feature flag"
+    );
 }
 
 /// Verifies that `multi_get` with `async_io=true` returns correct results
@@ -93,6 +98,18 @@ fn multi_get_async_io_matches_serial_get_across_levels() {
         // in at least L0 and one deeper level.
         let value = vec![b'v'; 200];
 
+        // 30-second timeout for each compaction wait. With
+        // disable_auto_compactions=true and a high L0 trigger, no background
+        // work runs concurrently, but we still call wait_for_compact after
+        // each manual compaction as defense-in-depth so the level layout is
+        // settled before we measure it.
+        let make_wait_opts = || {
+            let mut o = WaitForCompactOptions::default();
+            o.set_flush(true);
+            o.set_timeout(30 * 1_000_000); // 30s in microseconds
+            o
+        };
+
         let put_batch = |start: u32, end: u32| {
             for i in start..end {
                 let key = format!("key-{i:08}");
@@ -107,6 +124,7 @@ fn multi_get_async_io_matches_serial_get_across_levels() {
         co.set_change_level(true);
         co.set_target_level(2);
         db.compact_range_opt::<&[u8], &[u8]>(None, None, &co);
+        db.wait_for_compact(&make_wait_opts()).unwrap();
 
         // Batch 2 -> L0 -> compact to L1.
         put_batch(200, 400);
@@ -114,15 +132,11 @@ fn multi_get_async_io_matches_serial_get_across_levels() {
         co.set_change_level(true);
         co.set_target_level(1);
         db.compact_range_opt::<&[u8], &[u8]>(None, None, &co);
+        db.wait_for_compact(&make_wait_opts()).unwrap();
 
         // Batch 3 -> stays in L0 (no further compaction).
         put_batch(400, 600);
-
-        // Wait for any in-flight background work (none expected, but cheap).
-        let mut wait_opts = WaitForCompactOptions::default();
-        wait_opts.set_flush(true);
-        wait_opts.set_timeout(30 * 1_000_000); // 30s
-        db.wait_for_compact(&wait_opts).unwrap();
+        db.wait_for_compact(&make_wait_opts()).unwrap();
 
         let (non_empty, counts) = level_layout(&db, 5);
         assert!(

--- a/tests/test_coroutines.rs
+++ b/tests/test_coroutines.rs
@@ -1,0 +1,149 @@
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//! Smoke tests for the async-IO `MultiGet` path.
+//!
+//! These tests run in both feature configurations. When the `coroutines`
+//! feature is disabled, `async_io=true` only parallelizes within a single
+//! LSM level; when enabled, the multi-level coroutine path activates. The
+//! tests don't assert anything about *which* path was taken - only that the
+//! results are correct in both cases. That's the property that matters from
+//! the user's perspective.
+
+mod util;
+
+use pretty_assertions::assert_eq;
+use rust_rocksdb::{DB, Options, ReadOptions, WaitForCompactOptions, WriteOptions};
+
+use util::DBPath;
+
+#[test]
+fn built_with_coroutines_matches_feature_flag() {
+    assert_eq!(
+        rust_rocksdb::built_with_coroutines(),
+        cfg!(feature = "coroutines")
+    );
+}
+
+/// Builds a DB whose keyspace is spread across multiple LSM levels, then
+/// verifies that `multi_get` with `async_io=true` returns identical results
+/// to a loop of single `get`s. Both branches of `version_set.cc`'s
+/// `MultiGetFromSST{,Coroutine}` dispatch must produce correct results.
+#[test]
+fn multi_get_async_io_matches_serial_get() {
+    let path = DBPath::new("_rust_rocksdb_multi_get_async_io");
+    {
+        // Force many small SST files spread across several levels.
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.set_write_buffer_size(64 * 1024);
+        opts.set_target_file_size_base(64 * 1024);
+        opts.set_max_bytes_for_level_base(256 * 1024);
+        opts.set_level_zero_file_num_compaction_trigger(2);
+        opts.set_num_levels(4);
+        opts.set_disable_auto_compactions(false);
+
+        let db = DB::open(&opts, &path).unwrap();
+
+        let mut wo = WriteOptions::default();
+        wo.set_sync(false);
+
+        // Insert enough data to span multiple non-empty levels after
+        // compactions settle.
+        let n: u32 = 4_000;
+        let value = vec![b'v'; 200];
+        for i in 0..n {
+            let key = format!("key-{i:08}");
+            db.put_opt(key.as_bytes(), &value, &wo).unwrap();
+        }
+        db.flush().unwrap();
+
+        // Trigger a full compaction and wait for it to finish so the
+        // resulting LSM has a stable level layout.
+        db.compact_range::<&[u8], &[u8]>(None, None);
+        let mut wait_opts = WaitForCompactOptions::default();
+        wait_opts.set_flush(true);
+        wait_opts.set_timeout(30 * 1_000_000); // 30s in microseconds
+        db.wait_for_compact(&wait_opts).unwrap();
+
+        // Build a batch of keys mixing hits and misses, sparsely spread
+        // across the keyspace so they're likely to land in different SSTs
+        // and different levels.
+        let mut keys: Vec<Vec<u8>> = (0..n)
+            .step_by(53)
+            .map(|i| format!("key-{i:08}").into_bytes())
+            .collect();
+        keys.push(b"key-99999999".to_vec()); // miss
+        keys.push(b"a-missing-key".to_vec()); // miss
+        keys.push(b"key-00000017".to_vec()); // hit, small key
+
+        // Reference: a loop of single Gets.
+        let reference: Vec<Option<Vec<u8>>> = keys.iter().map(|k| db.get(k).unwrap()).collect();
+
+        // Test path: multi_get_opt with async_io=true.
+        let mut ro = ReadOptions::default();
+        ro.set_async_io(true);
+        let key_refs: Vec<&[u8]> = keys.iter().map(Vec::as_slice).collect();
+        let async_results: Vec<Option<Vec<u8>>> = db
+            .multi_get_opt(key_refs, &ro)
+            .into_iter()
+            .map(Result::unwrap)
+            .collect();
+
+        assert_eq!(reference.len(), async_results.len());
+        assert_eq!(
+            reference,
+            async_results,
+            "async_io MultiGet results must match a serial Get loop \
+             (coroutines feature: {})",
+            cfg!(feature = "coroutines")
+        );
+    }
+}
+
+/// Same as above, but reads a batch of keys that are guaranteed to all hit
+/// the same single SST/level after compaction. Stresses the single-level
+/// async path even when coroutines are enabled (which forces a single-file
+/// fast-path in version_set.cc's `MultiGetFromSST`).
+#[test]
+fn multi_get_async_io_same_level_matches_serial_get() {
+    let path = DBPath::new("_rust_rocksdb_multi_get_async_io_same_level");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+
+        let db = DB::open(&opts, &path).unwrap();
+        for i in 0..32u32 {
+            let key = format!("key-{i:04}");
+            db.put(key.as_bytes(), format!("value-{i}").as_bytes())
+                .unwrap();
+        }
+        db.flush().unwrap();
+
+        let keys: Vec<Vec<u8>> = (0..32u32)
+            .map(|i| format!("key-{i:04}").into_bytes())
+            .collect();
+
+        let reference: Vec<Option<Vec<u8>>> = keys.iter().map(|k| db.get(k).unwrap()).collect();
+
+        let mut ro = ReadOptions::default();
+        ro.set_async_io(true);
+        let key_refs: Vec<&[u8]> = keys.iter().map(Vec::as_slice).collect();
+        let async_results: Vec<Option<Vec<u8>>> = db
+            .multi_get_opt(key_refs, &ro)
+            .into_iter()
+            .map(Result::unwrap)
+            .collect();
+
+        assert_eq!(reference, async_results);
+    }
+}

--- a/tests/test_coroutines.rs
+++ b/tests/test_coroutines.rs
@@ -1,3 +1,5 @@
+// Copyright 2026 Tyler Neely
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
@@ -13,83 +15,136 @@
 //! Smoke tests for the async-IO `MultiGet` path.
 //!
 //! These tests run in both feature configurations. When the `coroutines`
-//! feature is disabled, `async_io=true` only parallelizes within a single
+//! feature is disabled, `async_io=true` parallelizes only within a single
 //! LSM level; when enabled, the multi-level coroutine path activates. The
-//! tests don't assert anything about *which* path was taken - only that the
-//! results are correct in both cases. That's the property that matters from
-//! the user's perspective.
+//! tests verify that results are *correct* in both configurations - they do
+//! not assert which dispatch branch ran.
+//!
+//! The multi-level test explicitly populates several LSM levels and asserts
+//! the layout via `rocksdb.num-files-at-levelN` before running the
+//! MultiGet, so failures from a "MultiGet across multiple levels" bug land
+//! in a test that actually has data in multiple levels.
 
 mod util;
 
 use pretty_assertions::assert_eq;
-use rust_rocksdb::{DB, Options, ReadOptions, WaitForCompactOptions, WriteOptions};
+use rust_rocksdb::{
+    CompactOptions, DB, Options, ReadOptions, WaitForCompactOptions, WriteOptions,
+    properties::num_files_at_level,
+};
 
 use util::DBPath;
 
-#[test]
-fn built_with_coroutines_matches_feature_flag() {
-    assert_eq!(
-        rust_rocksdb::built_with_coroutines(),
-        cfg!(feature = "coroutines")
-    );
+/// Counts non-empty levels by querying `rocksdb.num-files-at-level{N}` for
+/// each level. Returns `(non_empty_count, [files_per_level; max_levels])`.
+fn level_layout(db: &DB, max_levels: usize) -> (usize, Vec<u64>) {
+    let counts: Vec<u64> = (0..max_levels)
+        .map(|lvl| {
+            db.property_int_value(num_files_at_level(lvl))
+                .unwrap()
+                .unwrap_or(0)
+        })
+        .collect();
+    let non_empty = counts.iter().filter(|&&n| n > 0).count();
+    (non_empty, counts)
 }
 
-/// Builds a DB whose keyspace is spread across multiple LSM levels, then
-/// verifies that `multi_get` with `async_io=true` returns identical results
-/// to a loop of single `get`s. Both branches of `version_set.cc`'s
-/// `MultiGetFromSST{,Coroutine}` dispatch must produce correct results.
 #[test]
-fn multi_get_async_io_matches_serial_get() {
-    let path = DBPath::new("_rust_rocksdb_multi_get_async_io");
+fn built_with_coroutines_helper_is_callable() {
+    // We can't meaningfully assert equality with `cfg!(feature = ...)` here
+    // because `built_with_coroutines()` is implemented as exactly that - the
+    // assertion would be tautological. Just verify it's callable and stable
+    // within a single process. The real value of `built_with_coroutines()`
+    // is documentation: it gives callers a single source of truth they can
+    // log or surface in diagnostics.
+    let a = rust_rocksdb::built_with_coroutines();
+    let b = rust_rocksdb::built_with_coroutines();
+    assert_eq!(a, b);
+}
+
+/// Verifies that `multi_get` with `async_io=true` returns correct results
+/// when keys are actually spread across multiple LSM levels. Without an
+/// explicit level-layout check, a regression that breaks the multi-level
+/// dispatch path could pass silently because the test setup never produced
+/// such a layout.
+#[test]
+fn multi_get_async_io_matches_serial_get_across_levels() {
+    let path = DBPath::new("_rust_rocksdb_multi_get_async_io_multi_level");
     {
-        // Force many small SST files spread across several levels.
+        // Configure tiny memtables and SSTs so a moderate number of writes
+        // forces L0->L1->L2 compactions. Disable auto compactions so the
+        // test drives the layout deterministically via `compact_range_opt`.
         let mut opts = Options::default();
         opts.create_if_missing(true);
-        opts.set_write_buffer_size(64 * 1024);
-        opts.set_target_file_size_base(64 * 1024);
-        opts.set_max_bytes_for_level_base(256 * 1024);
-        opts.set_level_zero_file_num_compaction_trigger(2);
-        opts.set_num_levels(4);
-        opts.set_disable_auto_compactions(false);
+        opts.set_write_buffer_size(4 * 1024);
+        opts.set_target_file_size_base(4 * 1024);
+        opts.set_max_bytes_for_level_base(16 * 1024);
+        opts.set_max_bytes_for_level_multiplier(2.0);
+        opts.set_num_levels(5);
+        opts.set_disable_auto_compactions(true);
+        opts.set_level_zero_file_num_compaction_trigger(64); // effectively disabled
 
         let db = DB::open(&opts, &path).unwrap();
-
         let mut wo = WriteOptions::default();
         wo.set_sync(false);
 
-        // Insert enough data to span multiple non-empty levels after
-        // compactions settle.
-        let n: u32 = 4_000;
+        // Three batches, each flushed to its own L0 file, then compacted
+        // down one level at a time. After the dance there should be data
+        // in at least L0 and one deeper level.
         let value = vec![b'v'; 200];
-        for i in 0..n {
-            let key = format!("key-{i:08}");
-            db.put_opt(key.as_bytes(), &value, &wo).unwrap();
-        }
-        db.flush().unwrap();
 
-        // Trigger a full compaction and wait for it to finish so the
-        // resulting LSM has a stable level layout.
-        db.compact_range::<&[u8], &[u8]>(None, None);
+        let put_batch = |start: u32, end: u32| {
+            for i in start..end {
+                let key = format!("key-{i:08}");
+                db.put_opt(key.as_bytes(), &value, &wo).unwrap();
+            }
+            db.flush().unwrap();
+        };
+
+        // Batch 1 -> L0 -> compact to L2.
+        put_batch(0, 200);
+        let mut co = CompactOptions::default();
+        co.set_change_level(true);
+        co.set_target_level(2);
+        db.compact_range_opt::<&[u8], &[u8]>(None, None, &co);
+
+        // Batch 2 -> L0 -> compact to L1.
+        put_batch(200, 400);
+        let mut co = CompactOptions::default();
+        co.set_change_level(true);
+        co.set_target_level(1);
+        db.compact_range_opt::<&[u8], &[u8]>(None, None, &co);
+
+        // Batch 3 -> stays in L0 (no further compaction).
+        put_batch(400, 600);
+
+        // Wait for any in-flight background work (none expected, but cheap).
         let mut wait_opts = WaitForCompactOptions::default();
         wait_opts.set_flush(true);
-        wait_opts.set_timeout(30 * 1_000_000); // 30s in microseconds
+        wait_opts.set_timeout(30 * 1_000_000); // 30s
         db.wait_for_compact(&wait_opts).unwrap();
 
-        // Build a batch of keys mixing hits and misses, sparsely spread
-        // across the keyspace so they're likely to land in different SSTs
-        // and different levels.
-        let mut keys: Vec<Vec<u8>> = (0..n)
-            .step_by(53)
+        let (non_empty, counts) = level_layout(&db, 5);
+        assert!(
+            non_empty >= 2,
+            "test setup failed to spread data across multiple LSM levels: \
+             non_empty={non_empty}, counts={counts:?}; \
+             coroutines feature: {}",
+            cfg!(feature = "coroutines")
+        );
+
+        // Build a key batch spanning all three insertion batches plus some
+        // misses. Each batch landed in a different level, so a MultiGet
+        // across this set forces multi-level lookup.
+        let mut keys: Vec<Vec<u8>> = (0..600u32)
+            .step_by(37)
             .map(|i| format!("key-{i:08}").into_bytes())
             .collect();
         keys.push(b"key-99999999".to_vec()); // miss
-        keys.push(b"a-missing-key".to_vec()); // miss
-        keys.push(b"key-00000017".to_vec()); // hit, small key
+        keys.push(b"key-00001234".to_vec()); // miss
 
-        // Reference: a loop of single Gets.
         let reference: Vec<Option<Vec<u8>>> = keys.iter().map(|k| db.get(k).unwrap()).collect();
 
-        // Test path: multi_get_opt with async_io=true.
         let mut ro = ReadOptions::default();
         ro.set_async_io(true);
         let key_refs: Vec<&[u8]> = keys.iter().map(Vec::as_slice).collect();
@@ -99,24 +154,23 @@ fn multi_get_async_io_matches_serial_get() {
             .map(Result::unwrap)
             .collect();
 
-        assert_eq!(reference.len(), async_results.len());
         assert_eq!(
             reference,
             async_results,
             "async_io MultiGet results must match a serial Get loop \
-             (coroutines feature: {})",
+             (coroutines feature: {}, level counts: {counts:?})",
             cfg!(feature = "coroutines")
         );
     }
 }
 
-/// Same as above, but reads a batch of keys that are guaranteed to all hit
-/// the same single SST/level after compaction. Stresses the single-level
-/// async path even when coroutines are enabled (which forces a single-file
-/// fast-path in version_set.cc's `MultiGetFromSST`).
+/// Reads a batch of keys that all live in a single SST after a flush.
+/// Exercises the same-level fast path even when the coroutines feature is
+/// enabled, since version_set.cc's `MultiGetFromSST` short-circuits the
+/// coroutine dispatch when only one file is involved.
 #[test]
-fn multi_get_async_io_same_level_matches_serial_get() {
-    let path = DBPath::new("_rust_rocksdb_multi_get_async_io_same_level");
+fn multi_get_async_io_matches_serial_get_single_level() {
+    let path = DBPath::new("_rust_rocksdb_multi_get_async_io_single_level");
     {
         let mut opts = Options::default();
         opts.create_if_missing(true);


### PR DESCRIPTION
Adds a `coroutines` cargo feature. When enabled, RocksDB is compiled with `USE_COROUTINES=1` and linked against folly. Calling `ReadOptions::set_async_io(true)` on a `MultiGet` then issues parallel io_uring reads across SST files in multiple LSM levels, which can lower MultiGet latency on slow storage.

Meta's published benchmark is on remote/network flash. They haven't published numbers for local NVMe; the gain there is probably smaller, but I haven't measured it.

Linux only. Needs liburing >= 2.7 (Ubuntu 25.10+ via apt; older distros are handled by the script which builds liburing from source). Needs gcc <= 14 or clang — gcc-15 breaks folly's pinned libunwind.

Usage:

```
./scripts/build_folly.sh
export ROCKSDB_FOLLY_INSTALL_PATH=$PWD/librocksdb-sys/folly-build/installed
cargo build --features coroutines,io-uring
```

The folly build takes ~20-30 minutes the first time. CI caches it.

Caveats:

- folly's getdeps only builds libglog and libgflags as `.so` files. The final binary needs them at runtime via `LD_LIBRARY_PATH` or an rpath in the binary crate's `build.rs`. README has details.
- Not compatible with `mt_static` (folly precludes a fully static build).
- `optimize_multiget_for_io` can't be set from Rust yet. It defaults to true, which is the right choice for coroutine builds. facebook/rocksdb#14752 adds the C API; once that merges and we bump the submodule, the setter goes in here.

Full details in the README's "Async MultiGet with C++20 Coroutines" section.