### PR TITLE
Bump MSRV to 1.91.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- bump MSRV to 1.91.0 per the rolling 6-month policy. 1.91.0 was
+  released 2025-10-30, the most recent stable that satisfies the
+  6-month window from today. No critical compiler bugs or soundness
+  fixes in 1.92+ apply to this codebase. (zaidoon1)
+
 ## 0.49.1 (2026-05-18)
 
 - removed: drop the `numa` cargo feature that shipped in 0.49.0. The

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
 version = "0.49.1"
 edition = "2024"
-rust-version = "1.89.0"
+rust-version = "1.91.0"
 authors = [
     "Tyler Neely <t@jujit.su>",
     "David Greenberg <dsg123456789@gmail.com>",

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![crates.io](https://img.shields.io/crates/v/rust-rocksdb.svg)](https://crates.io/crates/rust-rocksdb)
 [![documentation](https://docs.rs/rust-rocksdb/badge.svg)](https://docs.rs/rust-rocksdb)
 [![license](https://img.shields.io/crates/l/rust-rocksdb.svg)](https://github.com/zaidoon1/rust-rocksdb/blob/master/LICENSE)
-![rust 1.89.0 required](https://img.shields.io/badge/rust-1.89.0-blue.svg?label=MSRV)
+![rust 1.91.0 required](https://img.shields.io/badge/rust-1.91.0-blue.svg?label=MSRV)
 ![GitHub commits (since latest release)](https://img.shields.io/github/commits-since/zaidoon1/rust-rocksdb/latest.svg)
 [![dependency status](https://deps.rs/repo/github/zaidoon1/rust-rocksdb/status.svg)](https://deps.rs/repo/github/zaidoon1/rust-rocksdb)
 
@@ -25,7 +25,7 @@ RocksDB is a fast key-value storage engine based on LSM-trees, optimized for SSD
 
 **Requirements:**
 - **Clang and LLVM** - Required for building RocksDB C++ components
-- **Rust 1.89.0+** - Current MSRV (rolling 6-month policy)
+- **Rust 1.91.0+** - Current MSRV (rolling 6-month policy)
 
 Add this to your `Cargo.toml`:
 
@@ -430,7 +430,7 @@ Crates that depend on `rust-librocksdb-sys` and want access to its outputs can r
 
 Feedback and pull requests welcome! Open an issue for feature requests or submit PRs. This fork maintains regular updates with latest RocksDB releases and Rust versions.
 
-**Current MSRV**: 1.89.0 (rolling 6-month policy)
+**Current MSRV**: 1.91.0 (rolling 6-month policy)
 
 ## ❓ Why This Fork
 

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rust-librocksdb-sys"
 version = "0.45.1+11.1.1"
 edition = "2024"
-rust-version = "1.89.0"
+rust-version = "1.91.0"
 authors = [
     "Karl Hobley <karlhobley10@gmail.com>",
     "Arkadiy Paronyan <arkadiy@ethcore.io>",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.91.0"


### PR DESCRIPTION
1.91.0 (released 2025-10-30) is the most recent stable that satisfies the rolling 6-month MSRV policy. No critical compiler bugs, soundness fixes, or security advisories in 1.92+ apply to this codebase:

- 1.91.1 patches (illumos file locking, WASM cross-crate) don't apply
- 1.93 Copy specialization soundness fix doesn't affect FFI wrappers
- CVE-2026-33055/56 in 1.94.1 is in Cargo's tar dep; crates.io users unaffected, and MSRV doesn't gate Cargo version anyway