### PR TITLE
Add ROCKSDB_BACKTRACE, ROCKSDB_PTHREAD_ADAPTIVE_MUTEX, and numa feature

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
           components: clippy
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y liburing-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y liburing-dev libnuma-dev pkg-config
 
       - name: Set PKG_CONFIG_PATH
         run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
@@ -87,6 +87,7 @@ jobs:
           cargo clippy --all-targets --features \
             "jemalloc \
             io-uring \
+            numa \
             valgrind \
             mt_static \
             rtti \

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ members = ["librocksdb-sys"]
 default = ["snappy", "lz4", "zstd", "zlib", "bzip2", "bindgen-runtime"]
 jemalloc = ["rust-librocksdb-sys/jemalloc"]
 io-uring = ["rust-librocksdb-sys/io-uring"]
+# NUMA-aware memtable allocation. Linux only. See
+# `librocksdb-sys/Cargo.toml` for the system package this requires.
+numa = ["rust-librocksdb-sys/numa"]
 # Build RocksDB with folly + C++20 coroutines. See `librocksdb-sys/Cargo.toml`
 # and the "Coroutines / async MultiGet" section of the README for build
 # prerequisites. Linux only.

--- a/README.md
+++ b/README.md
@@ -194,6 +194,19 @@ features = ["malloc-usable-size"]
 
 Required if you want to use RocksDB's `optimize_filters_for_memory` feature. See [RocksDB documentation](https://github.com/facebook/rocksdb/blob/v9.0.0/include/rocksdb/table.h#L401-L434) for details.
 
+#### NUMA-Aware Allocation
+
+> **Linux only**
+
+```toml
+[dependencies.rust-rocksdb]
+features = ["numa"]
+```
+
+Builds RocksDB with `-DNUMA` and links against `libnuma`. When this is on, RocksDB's `Options::use_numa_aware_alloc()` will actually pin memtable arena allocations to the calling thread's NUMA node via `numa_alloc_onnode()` instead of falling back to `malloc()`. Useful on multi-socket bare-metal hosts where cross-socket memory traffic is a real cost; not relevant on single-socket / cloud instances with no NUMA topology.
+
+Install `libnuma-dev` (Debian/Ubuntu) / `numactl-devel` (Fedora/RHEL) / `numactl` (Arch) / `numactl-dev` (Alpine) before building. The build script probes for it via pkg-config and fails with a clear error if it's missing.
+
 ### Platform-Specific Features
 
 #### Multi-threaded Column Family Operations

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -35,6 +35,12 @@ bindgen-runtime = ["bindgen/runtime"]
 bindgen-static = ["bindgen/static"]
 mt_static = []
 io-uring = []
+# NUMA-aware memtable allocation via libnuma. Linux only. When enabled,
+# rocksdb's `Options::use_numa_aware_alloc()` actually pins memtable
+# allocations to the calling thread's NUMA node. Requires `libnuma-dev`
+# (Debian/Ubuntu) / `numactl-devel` (Fedora/RHEL) / `numactl` (Arch) /
+# `numactl-dev` (Alpine). Mostly useful on multi-socket bare-metal hosts.
+numa = []
 # Build RocksDB with `USE_COROUTINES=1 USE_FOLLY=1` and link against a folly
 # install. Enables the multi-level parallel `MultiGet` async-IO path described
 # in the RocksDB blog post "Asynchronous IO in RocksDB". Linux only. Requires

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -357,6 +357,8 @@ mod vendor {
         let layout = apply_target_os(&mut cfg, target);
         apply_lfs_defines(&mut cfg, target, layout);
         apply_io_uring(&mut cfg, target);
+        apply_backtrace(&mut cfg, target);
+        apply_numa(&mut cfg, target);
 
         #[cfg(feature = "coroutines")]
         super::coroutines::apply_compile_config(&mut cfg);
@@ -650,6 +652,14 @@ mod vendor {
                 ] {
                     cfg.define(d, None);
                 }
+                // PTHREAD_MUTEX_ADAPTIVE_NP is a glibc extension. Without it,
+                // rocksdb uses default pthread mutexes; with it, contended
+                // mutexes spin briefly before falling back to a futex wait,
+                // which is a small win for read-heavy workloads. Enable on
+                // Linux glibc only - musl and bionic don't define the constant.
+                if target.env_abi != "musl" {
+                    cfg.define("ROCKSDB_PTHREAD_ADAPTIVE_MUTEX", None);
+                }
                 SourceLayout::Posix
             }
             "windows" => {
@@ -735,6 +745,70 @@ mod vendor {
                     )
                 });
                 _cfg.define("ROCKSDB_IOURING_PRESENT", Some("1"));
+            }
+        }
+    }
+
+    /// Enable rocksdb's `execinfo.h`-based stack tracer (`port/stack_trace.cc`).
+    /// Without `ROCKSDB_BACKTRACE` defined, that file compiles a no-op
+    /// stub and rocksdb crashes (segfaults, aborts, assertion failures)
+    /// print no C++ frames at all - a real DX regression vs. the Makefile
+    /// build, which sets this define on every glibc-Linux and Apple target.
+    ///
+    /// We enable it on the same set: Linux glibc and Apple (macOS/iOS).
+    /// Skip:
+    ///   - musl Linux: doesn't ship libexecinfo by default; some distros
+    ///     patch it in via the `libexecinfo` package but we can't assume.
+    ///   - Android: bionic only added `<execinfo.h>` in API 33; older API
+    ///     levels would fail to compile.
+    ///   - Windows / MSVC: no equivalent; would need DbgHelp instead.
+    ///   - BSDs: would need libexecinfo from ports. We don't build the
+    ///     vendored sources on FreeBSD anyway.
+    fn apply_backtrace(cfg: &mut cc::Build, target: &Target) {
+        let supported = match target.os.as_str() {
+            "linux" => target.env_abi != "musl",
+            "macos" | "ios" => true,
+            _ => false,
+        };
+        if supported {
+            cfg.define("ROCKSDB_BACKTRACE", None);
+        }
+    }
+
+    /// NUMA-aware memtable allocation, opt-in via the `numa` cargo feature.
+    /// When enabled, rocksdb's `Options::use_numa_aware_alloc()` becomes
+    /// effective, the memtable arena uses `numa_alloc_onnode()` to pin
+    /// allocations to the current thread's NUMA node, and a handful of
+    /// internal counters get NUMA-aware variants.
+    ///
+    /// Mirrors how `apply_io_uring` handles its system library: probe via
+    /// pkg-config so the user gets a clear "install libnuma-dev" message
+    /// up front rather than a confusing link failure later.
+    fn apply_numa(_cfg: &mut cc::Build, _target: &Target) {
+        #[cfg(feature = "numa")]
+        {
+            if _target.os == "linux" {
+                pkg_config::probe_library("numa").unwrap_or_else(|e| {
+                    panic!(
+                        "the `numa` feature was requested but pkg-config probe for \
+                         `numa` failed: {e}\n\
+                         Hints:\n\
+                          - Debian/Ubuntu:  apt-get install libnuma-dev\n\
+                          - Fedora/RHEL:    dnf install numactl-devel\n\
+                          - Arch:           pacman -S numactl\n\
+                          - Alpine:         apk add numactl-dev\n\
+                          - or set PKG_CONFIG_PATH to a directory containing numa.pc\n\
+                          - when cross-compiling, also set PKG_CONFIG_ALLOW_CROSS=1\n\
+                            and point PKG_CONFIG_PATH at the target sysroot's pkgconfig dir."
+                    )
+                });
+                _cfg.define("NUMA", Some("1"));
+            } else {
+                println!(
+                    "cargo::warning=`numa` feature requested but target OS is \
+                     `{}`; NUMA is Linux-only, the define will not be set",
+                    _target.os
+                );
             }
         }
     }


### PR DESCRIPTION
Three drift fixes between rust-rocksdb's `build.rs` and RocksDB's own `Makefile`/`build_detect_platform` script, identified by diffing the two build paths.

## `ROCKSDB_BACKTRACE` (always-on where supported)

Without this define, rocksdb's `port/stack_trace.cc` compiles a no-op stub - rocksdb crashes (segfaults, aborts, assertion failures) print no C++ frames at all. The Makefile build path sets it on every glibc Linux and Apple target; `build.rs` did not, so debugging issues in the C++ side was harder than it needed to be.

Added `apply_backtrace()` that enables it on:

- Linux glibc (skip musl: no libexecinfo by default)
- macOS, iOS (libSystem ships `<execinfo.h>`)

Skipped on Android (bionic only added `<execinfo.h>` in API 33), Windows (no equivalent), and the BSDs (we don't build vendored sources there anyway).

## `ROCKSDB_PTHREAD_ADAPTIVE_MUTEX` (always-on where supported)

`PTHREAD_MUTEX_ADAPTIVE_NP` is a glibc extension. Without the define, rocksdb uses default pthread mutexes; with it, contended mutexes spin briefly before falling back to a futex wait. Small win on read-heavy workloads with mutex contention.

Set inside the existing Linux branch of `apply_target_os`, gated on `target.env_abi != "musl"` since musl and bionic don't define the constant.

## `numa` cargo feature (opt-in)

New Linux-only cargo feature mirroring the existing `io-uring` pattern. When enabled, the build script:

- Probes for libnuma via `pkg_config` and panics with a hint about the right apt/dnf/pacman/apk package on failure.
- Sets `-DNUMA` so RocksDB's `Options::use_numa_aware_alloc()` pins memtable arena allocations to the calling thread's NUMA node via `numa_alloc_onnode()` instead of falling back to `malloc()`.

Useful on multi-socket bare-metal hosts where cross-socket memory traffic costs are real. On cloud VMs / single-socket boxes it's a no-op even when enabled, so the feature is opt-in rather than default.

## CI

Added `libnuma-dev` to the apt install step in the existing clippy job and `numa` to its feature list, so compile-time issues are caught without needing a new workflow.