### PR TITLE
Reduce native development build size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- perf: reduce bundled RocksDB development build size by defaulting its
+  native compilation to `opt-level = 1` without debug information.
+  Set `ROCKSDB_NATIVE_DEBUG=1` to preserve Cargo's native debug settings.
 - perf: add allocation-free iterator callbacks, reusable snapshot read
   options, native batched pinned reads, and a batch-owned pinned result
   type.

--- a/README.md
+++ b/README.md
@@ -389,6 +389,10 @@ default development and test settings. Release builds, sanitizer builds, and
 profiles with different settings are unchanged. Set `ROCKSDB_NATIVE_DEBUG=1`
 when native RocksDB debug information is required.
 
+This matches the native package profile used by TiKV's application workspace,
+but applies it inside `rust-rocksdb` so consuming services do not need their own
+crate-specific profile configuration.
+
 Install [`sccache`](https://github.com/mozilla/sccache), then add this to
 `~/.cargo/config.toml`:
 

--- a/README.md
+++ b/README.md
@@ -375,9 +375,55 @@ cd rust-rocksdb
 git submodule update --init --recursive
 ```
 
-### Linking Against a Prebuilt RocksDB
+### Faster Local Development Builds
 
-By default, `rust-rocksdb` builds RocksDB from the bundled submodule. To link against a system-installed `librocksdb` instead (e.g. to share a single library across multiple Rust projects, cut compile time, or use a distro's package), the build script honors these opt-in environment variables:
+RocksDB is a large C++ dependency. The recommended development setup uses
+Cargo's build cache together with `sccache`. This keeps the cache outside the
+project's `target/` directory and avoids maintaining a separate RocksDB artifact
+format.
+
+When Cargo uses `PROFILE=debug`, `OPT_LEVEL=0`, and full debug information,
+`rust-rocksdb` automatically builds the bundled RocksDB and Snappy libraries
+with `opt-level = 1` and without native debug information. This covers Cargo's
+default development and test settings. Release builds, sanitizer builds, and
+profiles with different settings are unchanged. Set `ROCKSDB_NATIVE_DEBUG=1`
+when native RocksDB debug information is required.
+
+Install [`sccache`](https://github.com/mozilla/sccache), then add this to
+`~/.cargo/config.toml`:
+
+```toml
+[build]
+rustc-wrapper = "sccache"
+build-dir = "{cargo-cache-home}/build/{workspace-path-hash}"
+```
+
+`rust-librocksdb-sys` uses the `cc` crate, which recognizes `sccache` through
+`rustc-wrapper` and applies it to the bundled C and C++ compilation too.
+`build-dir` is stable in Cargo 1.91 and stores intermediate build output outside
+the workspace. Removing a project's `target/` directory therefore does not
+remove those intermediates.
+
+`ccache` is a C and C++ only alternative to `sccache`:
+
+```toml
+# .cargo/config.toml
+[env]
+CC = "ccache cc"
+CXX = "ccache c++"
+```
+
+Do not stack both cache wrappers around the same compiler. Cache misses are
+expected when the compiler, target, RocksDB sources, native features, or compiler
+flags change.
+
+### Using an Existing RocksDB Installation
+
+By default, `rust-rocksdb` builds RocksDB from the bundled submodule. Controlled
+development environments can avoid that build entirely by linking a compatible
+RocksDB installation. Prefer `pkg-config` when possible because its metadata can
+include the required native search paths and transitive libraries. The build
+script also supports explicit library and header directories:
 
 | Variable                   | Effect                                                                                                       |
 | -------------------------- | ------------------------------------------------------------------------------------------------------------ |
@@ -387,6 +433,7 @@ By default, `rust-rocksdb` builds RocksDB from the bundled submodule. To link ag
 | `ROCKSDB_INCLUDE_DIR=<p>`  | Headers for `bindgen`. Mandatory with `ROCKSDB_LIB_DIR`; with `ROCKSDB_USE_PKG_CONFIG` it is *merged in front* of pkg-config's discovered paths (does not replace them). |
 | `ROCKSDB_COMPILE=1`        | Force the bundled vendored build even if the above are set. Accepts `1` or `true` (case-insensitive).        |
 | `ROCKSDB_CXX_STD=c++23`    | Override the C++ standard used to compile RocksDB (default `c++20`). Only used for vendored builds.          |
+| `ROCKSDB_NATIVE_DEBUG=1`    | Preserve Cargo's native development optimization and debug settings for vendored builds.                    |
 | `CXXSTDLIB=stdc++`         | Override the C++ stdlib linked (e.g. `c++` for libc++, `stdc++` for libstdc++).                              |
 
 When you opt in via any of these:
@@ -401,10 +448,10 @@ Same set of variables exists for snappy (`SNAPPY_LIB_DIR`, `SNAPPY_STATIC`, `SNA
 #### Examples
 
 ```bash
-# Use distro-installed librocksdb via pkg-config (Debian/Ubuntu: librocksdb-dev)
+# Use a compatible RocksDB installation discovered through pkg-config
 ROCKSDB_USE_PKG_CONFIG=1 cargo build
 
-# Manual path; static link
+# Use a manually managed static library and matching headers
 ROCKSDB_LIB_DIR=/opt/rocksdb/lib \
 ROCKSDB_INCLUDE_DIR=/opt/rocksdb/include \
 ROCKSDB_STATIC=1 \

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -186,6 +186,7 @@ fn main() {
         "ROCKSDB_INCLUDE_DIR",
         "ROCKSDB_USE_PKG_CONFIG",
         "ROCKSDB_CXX_STD",
+        "ROCKSDB_NATIVE_DEBUG",
         // Snappy
         "SNAPPY_COMPILE",
         "SNAPPY_LIB_DIR",
@@ -341,6 +342,32 @@ fn emit_metadata(backend: &Backend) {
     println!("cargo::metadata=out_dir={}", out_dir().display());
 }
 
+/// Keep Cargo's default development and test settings from generating large
+/// native debug artifacts.
+fn apply_native_dev_defaults(config: &mut cc::Build) {
+    if env_truthy("ROCKSDB_NATIVE_DEBUG") || sanitizer_enabled() {
+        return;
+    }
+
+    let profile = env::var("PROFILE").unwrap_or_default();
+    let opt_level = env::var("OPT_LEVEL").unwrap_or_default();
+    let debug = env::var("DEBUG").unwrap_or_default();
+    let cargo_dev_defaults =
+        profile == "debug" && opt_level == "0" && matches!(debug.as_str(), "2" | "full" | "true");
+
+    if cargo_dev_defaults {
+        config.opt_level(1);
+        config.debug(false);
+    }
+}
+
+fn sanitizer_enabled() -> bool {
+    ["CFLAGS", "CXXFLAGS", "CARGO_ENCODED_RUSTFLAGS"]
+        .iter()
+        .filter_map(env::var_os)
+        .any(|flags| flags.to_string_lossy().contains("sanitize"))
+}
+
 // =========================================================================
 // Vendored build
 // =========================================================================
@@ -382,6 +409,7 @@ mod vendor {
             cfg.flag("-include").flag("cstdint");
         }
 
+        apply_native_dev_defaults(&mut cfg);
         cfg.cpp(true);
         cfg.compile("librocksdb.a");
     }
@@ -1042,6 +1070,7 @@ mod snappy {
         ] {
             cfg.file(src);
         }
+        apply_native_dev_defaults(&mut cfg);
         cfg.cpp(true);
         cfg.compile("libsnappy.a");
     }


### PR DESCRIPTION
## What changed

- Build bundled RocksDB and Snappy with `opt-level = 1` and no native debug information when Cargo uses its default development or test settings.
- Preserve release builds, non-default profiles, sanitizer builds, and the full native debug path.
- Document a global `sccache` and Cargo `build-dir` setup that applies across service repositories.
- Keep `ccache` and the existing system RocksDB backend documented as alternatives.

## Why

The default Cargo development profile produces very large C++ debug artifacts. On macOS ARM64, the RocksDB archive was 837 MB and the target directory was 1.9 GB. With the new default, the archive was 22 MB and the target directory was 167 MB.

This replaces the custom prebuilt bundle format and validation system with Cargo, `cc`, and compiler caches that are already widely used and maintained.

Set `ROCKSDB_NATIVE_DEBUG=1` when native RocksDB debug information is needed.

## Validation

- `cargo test --all`
- `cargo test --all --features multi-threaded-cf`
- Clippy with warnings denied for default and `multi-threaded-cf`
- rustdoc with warnings denied
- Verified default development compilation uses `-O1` without debug flags
- Verified `ROCKSDB_NATIVE_DEBUG=1` restores `-O0 -g`
- Verified sanitizer flags preserve native debug settings
- Verified Cargo 1.91 accepts the documented global `build-dir` configuration
