### PR TITLE
accept valid compaction levels in bulkload test

### DIFF
--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -1103,7 +1103,7 @@ fn get_with_cache_and_bulkload_test() {
             let livefiles = db.live_files().unwrap();
             assert_eq!(livefiles.len(), 1);
             livefiles.iter().for_each(|f| {
-                assert_eq!(f.level, 2);
+                assert!(f.level > 0, "compacted SST must not remain in L0");
                 assert_eq!(f.column_family_name, "default");
                 assert!(!f.name.is_empty());
                 assert_eq!(


### PR DESCRIPTION
The test only needs the SST outside L0 before deleting files by range. Manual compaction can leave the file in L1 before background work moves it to L2.