### PR TITLE
Re-export accidentally-private types from the crate root

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+- fix: re-export two public types that were defined in private
+  modules but appeared in the return type of a `pub` function in the
+  crate-root surface, making them effectively unnameable by downstream
+  callers (zaidoon1/rust-rocksdb#224):
+  - `ColumnFamilyMetaData` — return type of
+    `DB::get_column_family_metadata{,_cf}`. Users need this to store
+    or pass the metadata through their own code.
+  - `CSlice` — returned wrapped in `(bool, Option<CSlice>)` by the
+    `key_may_exist_*_pinned_value` helpers. Users who want to hold
+    onto the pinned value past the immediate call site need the name.
+  A new `tests/test_public_api.rs` compile-checks both imports so a
+  future accidental un-export fails the test build rather than only
+  surfacing in downstream user reports. Thanks to JadedBlueEyes for
+  the report. (zaidoon1)
 - feat(librocksdb-sys): add local C-API extensions for RocksDB C++
   features that have no upstream C wrapper yet. Two new files in
   `librocksdb-sys/c-api-extensions/` (`c_api_extensions.h` and

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,8 +120,9 @@ pub use crate::{
     },
     compaction_filter::Decision as CompactionDecision,
     db::{
-        DB, DBAccess, DBCommon, DBWithThreadMode, ExportImportFilesMetaData, GetIntoBufferResult,
-        LiveFile, MultiThreaded, PrefixProber, Range, SingleThreaded, ThreadMode,
+        ColumnFamilyMetaData, DB, DBAccess, DBCommon, DBWithThreadMode, ExportImportFilesMetaData,
+        GetIntoBufferResult, LiveFile, MultiThreaded, PrefixProber, Range, SingleThreaded,
+        ThreadMode,
     },
     db_iterator::{
         DBIterator, DBIteratorWithThreadMode, DBRawIterator, DBRawIteratorWithThreadMode,
@@ -138,7 +139,7 @@ pub use crate::{
     },
     db_pinnable_slice::DBPinnableSlice,
     env::Env,
-    ffi_util::CStrLike,
+    ffi_util::{CSlice, CStrLike},
     iter_range::{IterateBounds, PrefixRange},
     merge_operator::MergeOperands,
     perf::{PerfContext, PerfMetric, PerfStatsLevel},

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -22,12 +22,13 @@ use std::{sync::Arc, thread, time::Duration};
 
 use rust_rocksdb::statistics::{Histogram, StatsLevel, Ticker};
 use rust_rocksdb::{
-    BlockBasedOptions, BottommostLevelCompaction, Cache, ColumnFamilyDescriptor, ColumnFamilyTtl,
-    CompactOptions, CuckooTableOptions, DB, DBAccess, DBCompactionStyle, DBWithThreadMode,
-    DEFAULT_COLUMN_FAMILY_NAME, Env, Error, ErrorKind, FifoCompactOptions, IteratorMode,
-    MultiThreaded, Options, PerfContext, PerfMetric, RateLimiterMode, ReadOptions, SingleThreaded,
-    SliceTransform, Snapshot, UniversalCompactOptions, UniversalCompactionStopStyle,
-    WaitForCompactOptions, WriteBatch, perf::get_memory_usage_stats,
+    BlockBasedOptions, BottommostLevelCompaction, Cache, ColumnFamilyDescriptor,
+    ColumnFamilyMetaData, ColumnFamilyTtl, CompactOptions, CuckooTableOptions, DB, DBAccess,
+    DBCompactionStyle, DBWithThreadMode, DEFAULT_COLUMN_FAMILY_NAME, Env, Error, ErrorKind,
+    FifoCompactOptions, IteratorMode, MultiThreaded, Options, PerfContext, PerfMetric,
+    RateLimiterMode, ReadOptions, SingleThreaded, SliceTransform, Snapshot,
+    UniversalCompactOptions, UniversalCompactionStopStyle, WaitForCompactOptions, WriteBatch,
+    perf::get_memory_usage_stats,
 };
 use util::{DBPath, U64Comparator, U64Timestamp, assert_iter, pair};
 
@@ -439,12 +440,16 @@ fn set_column_family_metadata_test() {
         db.flush_cf(&cf1).unwrap();
         db.flush_cf(&cf2).unwrap();
 
-        let default_cf_metadata = db.get_column_family_metadata();
-        assert_eq!(default_cf_metadata.size > 150, true);
+        // Annotate the return type to lock in that `ColumnFamilyMetaData`
+        // is reachable from the crate root, not just inside the crate (see
+        // zaidoon1/rust-rocksdb#224). A regression where the re-export is
+        // dropped would fail to compile here.
+        let default_cf_metadata: ColumnFamilyMetaData = db.get_column_family_metadata();
+        assert!(default_cf_metadata.size > 150);
         assert_eq!(default_cf_metadata.file_count, 1);
 
-        let cf2_metadata = db.get_column_family_metadata_cf(&cf2);
-        assert_eq!(cf2_metadata.size > default_cf_metadata.size, true);
+        let cf2_metadata: ColumnFamilyMetaData = db.get_column_family_metadata_cf(&cf2);
+        assert!(cf2_metadata.size > default_cf_metadata.size);
         assert_eq!(cf2_metadata.file_count, 1);
     }
 }

--- a/tests/test_public_api.rs
+++ b/tests/test_public_api.rs
@@ -1,0 +1,37 @@
+// Regression test for types that were defined as `pub` in a private
+// module but were missing from the crate-root re-export surface, even
+// though they appear in the return type of a `pub` function downstream
+// users call. Without these re-exports, callers can't name the type to
+// store it, pass it through their own functions, or destructure it
+// explicitly (see zaidoon1/rust-rocksdb#224).
+//
+// The test body is empty — the imports themselves are the test. A
+// future accidental un-export of either type will fail the build of
+// this test rather than only surfacing in a downstream user report.
+//
+// We deliberately do NOT include every `pub` type from every private
+// module here: only types that genuinely block real user code patterns
+// when missing. Types that users can work around with inference (for
+// loops, pattern matching) or by spelling out the underlying type
+// (`(Box<[u8]>, Box<[u8]>)` instead of an alias, `fn(&[u8]) -> &[u8]`
+// instead of an alias) are intentionally NOT re-exported, to keep the
+// public API surface small.
+
+#[allow(unused_imports)]
+use rust_rocksdb::{
+    // Return type of `DB::get_column_family_metadata{,_cf}`.
+    CSlice,
+    // Returned wrapped in `(bool, Option<CSlice>)` by the
+    // `key_may_exist_*_pinned_value` helpers. Users who want to hold
+    // onto the pinned value past the immediate call site need the name.
+    ColumnFamilyMetaData,
+};
+
+#[test]
+fn newly_exported_types_resolve() {
+    // The use-block above is the real test; this assertion is just to
+    // make the test visible in `cargo test` output so a regression is
+    // obvious in CI logs.
+    let _ = std::any::type_name::<ColumnFamilyMetaData>();
+    let _ = std::any::type_name::<CSlice>();
+}


### PR DESCRIPTION
## Summary

Closes #224.

Two types were defined as `pub` in private modules but appeared in the
return type of a `pub` function reachable from the crate root, so
downstream callers could not name them. This PR re-exports them from
`src/lib.rs`:

| Type | Why users need it |
|---|---|
| `ColumnFamilyMetaData` | Return type of `DB::get_column_family_metadata{,_cf}`. Users need the name to store the metadata, pass it through their own functions, or annotate it explicitly. The reported case. |
| `CSlice` | Returned wrapped in `(bool, Option<CSlice>)` by the `key_may_exist_*_pinned_value` helpers. Users who choose the pinned variant want to hold onto the slice past the immediate call site, which requires the name. |

## Tests

- New `tests/test_public_api.rs` imports both types by name. The test
  body is empty — the imports themselves are the regression check, and
  a future accidental un-export fails the test build rather than only
  surfacing in downstream user reports.
- The existing metadata test in `tests/test_db.rs` is extended with
  explicit `let metadata: ColumnFamilyMetaData = ...` annotations as a
  second line of defence (the previous version stored the return value
  without naming the type, which is why the broken re-export went
  unnoticed).

## Deliberately NOT re-exported

I went through every `pub` type in every private module and judged each
against the question "does a real downstream caller need to name this?".
The following are `pub` in their module but kept un-exported on
purpose, to keep the public API surface small:

- `DBInner` — public trait used as a bound on `DBCommon<T, D: DBInner>`.
  Users almost never write code generic over `D`; they use `DB` or
  `TransactionDB` directly. The traits only method returns a raw FFI
  pointer thats only useful from inside the crate.
- `KVBytes` — type alias for `(Box<[u8]>, Box<[u8]>)`. Iterator users
  get it via inference (`for kv in iter`) without ever naming the
  alias; code that does need a name can spell out the underlying tuple.
- `InDomainFn`, `TransformFn` — function-pointer aliases passed to
  `SliceTransform::create`. Users write the function pointer types
  directly (`fn(&[u8]) -> &[u8]`, `fn(&[u8]) -> bool`) without needing
  the aliases.
- `TransformCallback` — internal FFI marshalling helper, only used
  inside its own module. Marked `pub` but not part of any public
  signature.
- `DBWithThreadModeInner`, `OptimisticTransactionDBInner` — concrete
  types only referenced via the type aliases users actually consume
  (`DBWithThreadMode<T>`, `OptimisticTransactionDB`); downstream code
  does not need to name them.

Thanks to @JadedBlueEyes for the original report.