### PR TITLE
refactor(librocksdb-sys): rewrite build.rs; add opt-in system rocksdb linking

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -36,6 +36,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
 
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -51,6 +53,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
 
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
@@ -64,6 +68,8 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v5
+        with:
+          submodules: recursive
 
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,59 @@
 # Changelog
 
+## Unreleased
+
+- feat: add transactiondb checkpoint support (gdorsi)
+- feat: add opt-in `coroutines` feature for multi-level async `MultiGet`,
+  wrapping RocksDB's `USE_COROUTINES=1` / `USE_FOLLY=1` build path with a
+  `scripts/build_folly.sh` helper. Linux-only, requires liburing >= 2.7
+  and the `ROCKSDB_FOLLY_INSTALL_PATH` env var pointing at a folly
+  install. See README "Async MultiGet with C++20 Coroutines" for full
+  prerequisites and runtime constraints. (zaidoon1)
+- feat: add opt-in linking against a system-installed RocksDB. Set
+  `ROCKSDB_USE_PKG_CONFIG=1` to discover rocksdb via pkg-config, or
+  `ROCKSDB_LIB_DIR=<path>` to point at a prebuilt library directly.
+  Default behavior (vendored build) is unchanged. Closes #310. (zaidoon1)
+- refactor: rewrite `librocksdb-sys/build.rs` into typed `Target` and
+  `Backend` abstractions split across `mod vendor / system / snappy /
+  bindings / coroutines`, fixing several correctness bugs along the way.
+  (zaidoon1)
+- fix: bindgen now runs against the chosen backend's headers (vendored
+  vs system) instead of always the bundled headers. Eliminates a silent
+  ABI-mismatch hazard when linking system rocksdb. (zaidoon1)
+- fix: Windows runtime libs (`rpcrt4`, `shlwapi`) are now linked in both
+  vendored and system-link paths. Previously, linking a system rocksdb on
+  Windows produced unresolved-symbol errors. (zaidoon1)
+- fix: target-OS detection now reads `CARGO_CFG_TARGET_*` instead of host
+  `#[cfg(target_os=...)]`, eliminating a class of cross-compile bugs.
+  (zaidoon1)
+- fix: FreeBSD branch now honors `ROCKSDB_STATIC` and
+  `ROCKSDB_INCLUDE_DIR`; `ROCKSDB_COMPILE=1` on FreeBSD is rejected up
+  front with a clear error (the bundled sources don't build on FreeBSD).
+  (zaidoon1)
+- behavior change: on Android targets, the C++ stdlib link is now
+  `libc++` (NDK r18+, 2018) instead of `libstdc++`. Previous behavior
+  produced unresolved-symbol errors on modern NDK toolchains. (zaidoon1)
+- feat: added `cargo::metadata=include=` and `cargo::metadata=root=`
+  emissions; downstream `-sys` crates can read these as
+  `DEP_ROCKSDB_INCLUDE` and `DEP_ROCKSDB_ROOT`. Legacy
+  `cargo_manifest_dir`/`out_dir` keys preserved. (zaidoon1)
+- fix: iOS deployment target pinned via `-mios-version-min=12.0`
+  compiler flag instead of mutating process env, removing one of two
+  `unsafe { env::set_var }` blocks. Flag only emitted for actual iOS
+  targets (not tvos/watchos). (zaidoon1)
+- fix: comprehensive `cargo::rerun-if-env-changed=` coverage including
+  `CXXSTDLIB`, `CC`, `CXX`, `CFLAGS`, `CXXFLAGS`, `ROCKSDB_INCLUDE_DIR`,
+  `ROCKSDB_CXX_STD`, `CARGO_ENCODED_RUSTFLAGS`,
+  `BINDGEN_EXTRA_CLANG_ARGS`, `DEP_<LZ4/ZSTD/Z/BZIP2>_INCLUDE`,
+  `DEP_JEMALLOC_ROOT`, `PKG_CONFIG_*`. (zaidoon1)
+- fix: define `HAVE_FULLFSYNC` on Apple targets (macOS, iOS, tvOS,
+  watchOS) so RocksDB takes the `fcntl(F_FULLFSYNC)` path for true on-
+  disk durability rather than the weaker plain `fsync` (which on macOS
+  only flushes to the drive cache). Matches RocksDB's CMakeLists.txt.
+  (zaidoon1)
+- fix: emit `-DWIN32` (not `-DDWIN32`) on Windows targets so the define
+  matches what RocksDB's CMakeLists.txt sets. (zaidoon1)
+
 ## 0.48.0 (2026-05-04)
 
 - upgrade RocksDB to 11.1.1 (zaidoon1)

--- a/README.md
+++ b/README.md
@@ -375,6 +375,57 @@ cd rust-rocksdb
 git submodule update --init --recursive
 ```
 
+### Linking Against a Prebuilt RocksDB
+
+By default, `rust-rocksdb` builds RocksDB from the bundled submodule. To link against a system-installed `librocksdb` instead (e.g. to share a single library across multiple Rust projects, cut compile time, or use a distro's package), the build script honors these opt-in environment variables:
+
+| Variable                   | Effect                                                                                                       |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `ROCKSDB_USE_PKG_CONFIG=1` | Probe `pkg-config rocksdb` to discover lib + include paths automatically. Accepts `1` or `true`.             |
+| `ROCKSDB_LIB_DIR=<path>`   | Look for `librocksdb.{a,so,dylib,dll}` in `<path>`. **Requires `ROCKSDB_INCLUDE_DIR` to be set too.**        |
+| `ROCKSDB_STATIC`           | Static-link the system rocksdb (default is dynamic). Any non-empty value enables it (legacy semantics).      |
+| `ROCKSDB_INCLUDE_DIR=<p>`  | Headers for `bindgen`. Mandatory with `ROCKSDB_LIB_DIR`; with `ROCKSDB_USE_PKG_CONFIG` it is *merged in front* of pkg-config's discovered paths (does not replace them). |
+| `ROCKSDB_COMPILE=1`        | Force the bundled vendored build even if the above are set. Accepts `1` or `true` (case-insensitive).        |
+| `ROCKSDB_CXX_STD=c++23`    | Override the C++ standard used to compile RocksDB (default `c++20`). Only used for vendored builds.          |
+| `CXXSTDLIB=stdc++`         | Override the C++ stdlib linked (e.g. `c++` for libc++, `stdc++` for libstdc++).                              |
+
+When you opt in via any of these:
+
+- `bindgen` runs against the **chosen backend's headers** (system rocksdb when linked from the system, bundled otherwise), so the generated FFI cannot silently drift from the linked library. If no include directory can be determined, the build script panics with an actionable error rather than guessing `/usr/include`.
+- No version pin is enforced &mdash; you're the power user. The bundled RocksDB version is the trailing component of `librocksdb-sys`'s `version = "X.Y.Z+RR.S.T"` in `Cargo.toml`; make sure your system rocksdb is API-compatible.
+- The `snappy` Cargo feature becomes a no-op: the system librocksdb is expected to provide snappy support itself, so building and linking a second copy would risk duplicate symbols. The build script emits a `cargo::warning=` so the silent skip isn't surprising.
+- The `coroutines` Cargo feature still emits folly link directives, but the build script emits a `cargo::warning=` reminding you that your prebuilt librocksdb must have been built with `USE_COROUTINES=1` and `USE_FOLLY=1` &mdash; otherwise you'll get unresolved-symbol link errors against folly.
+- On FreeBSD the system rocksdb is used unconditionally (the bundled sources don't currently build on FreeBSD). `ROCKSDB_COMPILE=1` is rejected up front with a clear error on FreeBSD targets to avoid a long, doomed C++ compile.
+
+Same set of variables exists for snappy (`SNAPPY_LIB_DIR`, `SNAPPY_STATIC`, `SNAPPY_COMPILE`) if you'd like to swap in a system libsnappy while keeping the bundled rocksdb.
+
+#### Examples
+
+```bash
+# Use distro-installed librocksdb via pkg-config (Debian/Ubuntu: librocksdb-dev)
+ROCKSDB_USE_PKG_CONFIG=1 cargo build
+
+# Manual path; static link
+ROCKSDB_LIB_DIR=/opt/rocksdb/lib \
+ROCKSDB_INCLUDE_DIR=/opt/rocksdb/include \
+ROCKSDB_STATIC=1 \
+  cargo build
+```
+
+#### Downstream `-sys` Integration
+
+Crates that depend on `rust-librocksdb-sys` and want access to its outputs can read these via the `links = "rocksdb"` metadata channel:
+
+| Build env var                     | Source                                                                                                                |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `DEP_ROCKSDB_INCLUDE`             | Path to the RocksDB headers in use. Always a single path; downstream crates needing the full pkg-config set should probe pkg-config themselves. |
+| `DEP_ROCKSDB_ROOT`                | `OUT_DIR` of `rust-librocksdb-sys`.                                                                                   |
+| `DEP_ROCKSDB_LINK_TARGET`         | Name of the linked library (always `rocksdb`). Project-local convenience; equivalently readable from `CARGO_MANIFEST_LINKS`. |
+| `DEP_ROCKSDB_FOLLY_GLOG_LIBDIR`   | glog lib dir (only with `coroutines` feature).                                                                        |
+| `DEP_ROCKSDB_FOLLY_GFLAGS_LIBDIR` | gflags lib dir (only with `coroutines` feature).                                                                      |
+| `DEP_ROCKSDB_CARGO_MANIFEST_DIR`  | *Legacy*. Manifest dir of `rust-librocksdb-sys`. Kept for backwards compatibility; prefer `DEP_ROCKSDB_INCLUDE` for header discovery. |
+| `DEP_ROCKSDB_OUT_DIR`             | *Legacy*. Alias for `DEP_ROCKSDB_ROOT`. Kept for backwards compatibility.                                             |
+
 ## 🤝 Contributing
 
 Feedback and pull requests welcome! Open an issue for feature requests or submit PRs. This fork maintains regular updates with latest RocksDB releases and Rust versions.

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -34,7 +34,7 @@ static = ["libz-sys?/static", "bzip2-sys?/static"]
 bindgen-runtime = ["bindgen/runtime"]
 bindgen-static = ["bindgen/static"]
 mt_static = []
-io-uring = ["pkg-config"]
+io-uring = []
 # Build RocksDB with `USE_COROUTINES=1 USE_FOLLY=1` and link against a folly
 # install. Enables the multi-level parallel `MultiGet` async-IO path described
 # in the RocksDB blog post "Asynchronous IO in RocksDB". Linux only. Requires
@@ -74,5 +74,4 @@ uuid = { version = "1", features = ["v4"] }
 cc = { version = "1.2", features = ["parallel"] }
 bindgen = { version = "0.72", default-features = false }
 glob = "0.3"
-pkg-config = { version = "0.3", optional = true }
-libc = "0.2"
+pkg-config = "0.3"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1,861 +1,1398 @@
-use std::path::Path;
-use std::{env, fs, path::PathBuf, process::Command};
+//! `librocksdb-sys` build script.
+//!
+//! High-level flow:
+//!
+//! 1. Read target info from `CARGO_CFG_*` env vars (typed in [`Target`]).
+//! 2. Pick a [`Backend`] (vendored sources or prebuilt system library)
+//!    based on env vars; see [`Backend::resolve`] for the precedence rules.
+//! 3. Build vendored, or emit the system link directives.
+//! 4. Link the platform runtime libs RocksDB needs regardless of backend
+//!    (Windows rpcrt4/shlwapi, riscv64 libatomic, the C++ stdlib).
+//! 5. Resolve `snappy` the same way if the `snappy` feature is on.
+//! 6. Run `bindgen` against the *chosen* backend's headers so the
+//!    generated FFI cannot drift from the linked library.
+//! 7. Emit `cargo::metadata=` entries for downstream crates.
+//!
+//! See the project README for the full list of environment variables.
+//! Every variable that can influence the build is registered with
+//! `cargo::rerun-if-env-changed=` at the top of [`main`].
 
-#[cfg(target_os = "linux")]
-use libc::{AT_HWCAP, getauxval};
+use std::env;
+use std::path::{Path, PathBuf};
 
-// On these platforms jemalloc-sys will use a prefixed jemalloc which cannot be linked together
-// with RocksDB.
-// See https://github.com/tikv/jemallocator/blob/f7adfca5aff272b43fd3ad896252b57fbbd9c72a/jemalloc-sys/src/env.rs#L24
+// =========================================================================
+// Constants
+// =========================================================================
+
+/// On these platforms `jemalloc-sys` uses a prefixed jemalloc that cannot be
+/// linked together with RocksDB's own usage of jemalloc symbols.
+/// See <https://github.com/tikv/jemallocator/blob/f7adfca5aff272b43fd3ad896252b57fbbd9c72a/jemalloc-sys/src/env.rs#L24>.
 const NO_JEMALLOC_TARGETS: &[&str] = &["android", "dragonfly", "darwin"];
 
-fn link(name: &str, bundled: bool) {
-    use std::env::var;
-    let target = var("TARGET").unwrap();
-    let target: Vec<_> = target.split('-').collect();
-    if target.get(2) == Some(&"windows") {
-        println!("cargo:rustc-link-lib=dylib={name}");
-        if bundled && target.get(3) == Some(&"gnu") {
-            let dir = var("CARGO_MANIFEST_DIR").unwrap();
-            println!("cargo:rustc-link-search=native={}/{}", dir, target[0]);
+/// Default C++ standard used to build RocksDB. Can be overridden with
+/// `ROCKSDB_CXX_STD`.
+const DEFAULT_CXX_STD: &str = "c++20";
+
+// =========================================================================
+// Target info
+// =========================================================================
+
+/// Snapshot of the **target** platform (NOT the host). Always read from
+/// `CARGO_CFG_TARGET_*` env vars, never from `#[cfg(target_os=...)]`
+/// attributes — those reflect the host machine where the build script
+/// runs, which is wrong when cross-compiling.
+struct Target {
+    /// Full target triple, e.g. `x86_64-unknown-linux-gnu`.
+    triple: String,
+    /// e.g. `linux`, `macos`, `windows`, `ios`, `android`, `freebsd`.
+    os: String,
+    /// e.g. `x86_64`, `aarch64`, `riscv64`.
+    arch: String,
+    /// e.g. `gnu`, `musl`, `msvc`, or empty.
+    env_abi: String,
+    /// 32 or 64.
+    pointer_width: u32,
+    /// `little` or `big`.
+    endian: String,
+    /// Target features enabled at build time, e.g. `sse4.2`, `avx2`, `crc`.
+    features: Vec<String>,
+    /// Argument to `-Ctarget-cpu=`, if set in `RUSTFLAGS`.
+    rust_target_cpu: Option<String>,
+}
+
+impl Target {
+    fn from_env() -> Self {
+        let features = env::var("CARGO_CFG_TARGET_FEATURE")
+            .unwrap_or_default()
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(str::to_owned)
+            .collect();
+
+        Self {
+            triple: env::var("TARGET").expect("TARGET is always set by Cargo"),
+            os: env::var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS"),
+            arch: env::var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH"),
+            env_abi: env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default(),
+            pointer_width: env::var("CARGO_CFG_TARGET_POINTER_WIDTH")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(64),
+            endian: env::var("CARGO_CFG_TARGET_ENDIAN").expect("CARGO_CFG_TARGET_ENDIAN"),
+            features,
+            rust_target_cpu: parse_rust_target_cpu(),
+        }
+    }
+
+    fn has_feature(&self, name: &str) -> bool {
+        self.features.iter().any(|f| f == name)
+    }
+
+    fn is_msvc(&self) -> bool {
+        self.env_abi == "msvc"
+    }
+}
+
+/// Parse the argument to `-Ctarget-cpu=` from `CARGO_ENCODED_RUSTFLAGS`,
+/// if present. Encoded RUSTFLAGS are separated by `0x1f` (US).
+fn parse_rust_target_cpu() -> Option<String> {
+    const PREFIX: &str = "-Ctarget-cpu=";
+    let raw = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default();
+    raw.split('\x1f')
+        .find_map(|f| f.strip_prefix(PREFIX).map(str::to_owned))
+}
+
+// =========================================================================
+// Backend resolution
+// =========================================================================
+
+/// Which RocksDB build path was chosen, plus the include director(ies)
+/// that downstream stages (bindgen, downstream crates) should use.
+enum Backend {
+    /// Build RocksDB from the bundled `rocksdb/` submodule sources.
+    Vendored { include: PathBuf },
+    /// Link against an already-built RocksDB. The build script has already
+    /// emitted the `cargo::rustc-link-*` directives; `includes` is the set
+    /// of header directories for bindgen to scan. Empty means we couldn't
+    /// determine one — [`bindings::generate`] panics with a helpful error
+    /// in that case rather than silently misbinding.
+    System { includes: Vec<PathBuf> },
+}
+
+impl Backend {
+    /// Decide the backend and emit any needed link directives for the
+    /// system path. Vendored compilation is deferred to [`vendor::build`].
+    fn resolve(target: &Target) -> Self {
+        // Highest priority: explicit "force compile" override. FreeBSD
+        // can't build RocksDB from these submodule sources, so the
+        // combination is rejected up front rather than failing midway
+        // through a long C++ compile.
+        if env_truthy("ROCKSDB_COMPILE") {
+            if target.os == "freebsd" {
+                panic!(
+                    "ROCKSDB_COMPILE=1 is not supported on FreeBSD: the \
+                     bundled RocksDB sources don't build on FreeBSD. \
+                     Unset ROCKSDB_COMPILE and let the build script link \
+                     against the system RocksDB (install via `pkg install \
+                     rocksdb`)."
+                );
+            }
+            return Backend::Vendored {
+                include: vendored_include(),
+            };
+        }
+
+        // Opt-in pkg-config probe.
+        if env_truthy("ROCKSDB_USE_PKG_CONFIG") {
+            return system::probe_pkg_config();
+        }
+
+        // Explicit lib-dir override.
+        if env::var_os("ROCKSDB_LIB_DIR").is_some() {
+            return system::from_lib_dir_env();
+        }
+
+        // FreeBSD historically can't build RocksDB from these submodule
+        // sources (see PR #908). Fall through to the system library at the
+        // platform's conventional location.
+        if target.os == "freebsd" {
+            return system::from_freebsd_defaults();
+        }
+
+        // Default: build vendored.
+        Backend::Vendored {
+            include: vendored_include(),
+        }
+    }
+
+    /// All include directories for this backend. Bindgen passes each as
+    /// `-I<path>` so headers split across multiple roots (rare but happens
+    /// with chained pkg-config deps) are all visible. Downstream metadata
+    /// emission (`emit_metadata`) takes the first one as the canonical
+    /// `DEP_ROCKSDB_INCLUDE` path.
+    ///
+    /// Empty slice means the backend couldn't determine a header location;
+    /// `bindings::generate` is responsible for panicking with an
+    /// actionable error in that case.
+    fn all_includes(&self) -> &[PathBuf] {
+        match self {
+            Backend::Vendored { include } => std::slice::from_ref(include),
+            Backend::System { includes } => includes,
         }
     }
 }
 
-fn fail_on_empty_directory(name: &str) {
-    if fs::read_dir(name).unwrap().count() == 0 {
-        println!("The `{name}` directory is empty, did you forget to pull the submodules?");
-        println!("Try `git submodule update --init --recursive`");
-        panic!();
-    }
-}
+// =========================================================================
+// Main
+// =========================================================================
 
-fn rocksdb_include_dir() -> String {
-    match env::var("ROCKSDB_INCLUDE_DIR") {
-        Ok(val) => val,
-        Err(_) => "rocksdb/include".to_string(),
-    }
-}
+fn main() {
+    rerun_if_env_changed(&[
+        // RocksDB
+        "ROCKSDB_COMPILE",
+        "ROCKSDB_LIB_DIR",
+        "ROCKSDB_STATIC",
+        "ROCKSDB_INCLUDE_DIR",
+        "ROCKSDB_USE_PKG_CONFIG",
+        "ROCKSDB_CXX_STD",
+        // Snappy
+        "SNAPPY_COMPILE",
+        "SNAPPY_LIB_DIR",
+        "SNAPPY_STATIC",
+        // Compiler
+        "CC",
+        "CXX",
+        "CFLAGS",
+        "CXXFLAGS",
+        "CXXSTDLIB",
+        "CARGO_ENCODED_RUSTFLAGS",
+        // Bindgen
+        "BINDGEN_EXTRA_CLANG_ARGS",
+        // pkg-config
+        "PKG_CONFIG_PATH",
+        "PKG_CONFIG_LIBDIR",
+        "PKG_CONFIG_ALL_STATIC",
+        "PKG_CONFIG_ALLOW_CROSS",
+        "PKG_CONFIG_SYSROOT_DIR",
+        // Compression-sys upstream metadata. These are set by cargo via the
+        // `links` mechanism, but cargo does NOT automatically register them
+        // for rerun tracking — we must do that ourselves or the build will
+        // silently use stale paths after an upstream sys-crate bumps.
+        "DEP_LZ4_INCLUDE",
+        "DEP_ZSTD_INCLUDE",
+        "DEP_Z_INCLUDE",
+        "DEP_BZIP2_INCLUDE",
+        "DEP_JEMALLOC_ROOT",
+        // coroutines
+        "ROCKSDB_FOLLY_INSTALL_PATH",
+    ]);
 
-fn bindgen_rocksdb() {
-    let bindings = bindgen::Builder::default()
-        .header(rocksdb_include_dir() + "/rocksdb/c.h")
-        .derive_debug(false)
-        .blocklist_type("max_align_t") // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
-        .ctypes_prefix("libc")
-        .size_t_is_usize(true)
-        .generate()
-        .expect("unable to generate rocksdb bindings");
+    let target = Target::from_env();
 
-    let out_path = PathBuf::from(env::var("OUT_DIR").unwrap());
-    bindings
-        .write_to_file(out_path.join("bindings.rs"))
-        .expect("unable to write rocksdb bindings");
-}
+    #[cfg(feature = "coroutines")]
+    coroutines::validate_target(&target);
 
-#[cfg(target_os = "linux")]
-fn check_getauxval_supported() -> bool {
-    unsafe {
-        let aux_value = getauxval(AT_HWCAP);
-        if aux_value == 0 {
-            return false;
+    let backend = Backend::resolve(&target);
+
+    match &backend {
+        Backend::Vendored { .. } => {
+            println!("cargo::rerun-if-changed=rocksdb/");
+            ensure_submodule_present("rocksdb");
+            vendor::build(&target);
         }
-
-        true
-    }
-}
-
-/// Splits `CARGO_ENCODED_RUSTFLAGS` into a Vec.
-fn split_encoded_rustflags() -> Vec<String> {
-    let flags = std::env::var("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default();
-
-    // extra flags that Cargo invokes rustc with, separated by a 0x1f character
-    // https://doc.rust-lang.org/cargo/reference/environment-variables.html#environment-variables-cargo-sets-for-crates
-    flags.split("\x1f").map(|flag| flag.to_string()).collect()
-}
-
-/// Returns the argument to `-Ctarget-cpu=` if it exists.
-fn get_target_cpu_flag() -> Option<String> {
-    const TARGET_CPU_FLAG: &str = "-Ctarget-cpu=";
-    let flags = split_encoded_rustflags();
-    let complete_flag = flags.iter().find(|flag| flag.starts_with(TARGET_CPU_FLAG));
-    complete_flag.map(|flag| flag[TARGET_CPU_FLAG.len()..].to_string())
-}
-
-/// If the Rust `-Ctarget-cpu=` option is set, this attempts to pass it through to the C/C++
-/// compiler. It should print a Cargo build warning if the compiler does not support the flag,
-/// or if the architecture is not supported.
-fn pass_through_target_cpu(cfg: &mut cc::Build) {
-    let Some(target_cpu_flag) = get_target_cpu_flag() else {
-        return;
-    };
-
-    let arch = std::env::var("CARGO_CFG_TARGET_ARCH").unwrap_or_default();
-    match arch.as_str() {
-        "x86_64" => {
-            cfg.flag_if_supported(format!("-march={target_cpu_flag}"));
-        }
-        "aarch64" => {
-            cfg.flag_if_supported(format!("-mcpu={target_cpu_flag}"));
-        }
-        // TODO: add more architectures/compilers
-        _ => {
-            println!(
-                "cargo::warning=unknown target architecture: {arch}; C/C++ target flags not passed through"
-            );
+        Backend::System { .. } => {
+            // Link directives already emitted by `Backend::resolve`.
+            // We still need to link the C++ stdlib explicitly because
+            // there's no `cc::Build` to do it for us.
+            cpp_link_stdlib(&target);
         }
     }
-}
 
-fn build_rocksdb() {
-    // https://doc.rust-lang.org/cargo/reference/environment-variables.html
-    let target = env::var("TARGET").unwrap();
-    // https://doc.rust-lang.org/reference/conditional-compilation.html#target_arch
-    let target_arch = env::var("CARGO_CFG_TARGET_ARCH").unwrap();
-    let target_features_env = env::var("CARGO_CFG_TARGET_FEATURE").unwrap_or_default();
-    let target_features: Vec<_> = target_features_env.split(',').collect();
+    // Platform runtime libs needed regardless of backend.
+    apply_platform_runtime_libs(&target);
 
-    let mut config = cc::Build::new();
-    config.include("rocksdb/include/");
-    config.include("rocksdb/");
-    config.include("rocksdb/third-party/gtest-1.8.1/fused-src/");
+    #[cfg(feature = "coroutines")]
+    {
+        coroutines::warn_if_system_backend(&backend);
+        coroutines::link();
+    }
 
     if cfg!(feature = "snappy") {
-        config.define("SNAPPY", Some("1"));
-        config.include("snappy/");
+        snappy::ensure(&target, &backend);
     }
 
-    if cfg!(feature = "lz4") {
-        config.define("LZ4", Some("1"));
-        if let Some(path) = env::var_os("DEP_LZ4_INCLUDE") {
-            config.include(path);
+    bindings::generate(&backend);
+
+    emit_metadata(&backend);
+}
+
+/// Link platform-specific runtime libs that RocksDB needs whether built
+/// vendored or linked from the system.
+fn apply_platform_runtime_libs(target: &Target) {
+    if target.os == "windows" {
+        // RocksDB's port_win uses RPC + path-string APIs.
+        println!("cargo::rustc-link-lib=dylib=rpcrt4");
+        println!("cargo::rustc-link-lib=dylib=shlwapi");
+    }
+
+    // riscv64 needs libatomic for some 64-bit atomic ops on this arch.
+    if target.arch == "riscv64" {
+        println!("cargo::rustc-link-lib=atomic");
+    }
+}
+
+/// Emit the platform-appropriate C++ standard library link. Called on
+/// the system-link path; the vendored path lets `cc::Build` link the C++
+/// stdlib automatically as part of `compile()`.
+fn cpp_link_stdlib(target: &Target) {
+    if let Ok(stdlib) = env::var("CXXSTDLIB") {
+        if !stdlib.is_empty() {
+            println!("cargo::rustc-link-lib=dylib={stdlib}");
+        }
+        return;
+    }
+    match target.os.as_str() {
+        // Apple platforms, the BSDs, and Android (NDK r18+, 2018) all
+        // default to libc++.
+        "macos" | "ios" | "tvos" | "watchos" | "freebsd" | "openbsd" | "android" => {
+            println!("cargo::rustc-link-lib=dylib=c++");
+        }
+        "aix" => {
+            println!("cargo::rustc-link-lib=dylib=c++");
+            println!("cargo::rustc-link-lib=dylib=c++abi");
+        }
+        "linux" | "netbsd" | "dragonfly" => {
+            println!("cargo::rustc-link-lib=dylib=stdc++");
+        }
+        // Windows-MSVC links the CRT automatically.
+        _ => {}
+    }
+}
+
+/// Emit `cargo::metadata=` entries for downstream build scripts.
+///
+/// Cargo's `links = "rocksdb"` mechanism re-exposes each `KEY=VALUE`
+/// emitted here to dependent crates as `DEP_ROCKSDB_<KEY>=VALUE`.
+///
+/// Keys emitted (mirroring `libz-sys`, `openssl-sys`, etc. where there
+/// is a shared convention):
+///
+/// - `include` — path to the RocksDB headers. A single path, even when
+///   bindgen sees multiple via pkg-config; downstream crates needing
+///   the full set should probe pkg-config themselves.
+/// - `root` — `OUT_DIR` of this crate.
+/// - `link-target` — name of the linked library (always `rocksdb`).
+///   Project-local key; equivalently readable as `CARGO_MANIFEST_LINKS`.
+/// - `cargo_manifest_dir` — manifest dir of this crate.
+/// - `out_dir` — alias for `root`.
+fn emit_metadata(backend: &Backend) {
+    if let Some(inc) = backend.all_includes().first() {
+        println!("cargo::metadata=include={}", inc.display());
+    }
+    println!("cargo::metadata=root={}", out_dir().display());
+    println!("cargo::metadata=link-target=rocksdb");
+    println!(
+        "cargo::metadata=cargo_manifest_dir={}",
+        manifest_dir().display()
+    );
+    println!("cargo::metadata=out_dir={}", out_dir().display());
+}
+
+// =========================================================================
+// Vendored build
+// =========================================================================
+
+mod vendor {
+    use super::*;
+
+    /// Compile RocksDB from the bundled submodule sources.
+    pub(super) fn build(target: &Target) {
+        let mut cfg = base_cfg(target);
+
+        apply_compression_features(&mut cfg);
+        apply_optional_features(&mut cfg, target);
+        apply_jemalloc(&mut cfg, target);
+        apply_target_cpu(&mut cfg, target);
+        apply_target_arch(&mut cfg, target);
+        let layout = apply_target_os(&mut cfg, target);
+        apply_lfs_defines(&mut cfg, target, layout);
+        apply_io_uring(&mut cfg, target);
+
+        #[cfg(feature = "coroutines")]
+        super::coroutines::apply_compile_config(&mut cfg);
+
+        for src in collect_sources(target, layout) {
+            cfg.file(format!("rocksdb/{src}"));
+        }
+        cfg.file("build_version.cc");
+
+        if !target.is_msvc() {
+            // Force-include <cstdint>. Some translation units use uintN_t
+            // through transitive includes that break under stricter GCC
+            // versions (e.g. GCC 15 hides them by default).
+            cfg.flag("-include").flag("cstdint");
+        }
+
+        cfg.cpp(true);
+        cfg.compile("librocksdb.a");
+    }
+
+    /// Base `cc::Build` with the always-on flags, defines, includes, and
+    /// warning settings.
+    fn base_cfg(target: &Target) -> cc::Build {
+        let mut cfg = cc::Build::new();
+
+        cfg.include("rocksdb/include/")
+            .include("rocksdb/")
+            .include("rocksdb/third-party/gtest-1.8.1/fused-src/")
+            .include(".");
+
+        cfg.define("NDEBUG", Some("1"));
+        // True for C++ >= 17. We set `-std=c++20` below.
+        cfg.define("HAVE_ALIGNED_NEW", None);
+        // __uint128_t is supported by GCC and Clang; not MSVC.
+        if !target.is_msvc() {
+            cfg.define("HAVE_UINT128_EXTENSION", None);
+        }
+
+        if target.is_msvc() {
+            if cfg!(feature = "mt_static") {
+                cfg.static_crt(true);
+            }
+            cfg.flag("-EHsc");
+            // MSVC uses `-std:c++20`, not `-std=c++20`.
+            cfg.flag("-std:c++20");
+        } else {
+            cfg.flag(cxx_standard());
+            // Mirrors RocksDB's CMakeLists.txt warning flags.
+            for f in [
+                "-Wsign-compare",
+                "-Wshadow",
+                "-Wno-unused-parameter",
+                "-Wno-unused-variable",
+                "-Woverloaded-virtual",
+                "-Wnon-virtual-dtor",
+                "-Wno-missing-field-initializers",
+                "-Wno-strict-aliasing",
+                "-Wno-invalid-offsetof",
+            ] {
+                cfg.flag(f);
+            }
+        }
+
+        // LTO: gated on the `lto` feature. RocksDB's Makefile only
+        // supports clang-LTO; bail if the user's CC isn't clang.
+        if cfg!(feature = "lto") {
+            cfg.flag("-flto");
+            if !cfg.get_compiler().is_like_clang() {
+                panic!(
+                    "the `lto` feature requires Clang; set \
+                     `CC=/usr/bin/clang CXX=/usr/bin/clang++` or disable the feature"
+                );
+            }
+        }
+
+        cfg
+    }
+
+    /// Compression-format defines + include path injection. Each external
+    /// compression library is its own `-sys` crate that exports
+    /// `DEP_<NAME>_INCLUDE` for us via cargo `links` metadata.
+    fn apply_compression_features(cfg: &mut cc::Build) {
+        // snappy is special — we vendor it in this crate.
+        if cfg!(feature = "snappy") {
+            cfg.define("SNAPPY", Some("1"));
+            cfg.include("snappy/");
+        }
+
+        // (enabled, rocksdb_define, dep_env_var)
+        let externals: &[(bool, &str, &str)] = &[
+            (cfg!(feature = "lz4"), "LZ4", "DEP_LZ4_INCLUDE"),
+            (cfg!(feature = "zstd"), "ZSTD", "DEP_ZSTD_INCLUDE"),
+            (cfg!(feature = "zlib"), "ZLIB", "DEP_Z_INCLUDE"),
+            (cfg!(feature = "bzip2"), "BZIP2", "DEP_BZIP2_INCLUDE"),
+        ];
+        for (enabled, define, dep_var) in externals {
+            if !*enabled {
+                continue;
+            }
+            cfg.define(define, Some("1"));
+            if let Some(p) = env::var_os(dep_var) {
+                cfg.include(p);
+            }
+        }
+
+        if cfg!(feature = "zstd") && cfg!(feature = "zstd-static-linking-only") {
+            cfg.define("ZSTD_STATIC_LINKING_ONLY", Some("1"));
         }
     }
 
-    if cfg!(feature = "zstd") {
-        config.define("ZSTD", Some("1"));
-        if let Some(path) = env::var_os("DEP_ZSTD_INCLUDE") {
-            config.include(path);
+    /// Other Cargo features that translate into preprocessor defines.
+    fn apply_optional_features(cfg: &mut cc::Build, target: &Target) {
+        if cfg!(feature = "rtti") {
+            cfg.define("USE_RTTI", Some("1"));
         }
-
-        if cfg!(feature = "zstd-static-linking-only") {
-            config.define("ZSTD_STATIC_LINKING_ONLY", Some("1"));
-        }
-    }
-
-    if cfg!(feature = "zlib") {
-        config.define("ZLIB", Some("1"));
-        if let Some(path) = env::var_os("DEP_Z_INCLUDE") {
-            config.include(path);
+        if cfg!(feature = "malloc-usable-size") && target.os == "linux" {
+            cfg.define("ROCKSDB_MALLOC_USABLE_SIZE", Some("1"));
         }
     }
 
-    if cfg!(feature = "bzip2") {
-        config.define("BZIP2", Some("1"));
-        if let Some(path) = env::var_os("DEP_BZIP2_INCLUDE") {
-            config.include(path);
+    /// Pass `-Ctarget-cpu=...` through to the C/C++ compiler as `-march=` /
+    /// `-mcpu=` so the C++ side benefits from the same CPU baseline.
+    fn apply_target_cpu(cfg: &mut cc::Build, target: &Target) {
+        let Some(cpu) = &target.rust_target_cpu else {
+            return;
+        };
+        match target.arch.as_str() {
+            "x86_64" | "x86" => {
+                cfg.flag_if_supported(format!("-march={cpu}"));
+            }
+            "aarch64" | "arm" => {
+                cfg.flag_if_supported(format!("-mcpu={cpu}"));
+            }
+            other => {
+                println!(
+                    "cargo::warning=unknown target architecture: \
+                     {other}; C/C++ target-cpu flag not passed through"
+                );
+            }
         }
     }
 
-    if cfg!(feature = "rtti") {
-        config.define("USE_RTTI", Some("1"));
-    }
-
-    #[cfg(feature = "malloc-usable-size")]
-    if target.contains("linux") {
-        config.define("ROCKSDB_MALLOC_USABLE_SIZE", Some("1"));
-    }
-
-    // https://github.com/facebook/rocksdb/blob/be7703b27d9b3ac458641aaadf27042d86f6869c/Makefile#L195
-    if cfg!(feature = "lto") {
-        config.flag("-flto");
-        if !config.get_compiler().is_like_clang() {
-            panic!(
-                "LTO is only supported with clang. Either disable the `lto` feature\
-             or set `CC=/usr/bin/clang CXX=/usr/bin/clang++` environment variables."
-            );
+    /// CPU-feature flags driven by `CARGO_CFG_TARGET_FEATURE`. RocksDB uses
+    /// these to enable hardware-accelerated CRC32C and other intrinsics.
+    fn apply_target_arch(cfg: &mut cc::Build, target: &Target) {
+        match target.arch.as_str() {
+            "x86_64" | "x86" => apply_x86(cfg, target),
+            "aarch64" => apply_aarch64(cfg, target),
+            _ => {}
         }
     }
 
-    config.include(".");
-    config.define("NDEBUG", Some("1"));
-
-    // true for C++ >= 17; we set -std=c++20 below
-    config.define("HAVE_ALIGNED_NEW", None);
-
-    // __uint128_t is supported by GCC and Clang; Don't use it for MSVC
-    // TODO: implement a detection script?
-    if !target.contains("msvc") {
-        config.define("HAVE_UINT128_EXTENSION", None);
-    }
-
-    let mut lib_sources = include_str!("rocksdb_lib_sources.txt")
-        .trim()
-        .split('\n')
-        .map(str::trim)
-        // We have a pre-generated a version of build_version.cc in the local directory
-        .filter(|file| !matches!(*file, "util/build_version.cc"))
-        .collect::<Vec<&'static str>>();
-
-    // attempt to pass through the RUSTFLAGS -Ctarget-cpu to allow the same optimizations for C/C++
-    pass_through_target_cpu(&mut config);
-
-    // CPU-specific build configuration
-    if target_arch == "x86_64" {
-        // This is needed to enable hardware CRC32C. Technically, SSE 4.2 is
-        // only available since Intel Nehalem (about 2010) and AMD Bulldozer
-        // (about 2011).
-        if target_features.contains(&"sse2") {
-            config.flag_if_supported("-msse2");
+    fn apply_x86(cfg: &mut cc::Build, target: &Target) {
+        // SSE4.2 enables hardware CRC32C (Intel Nehalem+ / AMD Bulldozer+).
+        if target.has_feature("sse2") {
+            cfg.flag_if_supported("-msse2");
         }
-        if target_features.contains(&"sse4.1") {
-            config.flag_if_supported("-msse4.1");
+        if target.has_feature("sse4.1") {
+            cfg.flag_if_supported("-msse4.1");
         }
-        if target_features.contains(&"sse4.2") {
-            config.flag_if_supported("-msse4.2");
+        if target.has_feature("sse4.2") {
+            cfg.flag_if_supported("-msse4.2");
         } else {
             println!(
                 r#"cargo::warning=compiling without SSE4.2: CRC will be slow (set RUSTFLAGS="-Ctarget-cpu=..." to optimize RocksDB e.g. -Ctarget-cpu=broadwell)"#
             );
         }
-        // Pass along additional target features as defined in
-        // build_tools/build_detect_platform.
-        if target_features.contains(&"avx2") {
-            config.flag_if_supported("-mavx2");
+        if target.has_feature("avx2") {
+            cfg.flag_if_supported("-mavx2");
         }
-        if target_features.contains(&"bmi1") {
-            config.flag_if_supported("-mbmi");
+        if target.has_feature("bmi1") {
+            cfg.flag_if_supported("-mbmi");
         }
-        if target_features.contains(&"lzcnt") {
-            config.flag_if_supported("-mlzcnt");
+        if target.has_feature("lzcnt") {
+            cfg.flag_if_supported("-mlzcnt");
         }
-
-        if !target.contains("android") && target_features.contains(&"pclmulqdq") {
-            config.flag_if_supported("-mpclmul");
+        // Android targets don't define __PCLMUL__ even with the feature.
+        if target.os != "android" && target.has_feature("pclmulqdq") {
+            cfg.flag_if_supported("-mpclmul");
         }
-
-        if target_features.contains(&"avx") && !target_features.contains(&"pclmulqdq") {
-            // RocksDB BUG (<= 10.11.0/2026-01-23): assumes AVX implies -mpclmul
-            // x86-64-v3/-v4 does not include PCLMUL
+        // RocksDB <= 10.11.0 assumes AVX implies PCLMUL, which isn't true
+        // for x86-64-v3/-v4. Warn so the user knows the build may fail.
+        if target.has_feature("avx") && !target.has_feature("pclmulqdq") {
             println!(
-                r#"cargo:warning=RocksDB BUG: target arch missing -mpclmul; compile may fail: pass named architecture e.g. -Ctarget-cpu=broadwell"#
+                r#"cargo::warning=RocksDB BUG: target arch missing -mpclmul; compile may fail: pass a named architecture e.g. -Ctarget-cpu=broadwell"#
             );
         }
-    } else if target_arch == "aarch64" {
-        if target_features.contains(&"crc") && target_features.contains(&"aes") {
-            // the target supports the instructions RocksDB needs: if we don't have a target-cpu,
-            // use -march=armv8-a+crc+aes+crypto, like the RocksDB Makefile.
-            // If we DO have a target-cpu, assume pass_through_target_cpu() has set it above
-            if get_target_cpu_flag().is_none() {
-                // TODO: Should just be +crc+aes but RocksDB checks for __ARM_FEATURE_CRYPTO
-                // https://github.com/facebook/rocksdb/pull/14217
-                config.flag_if_supported("-march=armv8-a+crc+aes+crypto");
+    }
+
+    fn apply_aarch64(cfg: &mut cc::Build, target: &Target) {
+        if target.has_feature("crc") && target.has_feature("aes") {
+            // If no -Ctarget-cpu was provided, set an explicit baseline
+            // that includes the crypto extensions RocksDB checks for via
+            // __ARM_FEATURE_CRYPTO. See facebook/rocksdb#14217.
+            if target.rust_target_cpu.is_none() {
+                cfg.flag_if_supported("-march=armv8-a+crc+aes+crypto");
             }
         } else {
             println!(
-                r#"cargo:warning=building for aarch64 WITHOUT CRC instruction: build with RUSTFLAGS="-Ctarget-cpu=..." to optimize RocksDB e.g. -Ctarget-cpu=neoverse-n1"#
+                r#"cargo::warning=building for aarch64 WITHOUT CRC instruction: build with RUSTFLAGS="-Ctarget-cpu=..." to optimize RocksDB e.g. -Ctarget-cpu=neoverse-n1"#
             );
         }
     }
 
-    if target.contains("apple-ios") {
-        config.define("OS_MACOSX", None);
+    /// What source-file filter to apply when collecting RocksDB sources.
+    /// Non-Windows targets use POSIX implementations; Windows swaps in its
+    /// own `port/win/` set.
+    #[derive(Copy, Clone)]
+    enum SourceLayout {
+        Posix,
+        Windows,
+    }
 
-        config.define("IOS_CROSS_COMPILE", None);
-        config.define("PLATFORM", "IOS");
-        config.define("NIOSTATS_CONTEXT", None);
-        config.define("NPERF_CONTEXT", None);
-        config.define("ROCKSDB_PLATFORM_POSIX", None);
-        config.define("ROCKSDB_LIB_IO_POSIX", None);
+    /// All POSIX-ish targets share these two defines.
+    fn define_posix(cfg: &mut cc::Build) {
+        cfg.define("ROCKSDB_PLATFORM_POSIX", None);
+        cfg.define("ROCKSDB_LIB_IO_POSIX", None);
+    }
 
-        // SAFETY: This is the build script, which is single-threaded and runs
-        // before any other code. Setting environment variables here is safe.
-        unsafe { env::set_var("IPHONEOS_DEPLOYMENT_TARGET", "12.0") };
-    } else if target.contains("darwin") {
-        config.define("OS_MACOSX", None);
-        config.define("ROCKSDB_PLATFORM_POSIX", None);
-        config.define("ROCKSDB_LIB_IO_POSIX", None);
-    } else if target.contains("android") {
-        config.define("OS_ANDROID", None);
-        config.define("ROCKSDB_PLATFORM_POSIX", None);
-        config.define("ROCKSDB_LIB_IO_POSIX", None);
+    /// Plain `OS_<NAME>` mapping for the BSDs and AIX, all of which need
+    /// nothing beyond `define_posix()` + their own OS marker.
+    const PLAIN_POSIX_OS: &[(&str, &str)] = &[
+        ("freebsd", "OS_FREEBSD"),
+        ("dragonfly", "OS_DRAGONFLYBSD"),
+        ("netbsd", "OS_NETBSD"),
+        ("openbsd", "OS_OPENBSD"),
+        ("aix", "OS_AIX"),
+    ];
 
-        if &target == "armv7-linux-androideabi" {
-            config.define("_FILE_OFFSET_BITS", Some("32"));
-        }
-    } else if target.contains("aix") {
-        config.define("OS_AIX", None);
-        config.define("ROCKSDB_PLATFORM_POSIX", None);
-        config.define("ROCKSDB_LIB_IO_POSIX", None);
-    } else if target.contains("linux") {
-        config.define("OS_LINUX", None);
-        config.define("ROCKSDB_PLATFORM_POSIX", None);
-        config.define("ROCKSDB_LIB_IO_POSIX", None);
-        config.define("ROCKSDB_SCHED_GETCPU_PRESENT", None);
-
-        #[cfg(target_os = "linux")]
-        if check_getauxval_supported() {
-            config.define("ROCKSDB_AUXV_GETAUXVAL_PRESENT", None);
-        }
-        config.define("ROCKSDB_FALLOCATE_PRESENT", None);
-        config.define("ROCKSDB_RANGESYNC_PRESENT", None);
-    } else if target.contains("dragonfly") {
-        config.define("OS_DRAGONFLYBSD", None);
-        config.define("ROCKSDB_PLATFORM_POSIX", None);
-        config.define("ROCKSDB_LIB_IO_POSIX", None);
-    } else if target.contains("freebsd") {
-        config.define("OS_FREEBSD", None);
-        config.define("ROCKSDB_PLATFORM_POSIX", None);
-        config.define("ROCKSDB_LIB_IO_POSIX", None);
-    } else if target.contains("netbsd") {
-        config.define("OS_NETBSD", None);
-        config.define("ROCKSDB_PLATFORM_POSIX", None);
-        config.define("ROCKSDB_LIB_IO_POSIX", None);
-    } else if target.contains("openbsd") {
-        config.define("OS_OPENBSD", None);
-        config.define("ROCKSDB_PLATFORM_POSIX", None);
-        config.define("ROCKSDB_LIB_IO_POSIX", None);
-    } else if target.contains("windows") {
-        link("rpcrt4", false);
-        link("shlwapi", false);
-        config.define("DWIN32", None);
-        config.define("OS_WIN", None);
-        config.define("_MBCS", None);
-        config.define("WIN64", None);
-        config.define("NOMINMAX", None);
-        config.define("ROCKSDB_WINDOWS_UTF8_FILENAMES", None);
-
-        if &target == "x86_64-pc-windows-gnu" {
-            // Tell MinGW to create localtime_r wrapper of localtime_s function.
-            config.define("_POSIX_C_SOURCE", Some("1"));
-            // Tell MinGW to use at least Windows Vista headers instead of the ones of Windows XP.
-            // (This is minimum supported version of rocksdb)
-            config.define("_WIN32_WINNT", Some("_WIN32_WINNT_VISTA"));
+    /// Apply target-OS specific defines. Returns the source layout to use.
+    fn apply_target_os(cfg: &mut cc::Build, target: &Target) -> SourceLayout {
+        if let Some((_, marker)) = PLAIN_POSIX_OS.iter().find(|(os, _)| *os == target.os) {
+            cfg.define(marker, None);
+            define_posix(cfg);
+            return SourceLayout::Posix;
         }
 
-        // Remove POSIX-specific sources
-        lib_sources = lib_sources
-            .iter()
-            .cloned()
-            .filter(|file| {
-                !matches!(
-                    *file,
-                    "port/port_posix.cc"
-                        | "env/env_posix.cc"
-                        | "env/fs_posix.cc"
-                        | "env/io_posix.cc"
-                )
-            })
-            .collect::<Vec<&'static str>>();
-
-        // Add Windows-specific sources
-        lib_sources.extend([
-            "port/win/env_default.cc",
-            "port/win/port_win.cc",
-            "port/win/xpress_win.cc",
-            "port/win/io_win.cc",
-            "port/win/win_thread.cc",
-            "port/win/env_win.cc",
-            "port/win/win_logger.cc",
-        ]);
-
-        if cfg!(feature = "jemalloc") {
-            lib_sources.push("port/win/win_jemalloc.cc");
+        match target.os.as_str() {
+            "ios" | "tvos" | "watchos" => {
+                cfg.define("OS_MACOSX", None);
+                cfg.define("IOS_CROSS_COMPILE", None);
+                cfg.define("PLATFORM", "IOS");
+                cfg.define("NIOSTATS_CONTEXT", None);
+                cfg.define("NPERF_CONTEXT", None);
+                define_posix(cfg);
+                // Enable RocksDB's fcntl(F_FULLFSYNC) path for true on-
+                // disk durability. F_FULLFSYNC is Apple-specific and is
+                // available on all supported macOS / iOS / tvOS / watchOS
+                // versions. RocksDB's CMakeLists.txt detects it via
+                // check_cxx_symbol_exists; we hardcode it for Apple
+                // targets since the constant is universally available.
+                cfg.define("HAVE_FULLFSYNC", None);
+                // Pin the iOS deployment target via compiler flag rather
+                // than mutating process env (which Rust 2024 marks unsafe).
+                // Only emit for actual iOS — tvos/watchos use their own
+                // version-min flags and we don't pin those here, letting
+                // cc-rs's SDK detection drive the default. Use `flag()`
+                // (not `flag_if_supported`) so a non-Apple Clang fails
+                // loudly rather than silently dropping the pin.
+                if target.os == "ios" {
+                    cfg.flag("-mios-version-min=12.0");
+                }
+                SourceLayout::Posix
+            }
+            "macos" => {
+                cfg.define("OS_MACOSX", None);
+                define_posix(cfg);
+                // Enable true on-disk durability via fcntl(F_FULLFSYNC).
+                // See the iOS arm above for rationale.
+                cfg.define("HAVE_FULLFSYNC", None);
+                SourceLayout::Posix
+            }
+            "android" => {
+                cfg.define("OS_ANDROID", None);
+                define_posix(cfg);
+                if target.triple == "armv7-linux-androideabi" {
+                    cfg.define("_FILE_OFFSET_BITS", Some("32"));
+                }
+                SourceLayout::Posix
+            }
+            "linux" => {
+                cfg.define("OS_LINUX", None);
+                define_posix(cfg);
+                // getauxval has been in glibc since 2.16 (2012) and musl
+                // since 1.1.0 (2014); both predate our MSRV ecosystem.
+                for d in [
+                    "ROCKSDB_SCHED_GETCPU_PRESENT",
+                    "ROCKSDB_AUXV_GETAUXVAL_PRESENT",
+                    "ROCKSDB_FALLOCATE_PRESENT",
+                    "ROCKSDB_RANGESYNC_PRESENT",
+                ] {
+                    cfg.define(d, None);
+                }
+                SourceLayout::Posix
+            }
+            "windows" => {
+                // Mirrors RocksDB's CMakeLists.txt Windows branch:
+                //   add_definitions(-DWIN32 -DOS_WIN -D_MBCS -DWIN64 -DNOMINMAX)
+                for d in [
+                    "WIN32",
+                    "OS_WIN",
+                    "_MBCS",
+                    "WIN64",
+                    "NOMINMAX",
+                    "ROCKSDB_WINDOWS_UTF8_FILENAMES",
+                ] {
+                    cfg.define(d, None);
+                }
+                if target.triple == "x86_64-pc-windows-gnu" {
+                    // MinGW needs localtime_r and Vista+ headers.
+                    cfg.define("_POSIX_C_SOURCE", Some("1"));
+                    cfg.define("_WIN32_WINNT", Some("_WIN32_WINNT_VISTA"));
+                }
+                SourceLayout::Windows
+            }
+            other => {
+                println!(
+                    "cargo::warning=unknown target OS `{other}`; \
+                     building with default POSIX configuration"
+                );
+                define_posix(cfg);
+                SourceLayout::Posix
+            }
         }
     }
 
-    if cfg!(feature = "jemalloc") && NO_JEMALLOC_TARGETS.iter().all(|i| !target.contains(i)) {
-        config.define("ROCKSDB_JEMALLOC", Some("1"));
-        config.define("JEMALLOC_NO_DEMANGLE", Some("1"));
-        if let Some(jemalloc_root) = env::var_os("DEP_JEMALLOC_ROOT") {
-            config.include(Path::new(&jemalloc_root).join("include"));
-        }
-    }
-
-    #[cfg(feature = "io-uring")]
-    if target.contains("linux") {
-        pkg_config::probe_library("liburing")
-            .expect("The io-uring feature was requested but the library is not available");
-        config.define("ROCKSDB_IOURING_PRESENT", Some("1"));
-    }
-
-    #[cfg(feature = "coroutines")]
-    coroutines_compile_config(&mut config, &target);
-
-    if &target != "armv7-linux-androideabi"
-        && env::var("CARGO_CFG_TARGET_POINTER_WIDTH").unwrap() != "64"
-    {
-        config.define("_FILE_OFFSET_BITS", Some("64"));
-        config.define("_LARGEFILE64_SOURCE", Some("1"));
-    }
-
-    if target.contains("msvc") {
-        if cfg!(feature = "mt_static") {
-            config.static_crt(true);
-        }
-        config.flag("-EHsc");
-        // Don't use cxx_standard: Uses : instead of =
-        config.flag("-std:c++20");
-    } else {
-        config.flag(cxx_standard());
-        // matches the flags in CMakeLists.txt from rocksdb
-        config.flag("-Wsign-compare");
-        config.flag("-Wshadow");
-        config.flag("-Wno-unused-parameter");
-        config.flag("-Wno-unused-variable");
-        config.flag("-Woverloaded-virtual");
-        config.flag("-Wnon-virtual-dtor");
-        config.flag("-Wno-missing-field-initializers");
-        config.flag("-Wno-strict-aliasing");
-        config.flag("-Wno-invalid-offsetof");
-    }
-    if target.contains("riscv64gc") {
-        // link libatomic required to build for riscv64gc
-        println!("cargo:rustc-link-lib=atomic");
-    }
-    for file in lib_sources {
-        config.file(format!("rocksdb/{file}"));
-    }
-
-    config.file("build_version.cc");
-
-    config.cpp(true);
-
-    if !target.contains("windows") {
-        config.flag("-include").flag("cstdint");
-    }
-
-    // By default `cc` will link C++ standard library automatically,
-    // see https://docs.rs/cc/latest/cc/index.html#c-support.
-    // There is no need to manually set `cpp_link_stdlib`.
-
-    config.compile("librocksdb.a");
-}
-
-fn build_snappy() {
-    let target = env::var("TARGET").unwrap();
-    let endianness = env::var("CARGO_CFG_TARGET_ENDIAN").unwrap();
-    let mut config = cc::Build::new();
-
-    config.include("snappy/");
-    config.include(".");
-    config.define("NDEBUG", Some("1"));
-    config.extra_warnings(false);
-
-    if target.contains("msvc") {
-        config.flag("-EHsc");
-        if cfg!(feature = "mt_static") {
-            config.static_crt(true);
-        }
-        config.flag("-std:c++20");
-    } else {
-        config.flag("-std=c++20");
-    }
-
-    if endianness == "big" {
-        config.define("SNAPPY_IS_BIG_ENDIAN", Some("1"));
-    }
-
-    config.file("snappy/snappy.cc");
-    config.file("snappy/snappy-sinksource.cc");
-    config.file("snappy/snappy-c.cc");
-    config.cpp(true);
-    config.compile("libsnappy.a");
-}
-
-fn try_to_find_and_link_lib(lib_name: &str) -> bool {
-    println!("cargo:rerun-if-env-changed={lib_name}_COMPILE");
-    if let Ok(v) = env::var(format!("{lib_name}_COMPILE"))
-        && (v.to_lowercase() == "true" || v == "1")
-    {
-        return false;
-    }
-
-    println!("cargo:rerun-if-env-changed={lib_name}_LIB_DIR");
-    println!("cargo:rerun-if-env-changed={lib_name}_STATIC");
-
-    if let Ok(lib_dir) = env::var(format!("{lib_name}_LIB_DIR")) {
-        println!("cargo:rustc-link-search=native={lib_dir}");
-        let mode = match env::var_os(format!("{lib_name}_STATIC")) {
-            Some(_) => "static",
-            None => "dylib",
-        };
-        println!("cargo:rustc-link-lib={}={}", mode, lib_name.to_lowercase());
-        return true;
-    }
-    false
-}
-
-/// Returns the value of the `ROCKSDB_CXX_STD` env var, or the default `-std=c++{version}` flag for
-/// building RocksDB.
-fn cxx_standard() -> String {
-    env::var("ROCKSDB_CXX_STD").map_or("-std=c++20".to_owned(), |cxx_std| {
-        if !cxx_std.starts_with("-std=") {
-            format!("-std={cxx_std}")
-        } else {
-            cxx_std
-        }
-    })
-}
-
-fn update_submodules() {
-    let program = "git";
-    let dir = "../";
-    let args = ["submodule", "update", "--init"];
-    println!(
-        "Running command: \"{} {}\" in dir: {}",
-        program,
-        args.join(" "),
-        dir
-    );
-    let ret = Command::new(program).current_dir(dir).args(args).status();
-
-    match ret.map(|status| (status.success(), status.code())) {
-        Ok((true, _)) => (),
-        Ok((false, Some(c))) => panic!("Command failed with error code {c}"),
-        Ok((false, None)) => panic!("Command got killed"),
-        Err(e) => panic!("Command failed with error: {e}"),
-    }
-}
-
-fn cpp_link_stdlib(target: &str) {
-    // according to https://github.com/alexcrichton/cc-rs/blob/master/src/lib.rs#L2189
-    if let Ok(stdlib) = env::var("CXXSTDLIB") {
-        println!("cargo:rustc-link-lib=dylib={stdlib}");
-    } else if target.contains("apple") || target.contains("freebsd") || target.contains("openbsd") {
-        println!("cargo:rustc-link-lib=dylib=c++");
-    } else if target.contains("linux") {
-        println!("cargo:rustc-link-lib=dylib=stdc++");
-    } else if target.contains("aix") {
-        println!("cargo:rustc-link-lib=dylib=c++");
-        println!("cargo:rustc-link-lib=dylib=c++abi");
-    }
-}
-
-fn main() {
-    if !Path::new("rocksdb/AUTHORS").exists() {
-        update_submodules();
-    }
-    bindgen_rocksdb();
-    let target = env::var("TARGET").unwrap();
-
-    #[cfg(feature = "coroutines")]
-    validate_coroutines_target(&target);
-
-    if !try_to_find_and_link_lib("ROCKSDB") {
-        // rocksdb only works with the prebuilt rocksdb system lib on freebsd.
-        // we dont need to rebuild rocksdb
-        if target.contains("freebsd") {
-            println!("cargo:rustc-link-search=native=/usr/local/lib");
-            let mode = match env::var_os("ROCKSDB_STATIC") {
-                Some(_) => "static",
-                None => "dylib",
-            };
-            println!("cargo:rustc-link-lib={mode}=rocksdb");
-
+    /// Apply LFS (Large File Support) defines for 32-bit POSIX targets.
+    /// Inside [`apply_target_os`] for android-armv7 we already set
+    /// `_FILE_OFFSET_BITS=32`, so skip that case here.
+    fn apply_lfs_defines(cfg: &mut cc::Build, target: &Target, layout: SourceLayout) {
+        if matches!(layout, SourceLayout::Windows) {
             return;
         }
-
-        println!("cargo:rerun-if-changed=rocksdb/");
-        fail_on_empty_directory("rocksdb");
-        build_rocksdb();
-    } else {
-        cpp_link_stdlib(&target);
+        if target.triple == "armv7-linux-androideabi" {
+            return;
+        }
+        if target.pointer_width != 64 {
+            cfg.define("_FILE_OFFSET_BITS", Some("64"));
+            cfg.define("_LARGEFILE64_SOURCE", Some("1"));
+        }
     }
 
-    // Folly + transitive deps must be linked after rocksdb itself so the
-    // linker resolves rocksdb's coroutine references against folly. Done
-    // outside `build_rocksdb()` so it also applies when ROCKSDB_LIB_DIR
-    // points at an externally-built librocksdb that was compiled with
-    // USE_COROUTINES.
-    //
-    // Note: the freebsd branch above returns early, but
-    // `validate_coroutines_target()` (called before this block) already
-    // panics on non-Linux targets, so the early return is unreachable when
-    // the `coroutines` feature is enabled. If we ever relax the target
-    // validation, this branch will need to handle freebsd explicitly.
-    #[cfg(feature = "coroutines")]
-    coroutines_link_config();
-
-    if cfg!(feature = "snappy") && !try_to_find_and_link_lib("SNAPPY") {
-        println!("cargo:rerun-if-changed=snappy/");
-        fail_on_empty_directory("snappy");
-        build_snappy();
+    fn apply_jemalloc(cfg: &mut cc::Build, target: &Target) {
+        if !cfg!(feature = "jemalloc") {
+            return;
+        }
+        if NO_JEMALLOC_TARGETS
+            .iter()
+            .any(|t| target.triple.contains(t))
+        {
+            return;
+        }
+        cfg.define("ROCKSDB_JEMALLOC", Some("1"));
+        cfg.define("JEMALLOC_NO_DEMANGLE", Some("1"));
+        if let Some(root) = env::var_os("DEP_JEMALLOC_ROOT") {
+            cfg.include(Path::new(&root).join("include"));
+        }
     }
 
-    // Allow dependent crates to locate the sources and output directory of
-    // this crate. Notably, this allows a dependent crate to locate the RocksDB
-    // sources and built archive artifacts provided by this crate.
-    println!(
-        "cargo:cargo_manifest_dir={}",
-        env::var("CARGO_MANIFEST_DIR").unwrap()
-    );
-    println!("cargo:out_dir={}", env::var("OUT_DIR").unwrap());
+    fn apply_io_uring(_cfg: &mut cc::Build, _target: &Target) {
+        #[cfg(feature = "io-uring")]
+        {
+            if _target.os == "linux" {
+                pkg_config::probe_library("liburing").unwrap_or_else(|e| {
+                    panic!(
+                        "the `io-uring` feature was requested but pkg-config probe for \
+                         `liburing` failed: {e}\n\
+                         Hints:\n\
+                          - Debian/Ubuntu:  apt-get install liburing-dev\n\
+                          - Fedora/RHEL:    dnf install liburing-devel\n\
+                          - Arch:           pacman -S liburing\n\
+                          - Alpine:         apk add liburing-dev\n\
+                          - or set PKG_CONFIG_PATH to a directory containing liburing.pc\n\
+                          - when cross-compiling, also set PKG_CONFIG_ALLOW_CROSS=1\n\
+                            and point PKG_CONFIG_PATH at the target sysroot's pkgconfig dir."
+                    )
+                });
+                _cfg.define("ROCKSDB_IOURING_PRESENT", Some("1"));
+            }
+        }
+    }
+
+    /// Read `rocksdb_lib_sources.txt`, drop the pre-generated
+    /// `build_version.cc`, and apply the OS-specific source filter.
+    fn collect_sources(target: &Target, layout: SourceLayout) -> Vec<&'static str> {
+        let sources = include_str!("rocksdb_lib_sources.txt")
+            .lines()
+            .map(str::trim)
+            .filter(|l| !l.is_empty())
+            // We ship our own build_version.cc; the upstream one needs git.
+            .filter(|f| *f != "util/build_version.cc");
+
+        let mut out: Vec<&'static str> = match layout {
+            SourceLayout::Posix => sources.collect(),
+            SourceLayout::Windows => sources
+                .filter(|f| {
+                    !matches!(
+                        *f,
+                        "port/port_posix.cc"
+                            | "env/env_posix.cc"
+                            | "env/fs_posix.cc"
+                            | "env/io_posix.cc"
+                    )
+                })
+                .collect(),
+        };
+
+        if matches!(layout, SourceLayout::Windows) {
+            out.extend([
+                "port/win/env_default.cc",
+                "port/win/port_win.cc",
+                "port/win/xpress_win.cc",
+                "port/win/io_win.cc",
+                "port/win/win_thread.cc",
+                "port/win/env_win.cc",
+                "port/win/win_logger.cc",
+            ]);
+            if cfg!(feature = "jemalloc")
+                && !NO_JEMALLOC_TARGETS
+                    .iter()
+                    .any(|t| target.triple.contains(t))
+            {
+                out.push("port/win/win_jemalloc.cc");
+            }
+        }
+
+        out
+    }
+
+    /// Returns the `-std=c++NN` flag to use. Honors `ROCKSDB_CXX_STD`.
+    fn cxx_standard() -> String {
+        env::var("ROCKSDB_CXX_STD").map_or_else(
+            |_| format!("-std={DEFAULT_CXX_STD}"),
+            |s| {
+                if s.starts_with("-std=") {
+                    s
+                } else {
+                    format!("-std={s}")
+                }
+            },
+        )
+    }
 }
 
-/// Validates that the requested target is one we can build the `coroutines`
-/// feature for. Folly only ships a working build for Linux; on macOS, Windows,
-/// and the BSDs the folly toolchain is missing pieces (notably the io_uring
-/// async file system, and folly's getdeps build itself is flaky).
+// =========================================================================
+// System backend (env-vars and pkg-config)
+// =========================================================================
+
+mod system {
+    use super::*;
+
+    /// Build a `Backend::System` from `ROCKSDB_LIB_DIR`. Emits the
+    /// corresponding `cargo::rustc-link-*` directives.
+    pub(super) fn from_lib_dir_env() -> Backend {
+        let lib_dir =
+            env::var_os("ROCKSDB_LIB_DIR").expect("checked by caller in Backend::resolve");
+        emit_link_directives(Path::new(&lib_dir));
+
+        Backend::System {
+            includes: env_includes_override(),
+        }
+    }
+
+    /// FreeBSD default: link `/usr/local/lib/librocksdb.{so,a}` and read
+    /// headers from `/usr/local/include`. Honors `ROCKSDB_INCLUDE_DIR`
+    /// if set; `ROCKSDB_LIB_DIR` is handled in [`Backend::resolve`] and
+    /// does not reach this function.
+    pub(super) fn from_freebsd_defaults() -> Backend {
+        emit_link_directives(Path::new("/usr/local/lib"));
+
+        let mut includes = env_includes_override();
+        if includes.is_empty() {
+            includes.push(PathBuf::from("/usr/local/include"));
+        }
+        Backend::System { includes }
+    }
+
+    /// Use `pkg-config` to find rocksdb. Honors the standard `pkg-config`
+    /// crate env vars (`PKG_CONFIG_ALL_STATIC`, `PKG_CONFIG_PATH`, ...)
+    /// plus our `ROCKSDB_STATIC` for static-link opt-in.
+    pub(super) fn probe_pkg_config() -> Backend {
+        let mut config = pkg_config::Config::new();
+        // Honor ROCKSDB_STATIC even when going through pkg-config.
+        if env::var_os("ROCKSDB_STATIC").is_some() {
+            config.statik(true);
+        }
+        // We intentionally don't pass `.atleast_version(...)` — power
+        // users opting into this path know what version they have
+        // installed and are responsible for ABI compatibility.
+        let lib = config.probe("rocksdb").unwrap_or_else(|e| {
+            panic!(
+                "ROCKSDB_USE_PKG_CONFIG=1 but pkg-config probe for `rocksdb` failed: {e}\n\
+                 Hints:\n\
+                  - Debian/Ubuntu:  apt-get install librocksdb-dev\n\
+                  - Fedora/RHEL:    dnf install rocksdb-devel\n\
+                  - Arch:           pacman -S rocksdb\n\
+                  - Alpine:         apk add rocksdb-dev\n\
+                  - macOS:          brew install rocksdb\n\
+                  - or set PKG_CONFIG_PATH to a directory containing rocksdb.pc\n\
+                  - when cross-compiling, also set PKG_CONFIG_ALLOW_CROSS=1\n\
+                    and point PKG_CONFIG_PATH at the target sysroot's pkgconfig dir."
+            )
+        });
+
+        // pkg-config crate already emitted the link directives. We pass
+        // ALL of its discovered include paths to bindgen so headers split
+        // across multiple roots are visible.
+        //
+        // ROCKSDB_INCLUDE_DIR, when set, is merged in front of pkg-config's
+        // paths: bindgen sees the env-override path first (so it wins on
+        // duplicate header names), with pkg-config's additional paths
+        // remaining visible for vendors that ship rocksdb with sibling
+        // include dirs (e.g. for chained deps).
+        let mut includes = env_includes_override();
+        for p in lib.include_paths {
+            if !includes.contains(&p) {
+                includes.push(p);
+            }
+        }
+
+        Backend::System { includes }
+    }
+
+    /// Common link-directive emission: search path + static/dylib choice.
+    fn emit_link_directives(lib_dir: &Path) {
+        println!("cargo::rustc-link-search=native={}", lib_dir.display());
+        let kind = link_kind();
+        println!("cargo::rustc-link-lib={kind}=rocksdb");
+    }
+
+    /// `ROCKSDB_STATIC` set to any non-empty value → static link;
+    /// otherwise dylib.
+    fn link_kind() -> &'static str {
+        if env::var_os("ROCKSDB_STATIC").is_some() {
+            "static"
+        } else {
+            "dylib"
+        }
+    }
+
+    /// Read `ROCKSDB_INCLUDE_DIR` as a Vec (one element if set, empty
+    /// otherwise). Uses `var_os` so non-UTF-8 paths work on Unix.
+    fn env_includes_override() -> Vec<PathBuf> {
+        env::var_os("ROCKSDB_INCLUDE_DIR")
+            .map(|p| vec![PathBuf::from(p)])
+            .unwrap_or_default()
+    }
+}
+
+// =========================================================================
+// Snappy
+// =========================================================================
+
+mod snappy {
+    use super::*;
+
+    /// Ensure libsnappy is available to the build. With a vendored
+    /// rocksdb, that means either linking a prebuilt snappy (via
+    /// `SNAPPY_LIB_DIR`) or compiling our bundled copy.
+    ///
+    /// With a system rocksdb, snappy is a no-op: the prebuilt librocksdb
+    /// is typically already linked against its own libsnappy (or was
+    /// built with snappy disabled). Adding another copy here risks
+    /// duplicate-symbol link errors and silent version skew, so we skip
+    /// entirely — and emit a `cargo::warning=` so users who explicitly
+    /// enabled the `snappy` feature alongside a system rocksdb aren't
+    /// silently surprised that the feature is ignored.
+    pub(super) fn ensure(target: &Target, backend: &Backend) {
+        if matches!(backend, Backend::System { .. }) {
+            println!(
+                "cargo::warning=`snappy` feature is enabled but rocksdb \
+                 is being linked from the system; skipping vendored \
+                 snappy build (the system library is expected to provide \
+                 snappy support itself)."
+            );
+            return;
+        }
+        if try_system() {
+            return;
+        }
+        println!("cargo::rerun-if-changed=snappy/");
+        ensure_submodule_present("snappy");
+        build_vendored(target);
+    }
+
+    /// Try to link a prebuilt snappy via `SNAPPY_LIB_DIR`. Returns true if
+    /// linking succeeded and no vendored build is needed.
+    fn try_system() -> bool {
+        if env_truthy("SNAPPY_COMPILE") {
+            return false;
+        }
+        let Some(lib_dir) = env::var_os("SNAPPY_LIB_DIR") else {
+            return false;
+        };
+        println!(
+            "cargo::rustc-link-search=native={}",
+            lib_dir.to_string_lossy()
+        );
+        let kind = if env::var_os("SNAPPY_STATIC").is_some() {
+            "static"
+        } else {
+            "dylib"
+        };
+        println!("cargo::rustc-link-lib={kind}=snappy");
+        true
+    }
+
+    fn build_vendored(target: &Target) {
+        let mut cfg = cc::Build::new();
+        cfg.include("snappy/")
+            .include(".")
+            .define("NDEBUG", Some("1"))
+            .extra_warnings(false);
+
+        if target.is_msvc() {
+            cfg.flag("-EHsc");
+            if cfg!(feature = "mt_static") {
+                cfg.static_crt(true);
+            }
+            cfg.flag("-std:c++20");
+        } else {
+            cfg.flag("-std=c++20");
+        }
+
+        if target.endian == "big" {
+            cfg.define("SNAPPY_IS_BIG_ENDIAN", Some("1"));
+        }
+
+        for src in [
+            "snappy/snappy.cc",
+            "snappy/snappy-sinksource.cc",
+            "snappy/snappy-c.cc",
+        ] {
+            cfg.file(src);
+        }
+        cfg.cpp(true);
+        cfg.compile("libsnappy.a");
+    }
+}
+
+// =========================================================================
+// Bindgen
+// =========================================================================
+
+mod bindings {
+    use super::*;
+
+    /// Generate Rust FFI bindings against the backend's headers.
+    /// Critically, this uses the **chosen backend's** include dirs so a
+    /// system link cannot produce ABI-mismatched bindings.
+    ///
+    /// If we couldn't determine an include directory (only possible when
+    /// the system path was chosen and neither `ROCKSDB_INCLUDE_DIR` nor
+    /// pkg-config provided one), this panics with an actionable message
+    /// rather than guessing `/usr/include` and silently misbinding.
+    pub(super) fn generate(backend: &Backend) {
+        let includes = backend.all_includes();
+        let primary = includes.first().unwrap_or_else(|| {
+            panic!(
+                "could not determine the RocksDB include directory.\n\
+                 Set ROCKSDB_INCLUDE_DIR to the directory containing \
+                 `rocksdb/c.h`, OR ensure your pkg-config rocksdb.pc \
+                 file has correct Cflags."
+            )
+        });
+
+        let header = primary.join("rocksdb").join("c.h");
+
+        let mut builder = bindgen::Builder::default()
+            .header(header.display().to_string())
+            .derive_debug(false)
+            // https://github.com/rust-lang-nursery/rust-bindgen/issues/550
+            .blocklist_type("max_align_t")
+            .ctypes_prefix("libc")
+            .size_t_is_usize(true);
+
+        // Pass every include path so headers split across multiple roots
+        // (rare but happens with chained pkg-config deps) are all found.
+        for inc in includes {
+            builder = builder.clang_arg(format!("-I{}", inc.display()));
+        }
+
+        // Escape hatch for exotic system layouts. Whitespace-split — paths
+        // with spaces aren't supported; users with such paths should
+        // pre-process them upstream (e.g. via a shell function).
+        if let Ok(extra) = env::var("BINDGEN_EXTRA_CLANG_ARGS") {
+            for arg in extra.split_whitespace() {
+                builder = builder.clang_arg(arg);
+            }
+        }
+
+        let bindings = builder.generate().unwrap_or_else(|e| {
+            panic!(
+                "failed to generate RocksDB bindings from `{}`: {e}\n\
+                 Tried include paths: {:?}\n\
+                 Hints:\n\
+                  - confirm `{}` exists and is readable\n\
+                  - set BINDGEN_EXTRA_CLANG_ARGS=\"-I/extra/include\" if needed\n\
+                  - on cross-compile, ensure clang can find your sysroot headers",
+                header.display(),
+                includes,
+                header.display(),
+            )
+        });
+
+        let out = out_dir().join("bindings.rs");
+        bindings
+            .write_to_file(&out)
+            .unwrap_or_else(|e| panic!("failed to write bindings to `{}`: {e}", out.display()));
+    }
+}
+
+// =========================================================================
+// Coroutines (folly) — gated behind the `coroutines` feature
+// =========================================================================
+
 #[cfg(feature = "coroutines")]
-fn validate_coroutines_target(target: &str) {
-    if !target.contains("linux") {
+mod coroutines {
+    use super::*;
+
+    /// Validates that the requested target is one we can build the
+    /// `coroutines` feature for. Folly only ships a working build for
+    /// Linux; macOS, Windows, and the BSDs are missing pieces (notably
+    /// the io_uring async file system, and folly's getdeps build itself
+    /// is flaky elsewhere).
+    pub(super) fn validate_target(target: &Target) {
+        if target.os != "linux" {
+            panic!(
+                "the `coroutines` feature is only supported on Linux \
+                 (target was `{}`)",
+                target.triple
+            );
+        }
+    }
+
+    /// Compile-time configuration for the coroutines build: defines,
+    /// compiler flags, and include paths for folly + its dependencies.
+    /// Mirrors RocksDB's `CMakeLists.txt` (USE_COROUTINES branch) and
+    /// `folly.mk`.
+    pub(super) fn apply_compile_config(cfg: &mut cc::Build) {
+        cfg.define("USE_COROUTINES", None);
+        cfg.define("USE_FOLLY", None);
+        cfg.define("FOLLY_NO_CONFIG", None);
+        cfg.define("HAVE_CXX11_ATOMIC", None);
+
+        // GCC needs explicit -fcoroutines; clang enables coroutines under
+        // -std=c++20 by default. Using `flag()` (not `flag_if_supported`)
+        // forces an old GCC to fail loudly with "unrecognized option"
+        // rather than silently produce confusing template errors deep in
+        // folly headers.
+        if !cfg.get_compiler().is_like_clang() {
+            cfg.flag("-fcoroutines");
+        }
+        // Folly's headers trip warnings RocksDB's stricter flags would
+        // otherwise treat as significant.
+        for f in [
+            "-Wno-deprecated",
+            "-Wno-redundant-move",
+            "-Wno-maybe-uninitialized",
+            "-Wno-invalid-memory-model",
+        ] {
+            cfg.flag_if_supported(f);
+        }
+
+        let install_root = install_root();
+        for dep in [
+            "folly",
+            "boost",
+            "fmt",
+            "glog",
+            "gflags",
+            "double-conversion",
+            "libevent",
+            "libsodium",
+        ] {
+            let dir = resolve_dep(&install_root, dep);
+            cfg.include(dir.join("include"));
+        }
+    }
+
+    /// When the user has opted into `coroutines` AND a system rocksdb,
+    /// emit a `cargo::warning=` so a missing-symbol link error has a
+    /// breadcrumb back to this combination. This crate cannot tell
+    /// whether the prebuilt librocksdb was actually compiled with
+    /// `USE_COROUTINES=1`; we still emit the folly link directives (the
+    /// user accepted responsibility by opting into both), but surface
+    /// the risk loudly.
+    pub(super) fn warn_if_system_backend(backend: &Backend) {
+        if matches!(backend, Backend::System { .. }) {
+            println!(
+                "cargo::warning=`coroutines` feature is enabled and \
+                 RocksDB is being linked from the system: ensure that \
+                 librocksdb was built with USE_COROUTINES=1 and \
+                 USE_FOLLY=1, otherwise you will get unresolved-symbol \
+                 link errors against folly's coroutine helpers."
+            );
+        }
+    }
+
+    /// Link-time configuration: emit the `cargo::rustc-link-*` directives
+    /// for folly and its transitive deps. Order matters — folly must be
+    /// listed *after* librocksdb on the link line so its coroutine symbols
+    /// satisfy RocksDB's references.
+    pub(super) fn link() {
+        let install_root = install_root();
+
+        let folly = resolve_dep(&install_root, "folly");
+        let boost = resolve_dep(&install_root, "boost");
+        let fmt = resolve_dep(&install_root, "fmt");
+        let glog = resolve_dep(&install_root, "glog");
+        let gflags = resolve_dep(&install_root, "gflags");
+        let dbl_conv = resolve_dep(&install_root, "double-conversion");
+        let libevent = resolve_dep(&install_root, "libevent");
+        let libsodium = resolve_dep(&install_root, "libsodium");
+
+        // folly itself
+        println!(
+            "cargo::rustc-link-search=native={}",
+            folly.join("lib").display()
+        );
+        println!("cargo::rustc-link-lib=static=folly");
+
+        // Boost components — list matches folly.mk's PLATFORM_LDFLAGS.
+        // If FOLLY_COMMIT_HASH is bumped and a component vanishes, the
+        // link will fail with "cannot find -lboost_<x>"; trim this list
+        // then.
+        println!(
+            "cargo::rustc-link-search=native={}",
+            boost.join("lib").display()
+        );
+        for c in [
+            "context",
+            "filesystem",
+            "atomic",
+            "program_options",
+            "regex",
+            "system",
+            "thread",
+        ] {
+            println!("cargo::rustc-link-lib=static=boost_{c}");
+        }
+
+        println!(
+            "cargo::rustc-link-search=native={}",
+            dbl_conv.join("lib").display()
+        );
+        println!("cargo::rustc-link-lib=static=double-conversion");
+
+        println!(
+            "cargo::rustc-link-search=native={}",
+            libevent.join("lib").display()
+        );
+        println!("cargo::rustc-link-lib=static=event");
+
+        println!(
+            "cargo::rustc-link-search=native={}",
+            libsodium.join("lib").display()
+        );
+        println!("cargo::rustc-link-lib=static=sodium");
+
+        // glog and gflags build as shared libs only. We export their dirs
+        // as `cargo::metadata=folly_glog_libdir` etc. so downstream binary
+        // crates can embed rpath; cargo:rustc-link-arg doesn't propagate
+        // through transitive `-sys` crates (rust-lang/cargo#9554).
+        let glog_libdir = libdir_containing(&glog, "glog");
+        let gflags_libdir = libdir_containing(&gflags, "gflags");
+        println!("cargo::rustc-link-search=native={}", glog_libdir.display());
+        println!(
+            "cargo::rustc-link-search=native={}",
+            gflags_libdir.display()
+        );
+        println!("cargo::rustc-link-lib=dylib=glog");
+        println!("cargo::rustc-link-lib=dylib=gflags");
+        println!(
+            "cargo::metadata=folly_glog_libdir={}",
+            glog_libdir.display()
+        );
+        println!(
+            "cargo::metadata=folly_gflags_libdir={}",
+            gflags_libdir.display()
+        );
+
+        let fmt_libdir = libdir_containing(&fmt, "fmt");
+        println!("cargo::rustc-link-search=native={}", fmt_libdir.display());
+        println!("cargo::rustc-link-lib=static=fmt");
+
+        // folly transitive dep
+        println!("cargo::rustc-link-lib=dylib=dl");
+    }
+
+    /// `ROCKSDB_FOLLY_INSTALL_PATH` — must point at a folly install root
+    /// produced by `scripts/build_folly.sh` (or equivalent).
+    fn install_root() -> PathBuf {
+        let raw = env::var("ROCKSDB_FOLLY_INSTALL_PATH").unwrap_or_else(|_| {
+            panic!(
+                "the `coroutines` feature requires the env var \
+                 ROCKSDB_FOLLY_INSTALL_PATH to point at a folly install \
+                 produced by `scripts/build_folly.sh` (or equivalent)."
+            )
+        });
+        PathBuf::from(raw)
+    }
+
+    /// Resolve a dependency directory under folly's `installed/` tree.
+    ///
+    /// getdeps has two naming conventions:
+    /// 1. The project being built (folly itself) installs to
+    ///    `<root>/<name>` with no suffix.
+    /// 2. Its dependencies install to `<root>/<name>-<hash>`.
+    ///
+    /// We check (1) first then fall back to globbing (2). Panicking on
+    /// zero or multiple matches catches stale installs from prior
+    /// FOLLY_COMMIT_HASH values that would otherwise resolve non-
+    /// deterministically.
+    fn resolve_dep(install_root: &Path, name: &str) -> PathBuf {
+        let bare = install_root.join(name);
+        if bare.is_dir() {
+            return bare;
+        }
+        let pattern = install_root.join(format!("{name}-*"));
+        let pattern_str = pattern
+            .to_str()
+            .expect("ROCKSDB_FOLLY_INSTALL_PATH must be valid UTF-8");
+        let matches: Vec<PathBuf> = glob::glob(pattern_str)
+            .unwrap_or_else(|e| panic!("invalid glob `{pattern_str}`: {e}"))
+            .filter_map(Result::ok)
+            .collect();
+        match matches.as_slice() {
+            [] => panic!(
+                "could not find `{name}` or `{name}-*` under {}; \
+                 did `scripts/build_folly.sh` finish successfully?",
+                install_root.display()
+            ),
+            [only] => only.clone(),
+            many => panic!(
+                "found {} `{name}-*` directories under {}:\n  {}\n\
+                 this usually means a stale install from a prior \
+                 FOLLY_COMMIT_HASH is mixed with the current one. Remove \
+                 the stale entries or point ROCKSDB_FOLLY_INSTALL_PATH at \
+                 a clean install.",
+                many.len(),
+                install_root.display(),
+                many.iter()
+                    .map(|p| p.display().to_string())
+                    .collect::<Vec<_>>()
+                    .join("\n  ")
+            ),
+        }
+    }
+
+    /// Returns whichever of `<prefix>/lib` or `<prefix>/lib64` actually
+    /// contains the named library. getdeps sometimes leaves an empty
+    /// sibling directory as a CMake `GNUInstallDirs` side effect, so a
+    /// plain `is_dir()` check is not enough.
+    fn libdir_containing(prefix: &Path, lib_name: &str) -> PathBuf {
+        for sub in ["lib64", "lib"] {
+            let candidate = prefix.join(sub);
+            if !candidate.is_dir() {
+                continue;
+            }
+            let pattern = candidate.join(format!("lib{lib_name}.*"));
+            let Some(pattern_str) = pattern.to_str() else {
+                continue;
+            };
+            let mut iter = match glob::glob(pattern_str) {
+                Ok(it) => it,
+                Err(_) => continue,
+            };
+            if iter.any(|r| r.is_ok()) {
+                return candidate;
+            }
+        }
         panic!(
-            "the `coroutines` feature is only supported on Linux \
-             (target was `{target}`)"
+            "could not find `lib{lib_name}.{{so,a}}*` in either \
+             `{}/lib/` or `{}/lib64/`. The folly install at `{}` looks \
+             incomplete - rerun `scripts/build_folly.sh` to rebuild from \
+             scratch.",
+            prefix.display(),
+            prefix.display(),
+            prefix.display()
         );
     }
 }
 
-/// Compile-time configuration for the coroutines build: defines, compiler
-/// flags, and include paths for folly + its dependencies. Mirrors the logic
-/// in RocksDB's own `CMakeLists.txt` (lines 607-667) and `Makefile`
-/// (`USE_COROUTINES=1` branch around line 147).
-///
-/// Assumes `validate_coroutines_target()` has already been called by `main()`
-/// and the target is Linux.
-#[cfg(feature = "coroutines")]
-fn coroutines_compile_config(config: &mut cc::Build, _target: &str) {
-    config.define("USE_COROUTINES", None);
-    config.define("USE_FOLLY", None);
-    config.define("FOLLY_NO_CONFIG", None);
-    config.define("HAVE_CXX11_ATOMIC", None);
+// =========================================================================
+// Small utilities
+// =========================================================================
 
-    // GCC needs explicit -fcoroutines to enable coroutine support; clang
-    // enables coroutines under -std=c++20 by default. We use `flag()` not
-    // `flag_if_supported()` here: on a too-old GCC we want the build to
-    // fail loudly with "unrecognized option -fcoroutines" rather than
-    // silently drop the flag and produce a confusing C++ compile error
-    // deep inside folly headers that depend on coroutine support.
-    if !config.get_compiler().is_like_clang() {
-        config.flag("-fcoroutines");
-    }
-    // Folly's headers trip warnings that RocksDB's stricter build flags
-    // would otherwise treat as significant.
-    config.flag_if_supported("-Wno-deprecated");
-    config.flag_if_supported("-Wno-redundant-move");
-    config.flag_if_supported("-Wno-maybe-uninitialized");
-    config.flag_if_supported("-Wno-invalid-memory-model");
-
-    let install_root = coroutines_install_root();
-    for dep in [
-        "folly",
-        "boost",
-        "fmt",
-        "glog",
-        "gflags",
-        "double-conversion",
-        "libevent",
-        "libsodium",
-    ] {
-        let dir = resolve_folly_dep(&install_root, dep);
-        config.include(dir.join("include"));
+fn rerun_if_env_changed(vars: &[&str]) {
+    for v in vars {
+        println!("cargo::rerun-if-env-changed={v}");
     }
 }
 
-/// Link-time configuration for the coroutines build: emits the
-/// `cargo:rustc-link-*` directives for folly and its transitive dependencies.
-/// Order matters - folly must come after `librocksdb.a` on the linker command
-/// line so symbols resolve forward.
-#[cfg(feature = "coroutines")]
-fn coroutines_link_config() {
-    println!("cargo:rerun-if-env-changed=ROCKSDB_FOLLY_INSTALL_PATH");
-
-    let install_root = coroutines_install_root();
-
-    let folly = resolve_folly_dep(&install_root, "folly");
-    let boost = resolve_folly_dep(&install_root, "boost");
-    let fmt = resolve_folly_dep(&install_root, "fmt");
-    let glog = resolve_folly_dep(&install_root, "glog");
-    let gflags = resolve_folly_dep(&install_root, "gflags");
-    let dbl_conv = resolve_folly_dep(&install_root, "double-conversion");
-    let libevent = resolve_folly_dep(&install_root, "libevent");
-    let libsodium = resolve_folly_dep(&install_root, "libsodium");
-
-    // Folly itself.
-    println!(
-        "cargo:rustc-link-search=native={}",
-        folly.join("lib").display()
-    );
-    println!("cargo:rustc-link-lib=static=folly");
-
-    // Boost components. This list mirrors the static archives that RocksDB's
-    // own `folly.mk` links against (PLATFORM_LDFLAGS, ~line 50). The set is
-    // larger than what folly *strictly* needs because RocksDB's dependency
-    // chain reaches into more boost components than folly alone. If
-    // FOLLY_COMMIT_HASH is bumped and a component is no longer produced by
-    // the build, the link step will fail with "cannot find -lboost_<x>";
-    // that's the signal to trim this list.
-    println!(
-        "cargo:rustc-link-search=native={}",
-        boost.join("lib").display()
-    );
-    for lib in [
-        "context",
-        "filesystem",
-        "atomic",
-        "program_options",
-        "regex",
-        "system",
-        "thread",
-    ] {
-        println!("cargo:rustc-link-lib=static=boost_{lib}");
-    }
-
-    println!(
-        "cargo:rustc-link-search=native={}",
-        dbl_conv.join("lib").display()
-    );
-    println!("cargo:rustc-link-lib=static=double-conversion");
-
-    println!(
-        "cargo:rustc-link-search=native={}",
-        libevent.join("lib").display()
-    );
-    println!("cargo:rustc-link-lib=static=event");
-
-    println!(
-        "cargo:rustc-link-search=native={}",
-        libsodium.join("lib").display()
-    );
-    println!("cargo:rustc-link-lib=static=sodium");
-
-    // glog and gflags only build as shared libs from folly's getdeps, so we
-    // link them dynamically. We deliberately do NOT emit `cargo:rustc-link-arg`
-    // for rpath here: per `cargo:rustc-link-arg` semantics, those args only
-    // apply to artifacts of the crate that emits them (tests/examples/benches
-    // of `rust-librocksdb-sys` itself), not to downstream binaries that depend
-    // on this crate (see rust-lang/cargo#9554). Embedding rpath that only
-    // covers our own test binaries would be misleading. Downstream users must
-    // handle runtime discovery of libglog/libgflags themselves - see the
-    // "Async MultiGet with C++20 Coroutines" section in the top-level README.
-    let glog_libdir = libdir_containing(&glog, "glog");
-    let gflags_libdir = libdir_containing(&gflags, "gflags");
-    println!("cargo:rustc-link-search=native={}", glog_libdir.display());
-    println!("cargo:rustc-link-search=native={}", gflags_libdir.display());
-    println!("cargo:rustc-link-lib=dylib=glog");
-    println!("cargo:rustc-link-lib=dylib=gflags");
-    // Export the discovered directories for downstream build scripts so they
-    // can set rpath on their own crate's binaries without re-globbing folly's
-    // install layout. Accessible as `DEP_ROCKSDB_FOLLY_GLOG_LIBDIR` and
-    // `DEP_ROCKSDB_FOLLY_GFLAGS_LIBDIR` in dependent crates' build scripts
-    // (via the `links = "rocksdb"` metadata).
-    println!("cargo:folly_glog_libdir={}", glog_libdir.display());
-    println!("cargo:folly_gflags_libdir={}", gflags_libdir.display());
-
-    let fmt_libdir = libdir_containing(&fmt, "fmt");
-    println!("cargo:rustc-link-search=native={}", fmt_libdir.display());
-    println!("cargo:rustc-link-lib=static=fmt");
-
-    // libdl, needed by folly.
-    println!("cargo:rustc-link-lib=dylib=dl");
+fn out_dir() -> PathBuf {
+    PathBuf::from(env::var_os("OUT_DIR").expect("OUT_DIR"))
 }
 
-/// Returns the install root containing folly and its sibling dependency
-/// directories (e.g. `<root>/folly-<hash>`, `<root>/boost-<hash>`, etc).
-#[cfg(feature = "coroutines")]
-fn coroutines_install_root() -> PathBuf {
-    let raw = env::var("ROCKSDB_FOLLY_INSTALL_PATH").unwrap_or_else(|_| {
+fn manifest_dir() -> PathBuf {
+    PathBuf::from(env::var_os("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR"))
+}
+
+fn vendored_include() -> PathBuf {
+    manifest_dir().join("rocksdb").join("include")
+}
+
+/// Truthy interpretation of `1`, `true` (case-insensitive). Any other
+/// value (including unset) is falsy.
+fn env_truthy(name: &str) -> bool {
+    match env::var(name) {
+        Ok(v) => {
+            let v = v.trim();
+            v == "1" || v.eq_ignore_ascii_case("true")
+        }
+        Err(_) => false,
+    }
+}
+
+/// Exit with a helpful error if a vendored submodule looks unpopulated.
+/// On crates.io, the source tarball ships pre-populated, so this is only
+/// hit by git-clone consumers who forgot `git submodule update --init`.
+fn ensure_submodule_present(name: &str) {
+    let dir = manifest_dir().join(name);
+    let entries = std::fs::read_dir(&dir).unwrap_or_else(|e| {
         panic!(
-            "the `coroutines` feature requires the env var \
-             ROCKSDB_FOLLY_INSTALL_PATH to point at a folly install \
-             produced by `scripts/build_folly.sh` (or equivalent)."
+            "cannot read `{}`: {e}\n\
+             If you cloned this repo with git, run:\n  \
+             git submodule update --init --recursive",
+            dir.display()
         )
     });
-    PathBuf::from(raw)
-}
-
-/// Resolves a dependency directory under folly's `installed/` tree.
-///
-/// getdeps uses two naming conventions:
-///
-/// 1. The project being built (folly itself, in our case) installs to
-///    `<install_root>/<name>` with no version/hash suffix.
-/// 2. Its dependencies install to `<install_root>/<name>-<hash>` where the
-///    hash captures the manifest+ctx so changes to either reset the install.
-///
-/// We check (1) first - so `resolve_folly_dep(root, "folly")` returns
-/// `<root>/folly` directly when present - and fall back to globbing (2).
-/// Panics if zero or more than one directory matches in case (2): multiple
-/// matches typically indicate a stale install from a prior FOLLY_COMMIT_HASH
-/// mixed with the current one, which would otherwise be resolved
-/// non-deterministically and could link the wrong version.
-#[cfg(feature = "coroutines")]
-fn resolve_folly_dep(install_root: &Path, name: &str) -> PathBuf {
-    // Case 1: unsuffixed directory (used for the project being built).
-    let bare = install_root.join(name);
-    if bare.is_dir() {
-        return bare;
+    if entries.count() == 0 {
+        panic!(
+            "the `{}` directory is empty. If you cloned this repo \
+             with git, run:\n  git submodule update --init --recursive",
+            dir.display()
+        );
     }
-    // Case 2: glob for the hashed dependency directory.
-    let pattern = install_root.join(format!("{name}-*"));
-    let pattern_str = pattern
-        .to_str()
-        .expect("ROCKSDB_FOLLY_INSTALL_PATH must be valid UTF-8");
-    let matches: Vec<PathBuf> = glob::glob(pattern_str)
-        .unwrap_or_else(|e| panic!("invalid glob `{pattern_str}`: {e}"))
-        .filter_map(Result::ok)
-        .collect();
-    match matches.as_slice() {
-        [] => panic!(
-            "could not find `{name}` or `{name}-*` under {}; \
-             did `scripts/build_folly.sh` finish successfully?",
-            install_root.display()
-        ),
-        [only] => only.clone(),
-        many => panic!(
-            "found {} `{name}-*` directories under {}:\n  {}\n\
-             this usually means a stale install from a prior FOLLY_COMMIT_HASH \
-             is mixed with the current one. Remove the stale entries or point \
-             ROCKSDB_FOLLY_INSTALL_PATH at a clean install.",
-            many.len(),
-            install_root.display(),
-            many.iter()
-                .map(|p| p.display().to_string())
-                .collect::<Vec<_>>()
-                .join("\n  ")
-        ),
-    }
-}
-
-/// Returns whichever of `<prefix>/lib` or `<prefix>/lib64` actually contains
-/// the named library (matching `lib<lib_name>.{so,a}*`). Panics with a clear
-/// error if neither does.
-///
-/// Folly's getdeps install layout sometimes creates an empty `lib64/` as a
-/// side effect of CMake's `GNUInstallDirs` probing (or vice-versa), so a
-/// plain `.exists()` check on the directory is not enough - we'd point the
-/// linker at an empty directory and get a confusing "cannot find -l<name>"
-/// later. Probing for the actual library file catches this at config time
-/// with a useful error message.
-#[cfg(feature = "coroutines")]
-fn libdir_containing(prefix: &Path, lib_name: &str) -> PathBuf {
-    // Prefer `lib64/` when it has the library (more specific on RHEL-family
-    // distros); fall back to `lib/` (Debian-family).
-    for subdir in ["lib64", "lib"] {
-        let candidate = prefix.join(subdir);
-        if !candidate.is_dir() {
-            continue;
-        }
-        let glob_pattern = candidate.join(format!("lib{lib_name}.*"));
-        let pattern_str = match glob_pattern.to_str() {
-            Some(s) => s,
-            None => continue,
-        };
-        let mut iter = match glob::glob(pattern_str) {
-            Ok(it) => it,
-            Err(_) => continue,
-        };
-        if iter.any(|r| r.is_ok()) {
-            return candidate;
-        }
-    }
-    panic!(
-        "could not find `lib{lib_name}.{{so,a}}*` in either `{}/lib/` or `{}/lib64/`. \
-         The folly install at `{}` looks incomplete - rerun `scripts/build_folly.sh` \
-         to rebuild from scratch.",
-        prefix.display(),
-        prefix.display(),
-        prefix.display()
-    );
 }


### PR DESCRIPTION
## New: opt-in system rocksdb linking

Three opt-in mechanisms, none of which change default behavior:

* ROCKSDB_USE_PKG_CONFIG=1 - probe pkg-config for rocksdb (new)
* ROCKSDB_LIB_DIR=<path>   - link prebuilt rocksdb (existed; now correct)
* ROCKSDB_COMPILE=1        - force vendored build (existed)

No version pin enforced - users opting in are power users and accept responsibility for ABI compatibility with the bundled version.

When pkg-config is used together with ROCKSDB_INCLUDE_DIR, the env override is *merged* in front of pkg-config's discovered paths (not replaced) so sibling include dirs that the system rocksdb may need remain visible to bindgen.

## Bugs fixed

* Bindgen now matches the chosen backend's headers (was: always bundled, silent ABI drift potential when linking system rocksdb)
* Windows rpcrt4/shlwapi linked in BOTH backends (was: vendored only; system rocksdb on Windows failed to link)
* All target_os checks read CARGO_CFG_TARGET_* (was: host #[cfg], wrong when cross-compiling)
* FreeBSD branch now honors ROCKSDB_STATIC and ROCKSDB_INCLUDE_DIR
* FreeBSD + ROCKSDB_COMPILE=1 produces a clear error up front (was: would attempt vendored build, which is known-broken on FreeBSD)
* Android cpp_link_stdlib uses libc++ (NDK r18+) not libstdc++ (was: silently emitted -lstdc++, breaking modern NDK toolchains)
* Consistent cargo:: (MSRV 1.77+) syntax everywhere
* Removed git-submodule auto-init (broke non-workspace consumers); replaced with actionable error message
* Comprehensive rerun-if-env-changed coverage (added: CXXSTDLIB, CC, CXX, CFLAGS, CXXFLAGS, ROCKSDB_INCLUDE_DIR, ROCKSDB_CXX_STD, CARGO_ENCODED_ RUSTFLAGS, BINDGEN_EXTRA_CLANG_ARGS, DEP_LZ4_INCLUDE, DEP_ZSTD_INCLUDE, DEP_Z_INCLUDE, DEP_BZIP2_INCLUDE, DEP_JEMALLOC_ROOT, PKG_CONFIG_PATH, PKG_CONFIG_LIBDIR, PKG_CONFIG_ALL_STATIC, PKG_CONFIG_ALLOW_CROSS, PKG_CONFIG_SYSROOT_DIR)
* Removed dead link() helper (its bundled=true branch was unreachable)
* iOS deployment target via -mios-version-min flag, no unsafe set_var (Rust 2024 unsafe-attribute fix); flag only for actual iOS, not tvos/watchos; uses flag() not flag_if_supported so non-Apple Clang fails loudly rather than silently dropping the pin
* bindgen no longer falls back to /usr/include silently when system path has no include dir; panics with actionable hints instead
* pkg-config probe passes ALL discovered include paths to bindgen, not just the first
* Vendored snappy skipped when linking system rocksdb (avoids duplicate- symbol risk); emits cargo::warning= so users explicitly enabling the snappy feature alongside system rocksdb aren't silently surprised
* coroutines + system rocksdb emits a clear cargo::warning= so missing- symbol link errors trace back to that combination
* rocksdb_include_dir() returns absolute paths (was: relative)
* liburing pkg-config probe failure now includes 5-distro install hints matching the rocksdb probe-failure format
* Standard cargo:metadata=include/root keys, plus project-local link-target key (documented as such); legacy cargo_manifest_dir/out_dir kept for back-compat

## Architecture

* Single build.rs file, organized into mod vendor/system/snappy/bindings/ coroutines blocks with single-responsibility helpers
* Typed Target struct: single source of truth for CARGO_CFG_TARGET_*, eliminates the host-vs-target cfg confusion class of bug
* Typed Backend enum: encodes the chosen build path + include directories (Vec<PathBuf> to support multi-include from pkg-config)
* The 323-line monolithic build_rocksdb() is now ~25 lines of orchestration over ~10 small focused functions
* Cross-cutting decisions live with their owning modules: snappy::ensure(target, backend) and coroutines::warn_if_system_backend keep main() small and free of repeated `match backend` blocks

## Backwards compatibility

All existing env vars preserved unchanged:
  ROCKSDB_LIB_DIR, ROCKSDB_STATIC, ROCKSDB_COMPILE, ROCKSDB_INCLUDE_DIR, ROCKSDB_CXX_STD, SNAPPY_LIB_DIR, SNAPPY_STATIC, SNAPPY_COMPILE, ROCKSDB_FOLLY_INSTALL_PATH, CXXSTDLIB

Legacy cargo:metadata=cargo_manifest_dir/out_dir keys preserved.

Cargo.toml: pkg-config promoted from optional to required (needed for ROCKSDB_USE_PKG_CONFIG); io-uring feature no longer needs to gate it.