### PR TITLE
Add CompactOptions::set_blob_garbage_collection_age_cutoff

### DIFF
--- a/librocksdb-sys/c-api-extensions/c_api_extensions.cc
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.cc
@@ -13,6 +13,7 @@
 #include "rocksdb/table.h"
 
 using ROCKSDB_NAMESPACE::BlockBasedTableOptions;
+using ROCKSDB_NAMESPACE::CompactRangeOptions;
 using ROCKSDB_NAMESPACE::Options;
 using ROCKSDB_NAMESPACE::ReadOptions;
 
@@ -79,4 +80,18 @@ extern "C" void rocksdb_options_set_memtable_batch_lookup_optimization(
 extern "C" unsigned char rocksdb_options_get_memtable_batch_lookup_optimization(
     rocksdb_options_t* opt) {
   return reinterpret_cast<Options*>(opt)->memtable_batch_lookup_optimization;
+}
+
+// -----------------------------------------------------------------------------
+// CompactOptions::blob_garbage_collection_age_cutoff
+// -----------------------------------------------------------------------------
+
+extern "C" void rocksdb_compactoptions_set_blob_garbage_collection_age_cutoff(
+    rocksdb_compactoptions_t* opt, double v) {
+  reinterpret_cast<CompactRangeOptions*>(opt)->blob_garbage_collection_age_cutoff = v;
+}
+
+extern "C" double rocksdb_compactoptions_get_blob_garbage_collection_age_cutoff(
+    rocksdb_compactoptions_t* opt) {
+  return reinterpret_cast<CompactRangeOptions*>(opt)->blob_garbage_collection_age_cutoff;
 }

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.h
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.h
@@ -77,6 +77,17 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_memtable_batch_lookup_optimi
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_memtable_batch_lookup_optimization(
     rocksdb_options_t*);
 
+/* -------------------------------------------------------------------------
+ * CompactOptions::blob_garbage_collection_age_cutoff
+ *
+ * Sets the blob_garbage_collection_age_cutoff parameters on manual
+ * compactions. Matches upstream PR facebook/rocksdb#14768.
+ * ------------------------------------------------------------------------- */
+extern ROCKSDB_LIBRARY_API void rocksdb_compactoptions_set_blob_garbage_collection_age_cutoff(
+    rocksdb_compactoptions_t*, double);
+extern ROCKSDB_LIBRARY_API double rocksdb_compactoptions_get_blob_garbage_collection_age_cutoff(
+    rocksdb_compactoptions_t*);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -5068,10 +5068,18 @@ impl CompactOptions {
         }
     }
 
-    /// If set to < 0 or > 1, RocksDB leaves blob_garbage_collection_age_cutoff
-    /// from ColumnFamilyOptions in effect. Otherwise, it will override the
-    /// user-provided setting. This enables customers to selectively override the
-    /// age cutoff.
+    /// Override `CompactRangeOptions::blob_garbage_collection_age_cutoff` for a
+    /// single manual compaction.
+    ///
+    /// If set to `< 0` or `> 1`, RocksDB leaves the
+    /// `blob_garbage_collection_age_cutoff` from `ColumnFamilyOptions` in
+    /// effect (this is the default, `-1`). Otherwise, it overrides the
+    /// user-provided setting for the duration of this compaction. This
+    /// enables callers to selectively override the age cutoff per
+    /// `compact_range` call.
+    ///
+    /// See [`Options::set_blob_gc_age_cutoff`] for the CF-level setter that
+    /// this value overrides.
     pub fn set_blob_garbage_collection_age_cutoff(&mut self, v: c_double) {
         unsafe {
             ffi::rocksdb_compactoptions_set_blob_garbage_collection_age_cutoff(self.inner, v);

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -5067,6 +5067,16 @@ impl CompactOptions {
             ffi::rocksdb_compactoptions_set_full_history_ts_low(self.inner, ptr, len);
         }
     }
+
+    /// If set to < 0 or > 1, RocksDB leaves blob_garbage_collection_age_cutoff
+    /// from ColumnFamilyOptions in effect. Otherwise, it will override the
+    /// user-provided setting. This enables customers to selectively override the
+    /// age cutoff.
+    pub fn set_blob_garbage_collection_age_cutoff(&mut self, v: c_double) {
+        unsafe {
+            ffi::rocksdb_compactoptions_set_blob_garbage_collection_age_cutoff(self.inner, v);
+        }
+    }
 }
 
 pub struct WaitForCompactOptions {

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -851,6 +851,7 @@ fn compact_range_test() {
         compact_opts.set_target_level(1);
         compact_opts.set_change_level(true);
         compact_opts.set_bottommost_level_compaction(BottommostLevelCompaction::ForceOptimized);
+        compact_opts.set_blob_garbage_collection_age_cutoff(0.5);
 
         // put and compact column family cf1
         let cfs = vec!["cf1"];


### PR DESCRIPTION
Exposing these missing options in the C API extensions until https://github.com/facebook/rocksdb/pull/14768 is merged.