### PR TITLE
Allow ROCKSDB_COMPILE on FreeBSD

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,7 +395,6 @@ When you opt in via any of these:
 - No version pin is enforced &mdash; you're the power user. The bundled RocksDB version is the trailing component of `librocksdb-sys`'s `version = "X.Y.Z+RR.S.T"` in `Cargo.toml`; make sure your system rocksdb is API-compatible.
 - The `snappy` Cargo feature becomes a no-op: the system librocksdb is expected to provide snappy support itself, so building and linking a second copy would risk duplicate symbols. The build script emits a `cargo::warning=` so the silent skip isn't surprising.
 - The `coroutines` Cargo feature still emits folly link directives, but the build script emits a `cargo::warning=` reminding you that your prebuilt librocksdb must have been built with `USE_COROUTINES=1` and `USE_FOLLY=1` &mdash; otherwise you'll get unresolved-symbol link errors against folly.
-- On FreeBSD the system rocksdb is used unconditionally (the bundled sources don't currently build on FreeBSD). `ROCKSDB_COMPILE=1` is rejected up front with a clear error on FreeBSD targets to avoid a long, doomed C++ compile.
 
 Same set of variables exists for snappy (`SNAPPY_LIB_DIR`, `SNAPPY_STATIC`, `SNAPPY_COMPILE`) if you'd like to swap in a system libsnappy while keeping the bundled rocksdb.
 

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -27,7 +27,9 @@ use std::path::{Path, PathBuf};
 /// On these platforms `jemalloc-sys` uses a prefixed jemalloc that cannot be
 /// linked together with RocksDB's own usage of jemalloc symbols.
 /// See <https://github.com/tikv/jemallocator/blob/f7adfca5aff272b43fd3ad896252b57fbbd9c72a/jemalloc-sys/src/env.rs#L24>.
-const NO_JEMALLOC_TARGETS: &[&str] = &["android", "dragonfly", "darwin"];
+/// Additionally, FreeBSD comes with jemalloc out of the box, so we don't
+/// need to recompile it.
+const NO_JEMALLOC_TARGETS: &[&str] = &["android", "dragonfly", "darwin", "freebsd"];
 
 /// Default C++ standard used to build RocksDB. Can be overridden with
 /// `ROCKSDB_CXX_STD`.
@@ -125,20 +127,8 @@ impl Backend {
     /// Decide the backend and emit any needed link directives for the
     /// system path. Vendored compilation is deferred to [`vendor::build`].
     fn resolve(target: &Target) -> Self {
-        // Highest priority: explicit "force compile" override. FreeBSD
-        // can't build RocksDB from these submodule sources, so the
-        // combination is rejected up front rather than failing midway
-        // through a long C++ compile.
+        // Highest priority: explicit "force compile" override.
         if env_truthy("ROCKSDB_COMPILE") {
-            if target.os == "freebsd" {
-                panic!(
-                    "ROCKSDB_COMPILE=1 is not supported on FreeBSD: the \
-                     bundled RocksDB sources don't build on FreeBSD. \
-                     Unset ROCKSDB_COMPILE and let the build script link \
-                     against the system RocksDB (install via `pkg install \
-                     rocksdb`)."
-                );
-            }
             return Backend::Vendored {
                 include: vendored_include(),
             };
@@ -154,8 +144,7 @@ impl Backend {
             return system::from_lib_dir_env();
         }
 
-        // FreeBSD historically can't build RocksDB from these submodule
-        // sources (see PR #908). Fall through to the system library at the
+        // Fall through to the system library at the
         // platform's conventional location.
         if target.os == "freebsd" {
             return system::from_freebsd_defaults();
@@ -784,8 +773,7 @@ mod vendor {
     ///   - Android: bionic only added `<execinfo.h>` in API 33; older API
     ///     levels would fail to compile.
     ///   - Windows / MSVC: no equivalent; would need DbgHelp instead.
-    ///   - BSDs: would need libexecinfo from ports. We don't build the
-    ///     vendored sources on FreeBSD anyway.
+    ///   - BSDs: would need libexecinfo from ports.
     fn apply_backtrace(cfg: &mut cc::Build, target: &Target) {
         let supported = match target.os.as_str() {
             "linux" => target.env_abi != "musl",


### PR DESCRIPTION
[At some point in the past](https://github.com/rust-rocksdb/rust-rocksdb/pull/908), vanilla RocksDB wouldn't build on FreeBSD. I'm not sure what changed, but this is no longer the case on either FreeBSD 15.1-RELEASE or 14.4-RELEASE, using the `llvm21` port.

I think it should still be possible to link to the system RocksDB lib, and that can be the default (which might be up for discussion now), but I don't think we need to panic when forcing a build with `ROCKSDB_COMPILE`.