### PR TITLE
Expose EventListener error recovery status

### DIFF
--- a/librocksdb-sys/c-api-extensions/c_api_extensions.cc
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.cc
@@ -2,20 +2,275 @@
 // rationale and the list of extensions; this file just defines the
 // declarations from that header.
 //
-// Each extension function is the smallest possible delta over the existing
-// C API: a setter (or setter/getter pair) that exposes one C++ option
-// field. The implementations are intentionally identical in shape to the
-// upstream C wrappers they would replace once the matching PR lands.
+// Each extension is the smallest practical delta over the existing C API:
+// either an option setter/getter pair or a thin wrapper over an upstream C++
+// callback surface that has not reached rocksdb/c.h yet.
 
 #include "c_api_extensions.h"
 
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <memory>
+#include <string>
+
+#include "rocksdb/listener.h"
 #include "rocksdb/options.h"
 #include "rocksdb/table.h"
 
+using ROCKSDB_NAMESPACE::BackgroundErrorRecoveryInfo;
 using ROCKSDB_NAMESPACE::BlockBasedTableOptions;
 using ROCKSDB_NAMESPACE::CompactRangeOptions;
+using ROCKSDB_NAMESPACE::CompactionJobInfo;
+using ROCKSDB_NAMESPACE::DB;
+using ROCKSDB_NAMESPACE::EventListener;
+using ROCKSDB_NAMESPACE::ExternalFileIngestionInfo;
+using ROCKSDB_NAMESPACE::FlushJobInfo;
 using ROCKSDB_NAMESPACE::Options;
 using ROCKSDB_NAMESPACE::ReadOptions;
+using ROCKSDB_NAMESPACE::Status;
+using ROCKSDB_NAMESPACE::SubcompactionJobInfo;
+using ROCKSDB_NAMESPACE::WriteStallInfo;
+using ROCKSDB_NAMESPACE::MemTableInfo;
+
+struct rust_rocksdb_status_t {
+  Status* rep;
+};
+
+struct rust_rocksdb_background_error_recovery_info_t {
+  const BackgroundErrorRecoveryInfo* rep;
+};
+
+static bool RustSaveError(char** errptr, const Status& s) {
+  assert(errptr != nullptr);
+  if (s.ok()) {
+    return false;
+  }
+
+  std::string message = s.ToString();
+  char* copy = static_cast<char*>(std::malloc(message.size() + 1));
+  if (copy != nullptr) {
+    std::memcpy(copy, message.c_str(), message.size() + 1);
+  }
+
+  if (*errptr != nullptr) {
+    std::free(*errptr);
+  }
+  *errptr = copy;
+  return true;
+}
+
+extern "C" void rust_rocksdb_status_get_error(rust_rocksdb_status_t* status,
+                                               char** errptr) {
+  RustSaveError(errptr, *(status->rep));
+}
+
+extern "C" unsigned char rust_rocksdb_status_get_severity(
+    rust_rocksdb_status_t* status) {
+  return static_cast<unsigned char>(status->rep->severity());
+}
+
+extern "C" void rust_rocksdb_status_reset(rust_rocksdb_status_t* status) {
+  *(status->rep) = Status::OK();
+}
+
+extern "C" void rust_rocksdb_background_error_recovery_info_old_bg_error(
+    const rust_rocksdb_background_error_recovery_info_t* info, char** errptr) {
+  RustSaveError(errptr, info->rep->old_bg_error);
+}
+
+extern "C" unsigned char
+rust_rocksdb_background_error_recovery_info_old_bg_error_severity(
+    const rust_rocksdb_background_error_recovery_info_t* info) {
+  return static_cast<unsigned char>(info->rep->old_bg_error.severity());
+}
+
+extern "C" void rust_rocksdb_background_error_recovery_info_new_bg_error(
+    const rust_rocksdb_background_error_recovery_info_t* info, char** errptr) {
+  RustSaveError(errptr, info->rep->new_bg_error);
+}
+
+extern "C" unsigned char
+rust_rocksdb_background_error_recovery_info_new_bg_error_severity(
+    const rust_rocksdb_background_error_recovery_info_t* info) {
+  return static_cast<unsigned char>(info->rep->new_bg_error.severity());
+}
+
+struct rust_rocksdb_eventlistener_t : public EventListener {
+  void* state{};
+  void (*destructor)(void*){};
+  rust_rocksdb_on_flush_begin_cb on_flush_begin{};
+  rust_rocksdb_on_flush_completed_cb on_flush_completed{};
+  rust_rocksdb_on_compaction_begin_cb on_compaction_begin{};
+  rust_rocksdb_on_compaction_completed_cb on_compaction_completed{};
+  rust_rocksdb_on_subcompaction_begin_cb on_subcompaction_begin{};
+  rust_rocksdb_on_subcompaction_completed_cb on_subcompaction_completed{};
+  rust_rocksdb_on_external_file_ingested_cb on_external_file_ingested{};
+  rust_rocksdb_on_background_error_cb on_background_error{};
+  rust_rocksdb_on_error_recovery_begin_cb on_error_recovery_begin{};
+  rust_rocksdb_on_error_recovery_end_cb on_error_recovery_end{};
+  rust_rocksdb_on_stall_conditions_changed_cb on_stall_conditions_changed{};
+  rust_rocksdb_on_memtable_sealed_cb on_memtable_sealed{};
+
+  rust_rocksdb_eventlistener_t() = default;
+
+  rust_rocksdb_eventlistener_t(const rust_rocksdb_eventlistener_t&) = delete;
+  rust_rocksdb_eventlistener_t& operator=(
+      const rust_rocksdb_eventlistener_t&) = delete;
+  rust_rocksdb_eventlistener_t(rust_rocksdb_eventlistener_t&&) = delete;
+  rust_rocksdb_eventlistener_t& operator=(rust_rocksdb_eventlistener_t&&) =
+      delete;
+
+  void OnFlushBegin(DB* /*db*/, const FlushJobInfo& info) override {
+    if (on_flush_begin != nullptr) {
+      on_flush_begin(state,
+                     reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    }
+  }
+
+  void OnFlushCompleted(DB* /*db*/, const FlushJobInfo& info) override {
+    if (on_flush_completed != nullptr) {
+      on_flush_completed(
+          state, reinterpret_cast<const rocksdb_flushjobinfo_t*>(&info));
+    }
+  }
+
+  void OnCompactionBegin(DB* /*db*/, const CompactionJobInfo& info) override {
+    if (on_compaction_begin != nullptr) {
+      on_compaction_begin(
+          state, reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    }
+  }
+
+  void OnCompactionCompleted(DB* /*db*/, const CompactionJobInfo& info)
+      override {
+    if (on_compaction_completed != nullptr) {
+      on_compaction_completed(
+          state, reinterpret_cast<const rocksdb_compactionjobinfo_t*>(&info));
+    }
+  }
+
+  void OnSubcompactionBegin(const SubcompactionJobInfo& info) override {
+    if (on_subcompaction_begin != nullptr) {
+      on_subcompaction_begin(
+          state,
+          reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    }
+  }
+
+  void OnSubcompactionCompleted(const SubcompactionJobInfo& info) override {
+    if (on_subcompaction_completed != nullptr) {
+      on_subcompaction_completed(
+          state,
+          reinterpret_cast<const rocksdb_subcompactionjobinfo_t*>(&info));
+    }
+  }
+
+  void OnExternalFileIngested(DB* /*db*/,
+                              const ExternalFileIngestionInfo& info) override {
+    if (on_external_file_ingested != nullptr) {
+      on_external_file_ingested(
+          state,
+          reinterpret_cast<const rocksdb_externalfileingestioninfo_t*>(&info));
+    }
+  }
+
+  void OnBackgroundError(ROCKSDB_NAMESPACE::BackgroundErrorReason reason,
+                         Status* status) override {
+    if (on_background_error != nullptr) {
+      rust_rocksdb_status_t s = {status};
+      on_background_error(state, static_cast<uint32_t>(reason), &s);
+    }
+  }
+
+  void OnErrorRecoveryBegin(ROCKSDB_NAMESPACE::BackgroundErrorReason reason,
+                            Status bg_error,
+                            bool* auto_recovery) override {
+    if (on_error_recovery_begin != nullptr) {
+      rust_rocksdb_status_t s = {&bg_error};
+      unsigned char auto_recovery_value =
+          auto_recovery != nullptr && *auto_recovery;
+      on_error_recovery_begin(state, static_cast<uint32_t>(reason), &s,
+                              &auto_recovery_value);
+      if (auto_recovery != nullptr) {
+        *auto_recovery = auto_recovery_value != 0;
+      }
+    }
+    bg_error.PermitUncheckedError();
+  }
+
+  void OnErrorRecoveryEnd(const BackgroundErrorRecoveryInfo& info) override {
+    if (on_error_recovery_end != nullptr) {
+      rust_rocksdb_background_error_recovery_info_t c_info = {&info};
+      on_error_recovery_end(state, &c_info);
+    }
+    info.old_bg_error.PermitUncheckedError();
+    info.new_bg_error.PermitUncheckedError();
+  }
+
+  void OnStallConditionsChanged(const WriteStallInfo& info) override {
+    if (on_stall_conditions_changed != nullptr) {
+      on_stall_conditions_changed(
+          state, reinterpret_cast<const rocksdb_writestallinfo_t*>(&info));
+    }
+  }
+
+  void OnMemTableSealed(const MemTableInfo& info) override {
+    if (on_memtable_sealed != nullptr) {
+      on_memtable_sealed(
+          state, reinterpret_cast<const rocksdb_memtableinfo_t*>(&info));
+    }
+  }
+
+  ~rust_rocksdb_eventlistener_t() override {
+    if (destructor != nullptr) {
+      destructor(state);
+    }
+  }
+};
+
+extern "C" rust_rocksdb_eventlistener_t* rust_rocksdb_eventlistener_create(
+    void* state, void (*destructor)(void*),
+    rust_rocksdb_on_flush_begin_cb on_flush_begin,
+    rust_rocksdb_on_flush_completed_cb on_flush_completed,
+    rust_rocksdb_on_compaction_begin_cb on_compaction_begin,
+    rust_rocksdb_on_compaction_completed_cb on_compaction_completed,
+    rust_rocksdb_on_subcompaction_begin_cb on_subcompaction_begin,
+    rust_rocksdb_on_subcompaction_completed_cb on_subcompaction_completed,
+    rust_rocksdb_on_external_file_ingested_cb on_external_file_ingested,
+    rust_rocksdb_on_background_error_cb on_background_error,
+    rust_rocksdb_on_error_recovery_begin_cb on_error_recovery_begin,
+    rust_rocksdb_on_error_recovery_end_cb on_error_recovery_end,
+    rust_rocksdb_on_stall_conditions_changed_cb on_stall_conditions_changed,
+    rust_rocksdb_on_memtable_sealed_cb on_memtable_sealed) {
+  rust_rocksdb_eventlistener_t* listener = new rust_rocksdb_eventlistener_t;
+  listener->state = state;
+  listener->destructor = destructor;
+  listener->on_flush_begin = on_flush_begin;
+  listener->on_flush_completed = on_flush_completed;
+  listener->on_compaction_begin = on_compaction_begin;
+  listener->on_compaction_completed = on_compaction_completed;
+  listener->on_subcompaction_begin = on_subcompaction_begin;
+  listener->on_subcompaction_completed = on_subcompaction_completed;
+  listener->on_external_file_ingested = on_external_file_ingested;
+  listener->on_background_error = on_background_error;
+  listener->on_error_recovery_begin = on_error_recovery_begin;
+  listener->on_error_recovery_end = on_error_recovery_end;
+  listener->on_stall_conditions_changed = on_stall_conditions_changed;
+  listener->on_memtable_sealed = on_memtable_sealed;
+  return listener;
+}
+
+extern "C" void rust_rocksdb_eventlistener_destroy(
+    rust_rocksdb_eventlistener_t* listener) {
+  delete listener;
+}
+
+extern "C" void rust_rocksdb_options_add_eventlistener(
+    rocksdb_options_t* opt, rust_rocksdb_eventlistener_t* listener) {
+  reinterpret_cast<Options*>(opt)->listeners.emplace_back(
+      std::shared_ptr<EventListener>(listener));
+}
 
 // The opaque-handle types the C API hands out are defined at file scope in
 // `rocksdb/db/c.cc` as POD wrappers around a single C++ class:

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.h
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.h
@@ -88,6 +88,82 @@ extern ROCKSDB_LIBRARY_API void rocksdb_compactoptions_set_blob_garbage_collecti
 extern ROCKSDB_LIBRARY_API double rocksdb_compactoptions_get_blob_garbage_collection_age_cutoff(
     rocksdb_compactoptions_t*);
 
+/* -------------------------------------------------------------------------
+ * EventListener background error status severity and recovery callbacks
+ *
+ * RocksDB's C++ EventListener exposes Status::Severity on background errors
+ * and has callbacks for the automatic error recovery lifecycle. The upstream
+ * C listener wrapper available to this crate only forwards OnBackgroundError,
+ * so the Rust listener uses this local additive wrapper instead of changing
+ * the upstream rocksdb_eventlistener_create ABI.
+ * ------------------------------------------------------------------------- */
+typedef struct rust_rocksdb_status_t rust_rocksdb_status_t;
+typedef struct rust_rocksdb_eventlistener_t rust_rocksdb_eventlistener_t;
+typedef struct rust_rocksdb_background_error_recovery_info_t
+    rust_rocksdb_background_error_recovery_info_t;
+
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_status_get_error(
+    rust_rocksdb_status_t*, char**);
+extern ROCKSDB_LIBRARY_API unsigned char rust_rocksdb_status_get_severity(
+    rust_rocksdb_status_t*);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_status_reset(
+    rust_rocksdb_status_t*);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_background_error_recovery_info_old_bg_error(
+    const rust_rocksdb_background_error_recovery_info_t*, char**);
+extern ROCKSDB_LIBRARY_API unsigned char
+rust_rocksdb_background_error_recovery_info_old_bg_error_severity(
+    const rust_rocksdb_background_error_recovery_info_t*);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_background_error_recovery_info_new_bg_error(
+    const rust_rocksdb_background_error_recovery_info_t*, char**);
+extern ROCKSDB_LIBRARY_API unsigned char
+rust_rocksdb_background_error_recovery_info_new_bg_error_severity(
+    const rust_rocksdb_background_error_recovery_info_t*);
+
+typedef void (*rust_rocksdb_on_flush_begin_cb)(
+    void*, const rocksdb_flushjobinfo_t*);
+typedef void (*rust_rocksdb_on_flush_completed_cb)(
+    void*, const rocksdb_flushjobinfo_t*);
+typedef void (*rust_rocksdb_on_compaction_begin_cb)(
+    void*, const rocksdb_compactionjobinfo_t*);
+typedef void (*rust_rocksdb_on_compaction_completed_cb)(
+    void*, const rocksdb_compactionjobinfo_t*);
+typedef void (*rust_rocksdb_on_subcompaction_begin_cb)(
+    void*, const rocksdb_subcompactionjobinfo_t*);
+typedef void (*rust_rocksdb_on_subcompaction_completed_cb)(
+    void*, const rocksdb_subcompactionjobinfo_t*);
+typedef void (*rust_rocksdb_on_external_file_ingested_cb)(
+    void*, const rocksdb_externalfileingestioninfo_t*);
+typedef void (*rust_rocksdb_on_background_error_cb)(
+    void*, uint32_t, rust_rocksdb_status_t*);
+typedef void (*rust_rocksdb_on_error_recovery_begin_cb)(
+    void*, uint32_t, rust_rocksdb_status_t*, unsigned char*);
+typedef void (*rust_rocksdb_on_error_recovery_end_cb)(
+    void*, const rust_rocksdb_background_error_recovery_info_t*);
+typedef void (*rust_rocksdb_on_stall_conditions_changed_cb)(
+    void*, const rocksdb_writestallinfo_t*);
+typedef void (*rust_rocksdb_on_memtable_sealed_cb)(
+    void*, const rocksdb_memtableinfo_t*);
+
+extern ROCKSDB_LIBRARY_API rust_rocksdb_eventlistener_t*
+rust_rocksdb_eventlistener_create(
+    void* state, void (*destructor)(void*),
+    rust_rocksdb_on_flush_begin_cb on_flush_begin,
+    rust_rocksdb_on_flush_completed_cb on_flush_completed,
+    rust_rocksdb_on_compaction_begin_cb on_compaction_begin,
+    rust_rocksdb_on_compaction_completed_cb on_compaction_completed,
+    rust_rocksdb_on_subcompaction_begin_cb on_subcompaction_begin,
+    rust_rocksdb_on_subcompaction_completed_cb on_subcompaction_completed,
+    rust_rocksdb_on_external_file_ingested_cb on_external_file_ingested,
+    rust_rocksdb_on_background_error_cb on_background_error,
+    rust_rocksdb_on_error_recovery_begin_cb on_error_recovery_begin,
+    rust_rocksdb_on_error_recovery_end_cb on_error_recovery_end,
+    rust_rocksdb_on_stall_conditions_changed_cb on_stall_conditions_changed,
+    rust_rocksdb_on_memtable_sealed_cb on_memtable_sealed);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_eventlistener_destroy(
+    rust_rocksdb_eventlistener_t*);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_options_add_eventlistener(
+    rocksdb_options_t*, rust_rocksdb_eventlistener_t*);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1786,7 +1786,7 @@ impl Options {
 
     pub fn add_event_listener<L: EventListener>(&mut self, l: L) {
         let handle = new_event_listener(l);
-        unsafe { ffi::rocksdb_options_add_eventlistener(self.inner, handle.inner) }
+        unsafe { ffi::rust_rocksdb_options_add_eventlistener(self.inner, handle.inner) }
     }
 
     /// This is a factory that provides compaction filter objects which allow

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -196,6 +196,7 @@ pub enum DBBackgroundErrorReason {
     KManifestWrite = 4,
     KFlushNoWAL = 5,
     KManifestWriteNoWAL = 6,
+    KAsyncFileOpen = 7,
     KUnknown, // not an actual background error reason but will be used when we don't recognize the enum value
 }
 
@@ -209,7 +210,35 @@ impl From<u32> for DBBackgroundErrorReason {
             4 => DBBackgroundErrorReason::KManifestWrite,
             5 => DBBackgroundErrorReason::KFlushNoWAL,
             6 => DBBackgroundErrorReason::KManifestWriteNoWAL,
+            7 => DBBackgroundErrorReason::KAsyncFileOpen,
             _ => DBBackgroundErrorReason::KUnknown,
+        }
+    }
+}
+
+/// Severity carried by RocksDB's background error `Status`.
+#[derive(Copy, Clone, Debug, Eq, Ord, PartialEq, PartialOrd)]
+#[repr(u8)]
+pub enum StatusSeverity {
+    KNoError = 0,
+    KSoftError = 1,
+    KHardError = 2,
+    KFatalError = 3,
+    KUnrecoverableError = 4,
+    KMaxSeverity = 5,
+    KUnknown,
+}
+
+impl From<u8> for StatusSeverity {
+    fn from(value: u8) -> Self {
+        match value {
+            0 => StatusSeverity::KNoError,
+            1 => StatusSeverity::KSoftError,
+            2 => StatusSeverity::KHardError,
+            3 => StatusSeverity::KFatalError,
+            4 => StatusSeverity::KUnrecoverableError,
+            5 => StatusSeverity::KMaxSeverity,
+            _ => StatusSeverity::KUnknown,
         }
     }
 }
@@ -478,16 +507,102 @@ impl MemTableInfo {
 
 pub struct MutableStatus {
     result: Result<(), Error>,
-    ptr: *mut ffi::rocksdb_status_ptr_t,
+    ptr: *mut ffi::rust_rocksdb_status_t,
 }
 
 impl MutableStatus {
     pub fn reset(&self) {
-        unsafe { ffi::rocksdb_reset_status(self.ptr) }
+        unsafe { ffi::rust_rocksdb_status_reset(self.ptr) }
     }
 
     pub fn result(&self) -> &Result<(), Error> {
         &self.result
+    }
+
+    pub fn severity(&self) -> StatusSeverity {
+        unsafe { StatusSeverity::from(ffi::rust_rocksdb_status_get_severity(self.ptr)) }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundErrorStatus {
+    result: Result<(), Error>,
+    severity: StatusSeverity,
+}
+
+impl BackgroundErrorStatus {
+    pub fn result(&self) -> &Result<(), Error> {
+        &self.result
+    }
+
+    pub fn severity(&self) -> StatusSeverity {
+        self.severity
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackgroundErrorRecoveryInfo {
+    old_bg_error: BackgroundErrorStatus,
+    new_bg_error: BackgroundErrorStatus,
+}
+
+impl BackgroundErrorRecoveryInfo {
+    pub fn old_bg_error(&self) -> &BackgroundErrorStatus {
+        &self.old_bg_error
+    }
+
+    pub fn new_bg_error(&self) -> &BackgroundErrorStatus {
+        &self.new_bg_error
+    }
+}
+
+fn result_from_error_ptr(err: *mut c_char) -> Result<(), Error> {
+    if err.is_null() {
+        Ok(())
+    } else {
+        Err(convert_rocksdb_error(err))
+    }
+}
+
+fn status_result(status_ptr: *mut ffi::rust_rocksdb_status_t) -> Result<(), Error> {
+    unsafe {
+        let mut err: *mut c_char = std::ptr::null_mut();
+        ffi::rust_rocksdb_status_get_error(status_ptr, &raw mut err);
+        result_from_error_ptr(err)
+    }
+}
+
+fn background_error_status(status_ptr: *mut ffi::rust_rocksdb_status_t) -> BackgroundErrorStatus {
+    BackgroundErrorStatus {
+        result: status_result(status_ptr),
+        severity: unsafe {
+            StatusSeverity::from(ffi::rust_rocksdb_status_get_severity(status_ptr))
+        },
+    }
+}
+
+fn background_error_recovery_info(
+    info: *const ffi::rust_rocksdb_background_error_recovery_info_t,
+) -> BackgroundErrorRecoveryInfo {
+    unsafe {
+        let mut old_bg_error: *mut c_char = std::ptr::null_mut();
+        let mut new_bg_error: *mut c_char = std::ptr::null_mut();
+        ffi::rust_rocksdb_background_error_recovery_info_old_bg_error(info, &raw mut old_bg_error);
+        ffi::rust_rocksdb_background_error_recovery_info_new_bg_error(info, &raw mut new_bg_error);
+        BackgroundErrorRecoveryInfo {
+            old_bg_error: BackgroundErrorStatus {
+                result: result_from_error_ptr(old_bg_error),
+                severity: StatusSeverity::from(
+                    ffi::rust_rocksdb_background_error_recovery_info_old_bg_error_severity(info),
+                ),
+            },
+            new_bg_error: BackgroundErrorStatus {
+                result: result_from_error_ptr(new_bg_error),
+                severity: StatusSeverity::from(
+                    ffi::rust_rocksdb_background_error_recovery_info_new_bg_error_severity(info),
+                ),
+            },
+        }
     }
 }
 
@@ -511,6 +626,14 @@ pub trait EventListener: Send + Sync {
     fn on_stall_conditions_changed(&self, _: &WriteStallInfo) {}
     fn on_memtable_sealed(&self, _: &MemTableInfo) {}
     fn on_background_error(&self, _: DBBackgroundErrorReason, _: MutableStatus) {}
+    fn on_error_recovery_begin(
+        &self,
+        _: DBBackgroundErrorReason,
+        _: &BackgroundErrorStatus,
+        _: &mut bool,
+    ) {
+    }
+    fn on_error_recovery_end(&self, _: &BackgroundErrorRecoveryInfo) {}
 }
 
 extern "C" fn destructor<E: EventListener>(ctx: *mut c_void) {
@@ -521,7 +644,6 @@ extern "C" fn destructor<E: EventListener>(ctx: *mut c_void) {
 
 unsafe extern "C" fn on_flush_begin<E: EventListener>(
     ctx: *mut c_void,
-    _: *mut ffi::rocksdb_t,
     info: *const ffi::rocksdb_flushjobinfo_t,
 ) {
     let ctx = unsafe { &*(ctx as *mut E) };
@@ -531,7 +653,6 @@ unsafe extern "C" fn on_flush_begin<E: EventListener>(
 
 extern "C" fn on_flush_completed<E: EventListener>(
     ctx: *mut c_void,
-    _: *mut ffi::rocksdb_t,
     info: *const ffi::rocksdb_flushjobinfo_t,
 ) {
     let ctx = unsafe { &*(ctx as *mut E) };
@@ -541,7 +662,6 @@ extern "C" fn on_flush_completed<E: EventListener>(
 
 extern "C" fn on_compaction_begin<E: EventListener>(
     ctx: *mut c_void,
-    _: *mut ffi::rocksdb_t,
     info: *const ffi::rocksdb_compactionjobinfo_t,
 ) {
     let ctx = unsafe { &*(ctx as *mut E) };
@@ -551,7 +671,6 @@ extern "C" fn on_compaction_begin<E: EventListener>(
 
 extern "C" fn on_compaction_completed<E: EventListener>(
     ctx: *mut c_void,
-    _: *mut ffi::rocksdb_t,
     info: *const ffi::rocksdb_compactionjobinfo_t,
 ) {
     let ctx = unsafe { &*(ctx as *mut E) };
@@ -579,7 +698,6 @@ extern "C" fn on_subcompaction_completed<E: EventListener>(
 
 extern "C" fn on_external_file_ingested<E: EventListener>(
     ctx: *mut c_void,
-    _: *mut ffi::rocksdb_t,
     info: *const ffi::rocksdb_externalfileingestioninfo_t,
 ) {
     let ctx = unsafe { &*(ctx as *mut E) };
@@ -608,27 +726,48 @@ extern "C" fn on_memtable_sealed<E: EventListener>(
 extern "C" fn on_background_error<E: EventListener>(
     ctx: *mut c_void,
     reason: u32,
-    status_ptr: *mut ffi::rocksdb_status_ptr_t,
+    status_ptr: *mut ffi::rust_rocksdb_status_t,
 ) {
     let ctx = unsafe { &*(ctx as *mut E) };
-    let result = unsafe {
-        let mut err: *mut c_char = std::ptr::null_mut();
-        ffi::rocksdb_status_ptr_get_error(status_ptr, &raw mut err);
-        if err.is_null() {
-            Ok(())
-        } else {
-            Err(convert_rocksdb_error(err))
-        }
-    };
     let status = MutableStatus {
-        result,
+        result: status_result(status_ptr),
         ptr: status_ptr,
     };
     ctx.on_background_error(DBBackgroundErrorReason::from(reason), status);
 }
 
+extern "C" fn on_error_recovery_begin<E: EventListener>(
+    ctx: *mut c_void,
+    reason: u32,
+    status_ptr: *mut ffi::rust_rocksdb_status_t,
+    auto_recovery: *mut u8,
+) {
+    let ctx = unsafe { &*(ctx as *mut E) };
+    let status = background_error_status(status_ptr);
+    let mut auto_recovery_value = unsafe { !auto_recovery.is_null() && *auto_recovery != 0 };
+    ctx.on_error_recovery_begin(
+        DBBackgroundErrorReason::from(reason),
+        &status,
+        &mut auto_recovery_value,
+    );
+    if !auto_recovery.is_null() {
+        unsafe {
+            *auto_recovery = u8::from(auto_recovery_value);
+        }
+    }
+}
+
+extern "C" fn on_error_recovery_end<E: EventListener>(
+    ctx: *mut c_void,
+    info: *const ffi::rust_rocksdb_background_error_recovery_info_t,
+) {
+    let ctx = unsafe { &*(ctx as *mut E) };
+    let info = background_error_recovery_info(info);
+    ctx.on_error_recovery_end(&info);
+}
+
 pub struct DBEventListener {
-    pub(crate) inner: *mut ffi::rocksdb_eventlistener_t,
+    pub(crate) inner: *mut ffi::rust_rocksdb_eventlistener_t,
 }
 
 pub fn new_event_listener<E: EventListener>(e: E) -> DBEventListener {
@@ -638,7 +777,7 @@ pub fn new_event_listener<E: EventListener>(e: E) -> DBEventListener {
             // WARNING: none of the callbacks below are actually optional.
             // Rocksdb will try calling the callback as long as there is an
             // event listener setup, this means we must define all of them
-            inner: ffi::rocksdb_eventlistener_create(
+            inner: ffi::rust_rocksdb_eventlistener_create(
                 Box::into_raw(p) as *mut c_void,
                 Some(destructor::<E>),
                 Some(on_flush_begin::<E>),
@@ -649,6 +788,8 @@ pub fn new_event_listener<E: EventListener>(e: E) -> DBEventListener {
                 Some(on_subcompaction_completed::<E>),
                 Some(on_external_file_ingested::<E>),
                 Some(on_background_error::<E>),
+                Some(on_error_recovery_begin::<E>),
+                Some(on_error_recovery_end::<E>),
                 Some(on_stall_conditions_changed::<E>),
                 Some(on_memtable_sealed::<E>),
             ),

--- a/tests/test_event_listener.rs
+++ b/tests/test_event_listener.rs
@@ -228,13 +228,58 @@ fn test_event_listener_background_error() {
     assert_eq!(counter.background_error.load(Ordering::SeqCst), 0);
 }
 
-#[derive(Default, Clone)]
-struct BackgroundErrorCleaner(Arc<AtomicUsize>);
+#[test]
+fn test_background_error_reason_async_file_open() {
+    assert_eq!(
+        DBBackgroundErrorReason::from(7),
+        DBBackgroundErrorReason::KAsyncFileOpen
+    );
+}
+
+#[derive(Clone)]
+struct BackgroundErrorCleaner {
+    count: Arc<AtomicUsize>,
+    severity: Arc<AtomicUsize>,
+    recovery_begin: Arc<AtomicUsize>,
+    recovery_end: Arc<AtomicUsize>,
+}
+
+impl Default for BackgroundErrorCleaner {
+    fn default() -> Self {
+        Self {
+            count: Arc::new(AtomicUsize::new(0)),
+            severity: Arc::new(AtomicUsize::new(StatusSeverity::KUnknown as usize)),
+            recovery_begin: Arc::new(AtomicUsize::new(0)),
+            recovery_end: Arc::new(AtomicUsize::new(0)),
+        }
+    }
+}
 
 impl EventListener for BackgroundErrorCleaner {
     fn on_background_error(&self, _: DBBackgroundErrorReason, s: MutableStatus) {
+        assert!(s.result().is_err());
+        self.severity.store(s.severity() as usize, Ordering::SeqCst);
         s.reset();
-        self.0.fetch_add(1, Ordering::SeqCst);
+        assert_eq!(s.severity(), StatusSeverity::KNoError);
+        self.count.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn on_error_recovery_begin(
+        &self,
+        _: DBBackgroundErrorReason,
+        status: &BackgroundErrorStatus,
+        auto_recovery: &mut bool,
+    ) {
+        assert!(status.result().is_err());
+        assert_ne!(status.severity(), StatusSeverity::KNoError);
+        *auto_recovery = true;
+        self.recovery_begin.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn on_error_recovery_end(&self, info: &BackgroundErrorRecoveryInfo) {
+        assert!(info.old_bg_error().result().is_err());
+        assert_ne!(info.old_bg_error().severity(), StatusSeverity::KNoError);
+        self.recovery_end.fetch_add(1, Ordering::SeqCst);
     }
 }
 
@@ -244,7 +289,8 @@ fn test_event_listener_status_reset() {
 
     let mut opts = Options::default();
     let cleaner = BackgroundErrorCleaner::default();
-    let counter = cleaner.0.clone();
+    let counter = cleaner.count.clone();
+    let severity = cleaner.severity.clone();
     opts.add_event_listener(cleaner.clone());
     opts.create_if_missing(true);
     let db = DB::open(&opts, &path).unwrap();
@@ -266,6 +312,9 @@ fn test_event_listener_status_reset() {
 
     db.flush_opt(&fopts).unwrap();
     assert_eq!(counter.load(Ordering::SeqCst), 1);
+    assert!(
+        StatusSeverity::from(severity.load(Ordering::SeqCst) as u8) >= StatusSeverity::KHardError
+    );
 }
 
 fn corrupt_sst_file<P: AsRef<Path>>(db: &DB, path: P) {


### PR DESCRIPTION
## Summary
- expose RocksDB background error Status severity as StatusSeverity on MutableStatus
- add EventListener hooks for on_error_recovery_begin and on_error_recovery_end
- map kAsyncFileOpen background error reason instead of reporting KUnknown
- add a temporary local C API bridge while upstream RocksDB C API catches up

Upstream RocksDB C API PR: facebook/rocksdb#14809

## Testing
- cargo test --test test_event_listener
- cargo test --workspace --no-run
- git diff --check