### PR TITLE
Release 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,25 +1,38 @@
 # Changelog
 
-## Unreleased
+## 0.51.0 (2026-06-26)
 
 - fix(librocksdb-sys): upgrade the bundled RocksDB submodule to
   11.1.2. (zaidoon1)
+- feat: add `CompactOptions::set_blob_garbage_collection_age_cutoff`,
+  exposing the matching RocksDB option through the safe Rust API.
+  (kmorkos)
+- feat: expose RocksDB's non-deprecated error recovery end callback
+  through `EventListener::on_error_recovery_end`. The callback receives
+  `BackgroundErrorRecoveryInfo`, including old/new background error
+  statuses and severities. (zaidoon1)
+- fix: make raw pointer casts clippy-clean on Linux aarch64. No
+  behavior change is intended. (evanj)
+- fix(librocksdb-sys): parse `CARGO_ENCODED_RUSTFLAGS` with the
+  `rustflags` crate so both `-Ctarget-cpu=...` and
+  `-C target-cpu=...` forms are handled correctly. (evanj)
 - feat: add `SstFileWriter::delete_range` and expose
   `Options::set_experimental_mempurge_threshold`, matching upstream
-  rust-rocksdb APIs. (cooronx, Vladimir Petrzhikovskii)
+  rust-rocksdb APIs. (cooronx, 0xdeafbeef)
 - feat: add `TransactionDBCheckpoint::create_checkpoint_with_log_size`
   for upstream source compatibility. TransactionDB checkpoints may
-  still flush memtables regardless of the threshold. (gdorsi, zaidoon1)
+  still flush memtables regardless of the threshold. (calavera, gdorsi,
+  zaidoon1)
 - fix: make `DBRawIteratorWithThreadMode::timestamp()` safe and
   upstream-compatible by returning `Option<&[u8]>`; the prior zero-copy
-  unchecked behavior is available as `timestamp_unchecked()`. (ali2992,
-  zaidoon1)
+  unchecked behavior is available as `timestamp_unchecked()`.
+  (dillonhicks, ali2992, zaidoon1)
 - fix: derive multi-get key pointers and lengths from a single
   `AsRef<[u8]>` call per key across DB, Transaction, and TransactionDB
-  paths. (Niklas Fiekas)
+  paths. (niklasf)
 - fix(librocksdb-sys): disable `zstd-sys` default features while
   preserving local `experimental` support, avoiding an unnecessary
-  transitive bindgen path. (Congyu WANG, zaidoon1)
+  transitive bindgen path. (Congyuwang, zaidoon1)
 
 ## 0.50.0 (2026-05-23)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = [


### PR DESCRIPTION
## Versions

- `rust-rocksdb`: 0.50.0 -> **0.51.0**
- `rust-librocksdb-sys`: 0.46.0+11.1.1 -> **0.47.0+11.1.2**

## What is in this release

(Full notes in `CHANGELOG.md`.)

### Features

- **Bundled RocksDB upgraded to 11.1.2**.
- **`CompactOptions::set_blob_garbage_collection_age_cutoff`** exposed through the safe Rust API.
- **`EventListener::on_error_recovery_end`** exposes RocksDB's non-deprecated recovery-end callback with old/new background error statuses and severities.
- Upstream compatibility additions: `SstFileWriter::delete_range`, `Options::set_experimental_mempurge_threshold`, `TransactionDBCheckpoint::create_checkpoint_with_log_size`, and safe `DBRawIteratorWithThreadMode::timestamp()`.

### Fixes

- AArch64 clippy-clean raw pointer casts.
- `CARGO_ENCODED_RUSTFLAGS` target-cpu parsing via the `rustflags` crate.
- `zstd-sys` default features disabled while preserving local `experimental` support.
- Multi-get key pointer/length derivation now uses one `AsRef<[u8]>` call per key.

## Publishing note

Publish `rust-librocksdb-sys` first, then `rust-rocksdb`, because `rust-rocksdb 0.51.0` depends on `rust-librocksdb-sys ^0.47.0` and that version is not on crates.io yet.

The lightweight tag `v0.51.0` has been pushed at this release commit.

## Verifications run

- `git diff --check` - clean
- `cargo metadata --no-deps --format-version 1` - succeeds
- `cargo package -p rust-librocksdb-sys --allow-dirty` - succeeds
- `cargo publish -p rust-librocksdb-sys --dry-run` - succeeds

`cargo package -p rust-rocksdb` currently blocks until `rust-librocksdb-sys 0.47.0+11.1.2` is published; before that, crates.io cannot resolve `rust-librocksdb-sys = "^0.47.0"`.