### PR TITLE
ci(coroutines): also test aarch64

### DIFF
--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -14,12 +14,23 @@ env:
 
 jobs:
   build-and-test:
-    name: Build & test with coroutines feature
+    name: ${{ matrix.build }} (coroutines)
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [Linux-x64, Linux-ARM]
+        include:
+          - build: Linux-x64
+            os: ubuntu-24.04
+          - build: Linux-ARM
+            os: ubuntu-24.04-arm
     # The host runner just hosts the container; the actual build happens
     # inside `ubuntu:25.10` (see `container:` below). We pin a specific host
     # image rather than using `ubuntu-latest` so a GHA runner image rollover
-    # doesn't silently change anything visible to the build.
-    runs-on: ubuntu-24.04
+    # doesn't silently change anything visible to the build. The container
+    # image is multi-arch on Docker Hub, so the same `image:` works for
+    # both x86_64 and aarch64 hosts.
+    runs-on: ${{ matrix.os }}
     container:
       # The pinned folly commit (see librocksdb-sys/rocksdb/folly.mk) requires
       # liburing >= 2.7 for the io_uring_zcrx_* zero-copy receive APIs used


### PR DESCRIPTION
Adds a Linux-ARM matrix entry alongside the existing Linux-x64 job in the coroutines workflow. The container image (`ubuntu:25.10`) is multi-arch on Docker Hub, so the same image runs on both `ubuntu-24.04` and `ubuntu-24.04-arm` hosts without modification.

The folly cache key already encodes `runner.arch`, so x86_64 and aarch64 caches stay separate automatically - no key bump needed. Each arch builds folly from scratch the first time the job runs on that arch; subsequent runs hit the cache as before.

The two matrix entries run in parallel, so wall-clock time for the workflow doesn't double.