### PR TITLE
librocksdb-sys: use rustflags crate for CARGO_ENCODED_RUSTFLAGS

### DIFF
--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -78,3 +78,4 @@ cc = { version = "1.2", features = ["parallel"] }
 bindgen = { version = "0.72", default-features = false }
 glob = "0.3"
 pkg-config = "0.3"
+rustflags = "0.1"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -93,13 +93,15 @@ impl Target {
     }
 }
 
-/// Parse the argument to `-Ctarget-cpu=` from `CARGO_ENCODED_RUSTFLAGS`,
-/// if present. Encoded RUSTFLAGS are separated by `0x1f` (US).
+/// Parse the `target-cpu` option from `CARGO_ENCODED_RUSTFLAGS`, if present.
 fn parse_rust_target_cpu() -> Option<String> {
-    const PREFIX: &str = "-Ctarget-cpu=";
-    let raw = env::var("CARGO_ENCODED_RUSTFLAGS").unwrap_or_default();
-    raw.split('\x1f')
-        .find_map(|f| f.strip_prefix(PREFIX).map(str::to_owned))
+    const TARGET_CPU: &str = "target-cpu";
+    // use rustflags since parsing is annoying
+    // e.g. "-Ctarget-cpu=native" and "-C target-cpu=native" are equivalent
+    rustflags::from_env().find_map(|flag| match flag {
+        rustflags::Flag::Codegen { opt, value } if opt == TARGET_CPU => value,
+        _ => None,
+    })
 }
 
 // =========================================================================


### PR DESCRIPTION
This is a cherry pick of https://github.com/rust-rocksdb/rust-rocksdb/pull/1087

Commit 816d4c8 added parsing for -Ctarget-cpu. Unfortunately, the flags "-C target-cpu=x" and "-Ctarget-cpu=x" are equivalent, but are encoded in CARGO_ENCODED_RUSTFLAGS differently. The previous version of this code only handled the "-Ctarget-cpu=x" form correctly.

To fix this, use the rustflags crate that should ensure we continue to parse this correctly, even if there are future changes.