### PR TITLE
Suppress `folly` warnings `shadow` and `sign-compare` in coroutines build

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1189,8 +1189,8 @@ mod coroutines {
             "libevent",
             "libsodium",
         ] {
-            let dir = resolve_dep(&install_root, dep);
-            cfg.include(dir.join("include"));
+            let include = resolve_dep(&install_root, dep).join("include");
+            cfg.flag("-isystem").flag(include.as_os_str());
         }
     }
 


### PR DESCRIPTION
This as far as I can tell comes from library code.

It creates a lot of noise in the CI logs, and I think there is nothing we can do on our end about it (other than tell newer `gcc` versions to ignore the warning at that scope).

Example run is linked below. The `unsafe function` errors are due to an issue fixed in the following commit, but this illustrates the massive 8,000+ line storm of log output. After the fix, it reduces to a nominal 50-70 lines.

Before: https://github.com/gamesguru/rust-rocksdb/actions/runs/28824858516/job/85485365769

After: https://github.com/gamesguru/rust-rocksdb/actions/runs/28895025042/job/85717243710