### PR TITLE
Release 0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,15 @@
 # Changelog
 
-## Unreleased
+## 0.50.0 (2026-05-23)
 
+- breaking: bump MSRV to 1.91.0 per the rolling 6-month policy. 1.91.0
+  was released 2025-10-30, the most recent stable that satisfied the
+  6-month window at the time of the bump. No critical compiler bugs
+  or soundness fixes in 1.92+ apply to this codebase. (zaidoon1)
+- feat: implement `AsRawPtr<rocksdb_t>` for `OptimisticTransactionDB<T>`
+  (gated on the `raw-ptr` feature). Returns the underlying base DB
+  pointer for advanced C-API use cases such as verifying file
+  checksums directly. (ksurent)
 - fix: re-export two public types that were defined in private
   modules but appeared in the return type of a `pub` function in the
   crate-root surface, making them effectively unnameable by downstream

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.49.1"
+version = "0.50.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = [
@@ -45,7 +45,7 @@ raw-ptr = []
 
 [dependencies]
 libc = "0.2"
-rust-librocksdb-sys = { path = "librocksdb-sys", version = "0.45.1", default-features = false, features = [
+rust-librocksdb-sys = { path = "librocksdb-sys", version = "0.46.0", default-features = false, features = [
     "static",
 ] }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-librocksdb-sys"
-version = "0.45.1+11.1.1"
+version = "0.46.0+11.1.1"
 edition = "2024"
 rust-version = "1.91.0"
 authors = [


### PR DESCRIPTION
## Versions

- `rust-rocksdb`: 0.49.1 → **0.50.0**
- `rust-librocksdb-sys`: 0.45.1+11.1.1 → **0.46.0+11.1.1**

The minor bump is justified by the MSRV change (1.89 → 1.91), which is
technically breaking for users on older Rust toolchains.

## What is in this release

(Full notes in `CHANGELOG.md`.)

### Breaking

- **MSRV bumped to 1.91.0** per the rolling 6-month policy. 1.91.0 was
  released 2025-10-30, the most recent stable that satisfied the
  6-month window at the time of the bump.

### Features

- **`librocksdb-sys`: local C-API extensions** for three RocksDB C++
  options that have no upstream C wrapper yet
  (`optimize_multiget_for_io`, `uniform_cv_threshold` + `kAuto`,
  `memtable_batch_lookup_optimization`). The extensions live in
  `librocksdb-sys/c-api-extensions/` and compile additively alongside
  the vendored RocksDB sources; the submodule is never modified, so
  the build works on read-only source trees and needs no extra tools
  beyond the C++ compiler.
- **`rust-rocksdb`: three matching safe-Rust setters** (plus getters
  for the two `bool` options):
  - `BlockBasedOptions::set_index_block_search_type(IndexBlockSearchType)`
    + new `IndexBlockSearchType` enum (`Binary`, `Interpolation`,
    `Auto`).
  - `BlockBasedOptions::set_uniform_cv_threshold(f64)`.
  - `Options::{set,get}_memtable_batch_lookup_optimization(bool)`.
  - `ReadOptions::{set,get}_optimize_multiget_for_io(bool)`.
- **`AsRawPtr<rocksdb_t>` impl for `OptimisticTransactionDB<T>`**
  (gated on the `raw-ptr` feature), by @ksurent.

### Fixes

- Re-export `ColumnFamilyMetaData` and `CSlice` from the crate root
  (#224, thanks to @JadedBlueEyes).

## Upstream coordination

The three C-API extensions each have a matching PR open against
`facebook/rocksdb`. When upstream merges any of them and we bump the
submodule to a release containing it, the corresponding declaration in
`c_api_extensions.h` and definition in `c_api_extensions.cc` will be
dropped.

- `optimize_multiget_for_io`: [facebook/rocksdb#14752](https://github.com/facebook/rocksdb/pull/14752)
- `uniform_cv_threshold` + `kAuto`: [facebook/rocksdb#14775](https://github.com/facebook/rocksdb/pull/14775)
- `memtable_batch_lookup_optimization`: [facebook/rocksdb#14776](https://github.com/facebook/rocksdb/pull/14776)

## Verifications run

- `cargo fmt --all -- --check` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test --doc` — 10 passed
- `cargo test --test test_public_api` — 1 passed
- `cargo check` against the new version numbers — succeeds