### PR TITLE
fix cargo clippy cast warnings on linux aarch64

### DIFF
--- a/src/compaction_filter.rs
+++ b/src/compaction_filter.rs
@@ -133,14 +133,14 @@ where
         use self::Decision::{Change, Keep, Remove};
 
         let cb = &mut *(raw_cb as *mut F);
-        let key = slice::from_raw_parts(raw_key as *const u8, key_length);
-        let oldval = slice::from_raw_parts(existing_value as *const u8, value_length);
+        let key = slice::from_raw_parts(raw_key.cast::<u8>(), key_length);
+        let oldval = slice::from_raw_parts(existing_value.cast::<u8>(), value_length);
         let result = cb.filter(level as u32, key, oldval);
         match result {
             Keep => 0,
             Remove => 1,
             Change(newval) => {
-                *new_value = newval.as_ptr() as *mut c_char;
+                *new_value = newval.as_ptr().cast_mut().cast::<c_char>();
                 *new_value_length = newval.len() as size_t;
                 *value_changed = 1_u8;
                 0

--- a/src/comparator.rs
+++ b/src/comparator.rs
@@ -53,8 +53,8 @@ impl ComparatorCallback {
     ) -> c_int {
         unsafe {
             let cb: &mut Self = &mut *(raw_cb as *mut Self);
-            let a: &[u8] = slice::from_raw_parts(a_raw as *const u8, a_len);
-            let b: &[u8] = slice::from_raw_parts(b_raw as *const u8, b_len);
+            let a: &[u8] = slice::from_raw_parts(a_raw.cast::<u8>(), a_len);
+            let b: &[u8] = slice::from_raw_parts(b_raw.cast::<u8>(), b_len);
             (cb.compare_fn)(a, b) as c_int
         }
     }
@@ -91,8 +91,8 @@ impl ComparatorWithTsCallback {
     ) -> c_int {
         unsafe {
             let cb: &mut Self = &mut *(raw_cb as *mut Self);
-            let a: &[u8] = slice::from_raw_parts(a_raw as *const u8, a_len);
-            let b: &[u8] = slice::from_raw_parts(b_raw as *const u8, b_len);
+            let a: &[u8] = slice::from_raw_parts(a_raw.cast::<u8>(), a_len);
+            let b: &[u8] = slice::from_raw_parts(b_raw.cast::<u8>(), b_len);
             (cb.compare_fn)(a, b) as c_int
         }
     }
@@ -106,8 +106,8 @@ impl ComparatorWithTsCallback {
     ) -> c_int {
         unsafe {
             let cb: &mut Self = &mut *(raw_cb as *mut Self);
-            let a_ts: &[u8] = slice::from_raw_parts(a_ts_raw as *const u8, a_ts_len);
-            let b_ts: &[u8] = slice::from_raw_parts(b_ts_raw as *const u8, b_ts_len);
+            let a_ts: &[u8] = slice::from_raw_parts(a_ts_raw.cast::<u8>(), a_ts_len);
+            let b_ts: &[u8] = slice::from_raw_parts(b_ts_raw.cast::<u8>(), b_ts_len);
             (cb.compare_ts_fn)(a_ts, b_ts) as c_int
         }
     }
@@ -123,9 +123,9 @@ impl ComparatorWithTsCallback {
     ) -> c_int {
         unsafe {
             let cb: &mut Self = &mut *(raw_cb as *mut Self);
-            let a: &[u8] = slice::from_raw_parts(a_raw as *const u8, a_len);
+            let a: &[u8] = slice::from_raw_parts(a_raw.cast::<u8>(), a_len);
             let a_has_ts = a_has_ts_raw != 0;
-            let b: &[u8] = slice::from_raw_parts(b_raw as *const u8, b_len);
+            let b: &[u8] = slice::from_raw_parts(b_raw.cast::<u8>(), b_len);
             let b_has_ts = b_has_ts_raw != 0;
             (cb.compare_without_ts_fn)(a, a_has_ts, b, b_has_ts) as c_int
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -2128,7 +2128,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
             if ffi::rocksdb_iter_valid(iter) != 0 {
                 let mut key_len: size_t = 0;
                 let key_ptr = ffi::rocksdb_iter_key(iter, &raw mut key_len);
-                let key = slice::from_raw_parts(key_ptr as *const u8, key_len as usize);
+                let key = slice::from_raw_parts(key_ptr.cast::<u8>(), key_len as usize);
                 Ok(key.starts_with(prefix))
             } else if let Err(e) = (|| {
                 // Check status to differentiate end-of-range vs error
@@ -2232,7 +2232,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
             if ffi::rocksdb_iter_valid(iter) != 0 {
                 let mut key_len: size_t = 0;
                 let key_ptr = ffi::rocksdb_iter_key(iter, &raw mut key_len);
-                let key = slice::from_raw_parts(key_ptr as *const u8, key_len as usize);
+                let key = slice::from_raw_parts(key_ptr.cast::<u8>(), key_len as usize);
                 Ok(key.starts_with(prefix))
             } else if let Err(e) = (|| {
                 ffi_try!(ffi::rocksdb_iter_get_error(iter));
@@ -3431,7 +3431,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
                 Err(Error::new("Could not get full_history_ts_low".to_owned()))
             } else {
                 let mut vec = vec![0; ts_lowlen];
-                ptr::copy_nonoverlapping(ts as *mut u8, vec.as_mut_ptr(), ts_lowlen);
+                ptr::copy_nonoverlapping(ts.cast::<u8>(), vec.as_mut_ptr(), ts_lowlen);
                 ffi::rocksdb_free(ts as *mut c_void);
                 Ok(vec)
             }

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -5056,7 +5056,7 @@ impl CompactOptions {
 
     fn set_full_history_ts_low_impl(&mut self, ts: Option<Vec<u8>>) {
         let (ptr, len) = if let Some(ref ts) = ts {
-            (ts.as_ptr() as *mut c_char, ts.len())
+            (ts.as_ptr().cast_mut().cast::<c_char>(), ts.len())
         } else if self.full_history_ts_low.is_some() {
             (std::ptr::null::<Vec<u8>>() as *mut c_char, 0)
         } else {
@@ -5281,7 +5281,7 @@ unsafe extern "C" fn logger_callback(
     len: size_t,
 ) {
     let rust_callback: &LoggerCallback = unsafe { &*(raw_cb as LoggerCallbackPtr) };
-    let raw_msg = unsafe { std::slice::from_raw_parts(msg as *const u8, len) };
+    let raw_msg = unsafe { std::slice::from_raw_parts(msg.cast_const().cast::<u8>(), len) };
     let msg = String::from_utf8_lossy(raw_msg);
     let level =
         LogLevel::try_from_raw(level as i32).expect("rocksdb generated an invalid log level");

--- a/src/db_pinnable_slice.rs
+++ b/src/db_pinnable_slice.rs
@@ -44,7 +44,9 @@ impl Deref for DBPinnableSlice<'_> {
     fn deref(&self) -> &[u8] {
         unsafe {
             let mut val_len: size_t = 0;
-            let val = ffi::rocksdb_pinnableslice_value(self.ptr, &raw mut val_len) as *mut u8;
+            let val = ffi::rocksdb_pinnableslice_value(self.ptr, &raw mut val_len)
+                .cast_mut()
+                .cast::<u8>();
             slice::from_raw_parts(val, val_len)
         }
     }

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -258,7 +258,7 @@ impl FlushJobInfo {
             }
 
             // SAFETY: We're copying `length` bytes from a valid, non-null pointer.
-            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr as *const u8, length).to_vec();
+            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr.cast::<u8>(), length).to_vec();
 
             Some(cf_name_vec)
         }
@@ -307,7 +307,7 @@ impl CompactionJobInfo {
             }
 
             // SAFETY: We're copying `length` bytes from a valid, non-null pointer.
-            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr as *const u8, length).to_vec();
+            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr.cast::<u8>(), length).to_vec();
 
             Some(cf_name_vec)
         }
@@ -385,7 +385,7 @@ impl SubcompactionJobInfo {
             }
 
             // SAFETY: We're copying `length` bytes from a valid, non-null pointer.
-            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr as *const u8, length).to_vec();
+            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr.cast::<u8>(), length).to_vec();
 
             Some(cf_name_vec)
         }
@@ -428,7 +428,7 @@ impl IngestionInfo {
             }
 
             // SAFETY: We're copying `length` bytes from a valid, non-null pointer.
-            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr as *const u8, length).to_vec();
+            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr.cast::<u8>(), length).to_vec();
 
             Some(cf_name_vec)
         }
@@ -450,7 +450,7 @@ impl WriteStallInfo {
             }
 
             // SAFETY: We're copying `length` bytes from a valid, non-null pointer.
-            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr as *const u8, length).to_vec();
+            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr.cast::<u8>(), length).to_vec();
 
             Some(cf_name_vec)
         }
@@ -485,7 +485,7 @@ impl MemTableInfo {
             }
 
             // SAFETY: We're copying `length` bytes from a valid, non-null pointer.
-            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr as *const u8, length).to_vec();
+            let cf_name_vec = std::slice::from_raw_parts(cf_name_ptr.cast::<u8>(), length).to_vec();
 
             Some(cf_name_vec)
         }

--- a/src/ffi_util.rs
+++ b/src/ffi_util.rs
@@ -42,7 +42,7 @@ pub(crate) unsafe fn raw_data(ptr: *const c_char, size: usize) -> Option<Vec<u8>
         None
     } else {
         // SAFETY: Caller guarantees `ptr` points to `size` bytes; we immediately copy them.
-        Some(unsafe { std::slice::from_raw_parts(ptr as *const u8, size) }.to_vec())
+        Some(unsafe { std::slice::from_raw_parts(ptr.cast::<u8>(), size) }.to_vec())
     }
 }
 
@@ -243,7 +243,7 @@ impl CSlice {
 
 impl AsRef<[u8]> for CSlice {
     fn as_ref(&self) -> &[u8] {
-        unsafe { std::slice::from_raw_parts(self.data as *const u8, self.len) }
+        unsafe { std::slice::from_raw_parts(self.data.cast::<u8>(), self.len) }
     }
 }
 

--- a/src/merge_operator.rs
+++ b/src/merge_operator.rs
@@ -94,7 +94,7 @@ pub unsafe extern "C" fn delete_callback(
         if !value.is_null() {
             // Use pointer form to avoid implicit cast from slice reference to raw slice pointer
             drop(Box::from_raw(ptr::slice_from_raw_parts_mut(
-                value as *mut u8,
+                value.cast_mut().cast::<u8>(),
                 value_length,
             )));
         }
@@ -125,12 +125,12 @@ pub unsafe extern "C" fn full_merge_callback<F: MergeFn, PF: MergeFn>(
     unsafe {
         let cb = &mut *(raw_cb as *mut MergeOperatorCallback<F, PF>);
         let operands = &MergeOperands::new(operands_list, operands_list_len, num_operands);
-        let key = slice::from_raw_parts(raw_key as *const u8, key_len);
+        let key = slice::from_raw_parts(raw_key.cast::<u8>(), key_len);
         let oldval = if existing_value.is_null() {
             None
         } else {
             Some(slice::from_raw_parts(
-                existing_value as *const u8,
+                existing_value.cast::<u8>(),
                 existing_value_len,
             ))
         };
@@ -162,7 +162,7 @@ pub unsafe extern "C" fn partial_merge_callback<F: MergeFn, PF: MergeFn>(
     unsafe {
         let cb = &mut *(raw_cb as *mut MergeOperatorCallback<F, PF>);
         let operands = &MergeOperands::new(operands_list, operands_list_len, num_operands);
-        let key = slice::from_raw_parts(raw_key as *const u8, key_len);
+        let key = slice::from_raw_parts(raw_key.cast::<u8>(), key_len);
         (cb.partial_merge_fn)(key, None, operands).map_or_else(
             || {
                 *new_value_length = 0;
@@ -220,7 +220,7 @@ impl MergeOperands {
             unsafe {
                 let ptr = *self.operands_list.add(index);
                 let len = *self.operands_list_len.add(index);
-                Some(slice::from_raw_parts(ptr as *const u8, len))
+                Some(slice::from_raw_parts(ptr.cast::<u8>(), len))
             }
         }
     }

--- a/src/slice_transform.rs
+++ b/src/slice_transform.rs
@@ -101,10 +101,10 @@ pub unsafe extern "C" fn transform_callback(
 ) -> *mut c_char {
     unsafe {
         let cb = &mut *(raw_cb as *mut TransformCallback);
-        let key = slice::from_raw_parts(raw_key as *const u8, key_len);
+        let key = slice::from_raw_parts(raw_key.cast::<u8>(), key_len);
         let prefix = (cb.transform_fn)(key);
         *dst_length = prefix.len() as size_t;
-        prefix.as_ptr() as *mut c_char
+        prefix.as_ptr().cast_mut().cast::<c_char>()
     }
 }
 
@@ -115,7 +115,7 @@ pub unsafe extern "C" fn in_domain_callback(
 ) -> c_uchar {
     unsafe {
         let cb = &mut *(raw_cb as *mut TransformCallback);
-        let key = slice::from_raw_parts(raw_key as *const u8, key_len);
+        let key = slice::from_raw_parts(raw_key.cast::<u8>(), key_len);
         c_uchar::from(cb.in_domain_fn.is_none_or(|in_domain| in_domain(key)))
     }
 }

--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -201,7 +201,7 @@ impl<DB> Transaction<'_, DB> {
                 None
             } else {
                 let mut vec = vec![0; name_len];
-                std::ptr::copy_nonoverlapping(name as *mut u8, vec.as_mut_ptr(), name_len);
+                std::ptr::copy_nonoverlapping(name.cast::<u8>(), vec.as_mut_ptr(), name_len);
                 ffi::rocksdb_free(name as *mut c_void);
                 Some(vec)
             }

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -95,8 +95,8 @@ unsafe extern "C" fn writebatch_put_callback<T: WriteBatchIterator>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
-        let value = slice::from_raw_parts(v as *const u8, vlen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
+        let value = slice::from_raw_parts(v.cast::<u8>(), vlen);
         callbacks.put(key, value);
     }
 }
@@ -108,7 +108,7 @@ unsafe extern "C" fn writebatch_delete_callback<T: WriteBatchIterator>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
         callbacks.delete(key);
     }
 }
@@ -123,8 +123,8 @@ unsafe extern "C" fn writebatch_put_cf_callback<T: WriteBatchIteratorCf>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
-        let value = slice::from_raw_parts(v as *const u8, vlen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
+        let value = slice::from_raw_parts(v.cast::<u8>(), vlen);
         callbacks.put_cf(cfid, key, value);
     }
 }
@@ -137,7 +137,7 @@ unsafe extern "C" fn writebatch_delete_cf_callback<T: WriteBatchIteratorCf>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
         callbacks.delete_cf(cfid, key);
     }
 }
@@ -152,8 +152,8 @@ unsafe extern "C" fn writebatch_merge_cf_callback<T: WriteBatchIteratorCf>(
 ) {
     unsafe {
         let callbacks = &mut *(state as *mut T);
-        let key = slice::from_raw_parts(k as *const u8, klen);
-        let value = slice::from_raw_parts(v as *const u8, vlen);
+        let key = slice::from_raw_parts(k.cast::<u8>(), klen);
+        let value = slice::from_raw_parts(v.cast::<u8>(), vlen);
         callbacks.merge_cf(cfid, key, value);
     }
 }

--- a/src/write_batch_with_index.rs
+++ b/src/write_batch_with_index.rs
@@ -66,7 +66,7 @@ impl WriteBatchWithIndex {
                 Ok(None)
             } else {
                 Ok(Some(Vec::from_raw_parts(
-                    value_data as *mut u8,
+                    value_data.cast::<u8>(),
                     value_size,
                     value_size,
                 )))
@@ -99,7 +99,7 @@ impl WriteBatchWithIndex {
                 Ok(None)
             } else {
                 Ok(Some(Vec::from_raw_parts(
-                    value_data as *mut u8,
+                    value_data.cast::<u8>(),
                     value_size,
                     value_size,
                 )))
@@ -142,7 +142,7 @@ impl WriteBatchWithIndex {
                 Ok(None)
             } else {
                 Ok(Some(Vec::from_raw_parts(
-                    value_data as *mut u8,
+                    value_data.cast::<u8>(),
                     value_size,
                     value_size,
                 )))
@@ -224,7 +224,7 @@ impl WriteBatchWithIndex {
                 Ok(None)
             } else {
                 Ok(Some(Vec::from_raw_parts(
-                    value_data as *mut u8,
+                    value_data.cast::<u8>(),
                     value_size,
                     value_size,
                 )))


### PR DESCRIPTION
This is the equivalent fix to https://github.com/rust-rocksdb/rust-rocksdb/pull/1089


This changes casts to make clippy pass on Linux aarch64. There are no behavior changes intended. On Linux aarch64, clippy has two kinds of warnings:

First: c_char_ptr as *const u8: On linux aarch64, char is u8, so this is an unnecessary cast and warns:
```
  warning: casting raw pointers to the same type and constness is
  unnecessary (`*const u8` -> `*const u8`)
```
The fix is to use c_char_ptr.cast::<u8>()

Second: u8_ptr as *mut c_char: On linux x86-64 this changes sign and const, but on linux aarch64 it only changes const, so it warns:
```
  warning: `as` casting between raw pointers while changing only its
  constness
```
The fix is to use u8_ptr.cast_mut() or .cast_const().