### PR TITLE
Release 0.49.1

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -77,7 +77,7 @@ jobs:
           components: clippy
 
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y liburing-dev libnuma-dev pkg-config
+        run: sudo apt-get update && sudo apt-get install -y liburing-dev pkg-config
 
       - name: Set PKG_CONFIG_PATH
         run: echo "PKG_CONFIG_PATH=/usr/lib/x86_64-linux-gnu/pkgconfig" >> $GITHUB_ENV
@@ -87,7 +87,6 @@ jobs:
           cargo clippy --all-targets --features \
             "jemalloc \
             io-uring \
-            numa \
             valgrind \
             mt_static \
             rtti \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 0.49.1 (2026-05-18)
+
+- removed: drop the `numa` cargo feature that shipped in 0.49.0. The
+  feature set `-DNUMA` on the C++ build and linked `libnuma`, but the
+  `Options::use_numa_aware_alloc()` runtime knob and the
+  `numa_alloc_onnode()` arena code path were removed from rocksdb's
+  library proper before 11.1.1 — `NUMA` is now only referenced by
+  `tools/db_bench_tool.cc` and `tools/trace_analyzer_tool.cc`, neither
+  of which rust-rocksdb compiles. The feature was therefore a no-op
+  for library users while adding a build-time dependency on
+  `libnuma-dev`. For NUMA-local memtable arenas on multi-socket hosts
+  use OS-level pinning (`numactl --cpunodebind --membind`, systemd
+  `NUMAPolicy=` / `NUMAMask=`) instead. If you had `features = ["numa"]`
+  in your `Cargo.toml`, remove it. (zaidoon1)
+
 ## 0.49.0 (2026-05-18)
 
 - feat: add transactiondb checkpoint support (gdorsi)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.49.0"
+version = "0.49.1"
 edition = "2024"
 rust-version = "1.89.0"
 authors = [
@@ -22,9 +22,6 @@ members = ["librocksdb-sys"]
 default = ["snappy", "lz4", "zstd", "zlib", "bzip2", "bindgen-runtime"]
 jemalloc = ["rust-librocksdb-sys/jemalloc"]
 io-uring = ["rust-librocksdb-sys/io-uring"]
-# NUMA-aware memtable allocation. Linux only. See
-# `librocksdb-sys/Cargo.toml` for the system package this requires.
-numa = ["rust-librocksdb-sys/numa"]
 # Build RocksDB with folly + C++20 coroutines. See `librocksdb-sys/Cargo.toml`
 # and the "Coroutines / async MultiGet" section of the README for build
 # prerequisites. Linux only.
@@ -48,7 +45,7 @@ raw-ptr = []
 
 [dependencies]
 libc = "0.2"
-rust-librocksdb-sys = { path = "librocksdb-sys", version = "0.45.0", default-features = false, features = [
+rust-librocksdb-sys = { path = "librocksdb-sys", version = "0.45.1", default-features = false, features = [
     "static",
 ] }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -194,19 +194,6 @@ features = ["malloc-usable-size"]
 
 Required if you want to use RocksDB's `optimize_filters_for_memory` feature. See [RocksDB documentation](https://github.com/facebook/rocksdb/blob/v9.0.0/include/rocksdb/table.h#L401-L434) for details.
 
-#### NUMA-Aware Allocation
-
-> **Linux only**
-
-```toml
-[dependencies.rust-rocksdb]
-features = ["numa"]
-```
-
-Builds RocksDB with `-DNUMA` and links against `libnuma`. When this is on, RocksDB's `Options::use_numa_aware_alloc()` will actually pin memtable arena allocations to the calling thread's NUMA node via `numa_alloc_onnode()` instead of falling back to `malloc()`. Useful on multi-socket bare-metal hosts where cross-socket memory traffic is a real cost; not relevant on single-socket / cloud instances with no NUMA topology.
-
-Install `libnuma-dev` (Debian/Ubuntu) / `numactl-devel` (Fedora/RHEL) / `numactl` (Arch) / `numactl-dev` (Alpine) before building. The build script probes for it via pkg-config and fails with a clear error if it's missing.
-
 ### Platform-Specific Features
 
 #### Multi-threaded Column Family Operations

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-librocksdb-sys"
-version = "0.45.0+11.1.1"
+version = "0.45.1+11.1.1"
 edition = "2024"
 rust-version = "1.89.0"
 authors = [
@@ -35,12 +35,6 @@ bindgen-runtime = ["bindgen/runtime"]
 bindgen-static = ["bindgen/static"]
 mt_static = []
 io-uring = []
-# NUMA-aware memtable allocation via libnuma. Linux only. When enabled,
-# rocksdb's `Options::use_numa_aware_alloc()` actually pins memtable
-# allocations to the calling thread's NUMA node. Requires `libnuma-dev`
-# (Debian/Ubuntu) / `numactl-devel` (Fedora/RHEL) / `numactl` (Arch) /
-# `numactl-dev` (Alpine). Mostly useful on multi-socket bare-metal hosts.
-numa = []
 # Build RocksDB with `USE_COROUTINES=1 USE_FOLLY=1` and link against a folly
 # install. Enables the multi-level parallel `MultiGet` async-IO path described
 # in the RocksDB blog post "Asynchronous IO in RocksDB". Linux only. Requires

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -358,7 +358,6 @@ mod vendor {
         apply_lfs_defines(&mut cfg, target, layout);
         apply_io_uring(&mut cfg, target);
         apply_backtrace(&mut cfg, target);
-        apply_numa(&mut cfg, target);
 
         #[cfg(feature = "coroutines")]
         super::coroutines::apply_compile_config(&mut cfg);
@@ -772,44 +771,6 @@ mod vendor {
         };
         if supported {
             cfg.define("ROCKSDB_BACKTRACE", None);
-        }
-    }
-
-    /// NUMA-aware memtable allocation, opt-in via the `numa` cargo feature.
-    /// When enabled, rocksdb's `Options::use_numa_aware_alloc()` becomes
-    /// effective, the memtable arena uses `numa_alloc_onnode()` to pin
-    /// allocations to the current thread's NUMA node, and a handful of
-    /// internal counters get NUMA-aware variants.
-    ///
-    /// Mirrors how `apply_io_uring` handles its system library: probe via
-    /// pkg-config so the user gets a clear "install libnuma-dev" message
-    /// up front rather than a confusing link failure later.
-    fn apply_numa(_cfg: &mut cc::Build, _target: &Target) {
-        #[cfg(feature = "numa")]
-        {
-            if _target.os == "linux" {
-                pkg_config::probe_library("numa").unwrap_or_else(|e| {
-                    panic!(
-                        "the `numa` feature was requested but pkg-config probe for \
-                         `numa` failed: {e}\n\
-                         Hints:\n\
-                          - Debian/Ubuntu:  apt-get install libnuma-dev\n\
-                          - Fedora/RHEL:    dnf install numactl-devel\n\
-                          - Arch:           pacman -S numactl\n\
-                          - Alpine:         apk add numactl-dev\n\
-                          - or set PKG_CONFIG_PATH to a directory containing numa.pc\n\
-                          - when cross-compiling, also set PKG_CONFIG_ALLOW_CROSS=1\n\
-                            and point PKG_CONFIG_PATH at the target sysroot's pkgconfig dir."
-                    )
-                });
-                _cfg.define("NUMA", Some("1"));
-            } else {
-                println!(
-                    "cargo::warning=`numa` feature requested but target OS is \
-                     `{}`; NUMA is Linux-only, the define will not be set",
-                    _target.os
-                );
-            }
         }
     }
 


### PR DESCRIPTION
Hotfix that drops the `numa` cargo feature shipped in 0.49.0.

## Why

The 0.49.0 `numa` feature claimed that enabling it would make `Options::use_numa_aware_alloc()` pin memtable arena allocations to the calling thread's NUMA node. That claim was wrong. The runtime knob and the `numa_alloc_onnode()` arena code path were removed from rocksdb's library proper before 11.1.1 — `NUMA` is now only referenced by `tools/db_bench_tool.cc` and `tools/trace_analyzer_tool.cc`, neither of which rust-rocksdb compiles.

So the 0.49.0 feature unconditionally:
- defined `-DNUMA` on the C++ build (consumed by nothing in librocksdb)
- linked `libnuma` (referenced by nothing in librocksdb)
- forced users to install `libnuma-dev` / `numactl-devel` / equivalent
- forced CI runners to do the same

…in exchange for zero functional behavior change. Anyone who happened to flip it on in 0.49.0 paid the build-cost tax and got nothing.

## What this PR does

- removes the `numa` feature from `librocksdb-sys/Cargo.toml` and the `rust-rocksdb/Cargo.toml` passthrough
- removes `apply_numa` and its call site from `librocksdb-sys/build.rs`
- removes the "NUMA-Aware Allocation" section from `README.md`
- drops `libnuma-dev` from the clippy CI job and removes `numa` from the features list it tests
- adds a 0.49.1 CHANGELOG entry explaining the removal and pointing users at OS-level pinning (`numactl --cpunodebind --membind`, systemd `NUMAPolicy=` / `NUMAMask=`) for actual NUMA-local arenas

## Breaking surface

Anyone who added `features = ["numa"]` to their `Cargo.toml` while 0.49.0 was out (released ~30 min ago, no time for real adoption) will see an "unknown feature `numa`" error when bumping. Fix: delete the line.

## Version bumps

- `rust-rocksdb`: 0.49.0 → 0.49.1
- `rust-librocksdb-sys`: 0.45.0+11.1.1 → 0.45.1+11.1.1

(No RocksDB upgrade; the suffix is unchanged.)