### PR TITLE
Reduce allocations and FFI overhead in hot RocksDB paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,22 @@
 # Changelog
 
+## Unreleased
+
+- perf: add allocation-free iterator callbacks, reusable snapshot read
+  options, native batched pinned reads, and a batch-owned pinned result
+  type.
+- perf: add slice-based vectored `WriteBatch` operations that avoid Rust
+  key and value concatenation and return RocksDB errors.
+- perf: use RocksDB's integer property API when available, reuse
+  thread-local `PerfContext` wrappers safely, and avoid per-iterator
+  `ReadOptions` allocations when creating iterators for multiple column
+  families.
+- feat: expose `open_files_async`, cache occupancy metrics, and detailed
+  write buffer manager memory accounting.
+- fix: align `PerfStatsLevel` values and RTTI build flags with RocksDB
+  11.1.2, and prevent transaction-backed snapshots from being shared
+  across threads.
+
 ## 0.51.0 (2026-06-26)
 
 - fix(librocksdb-sys): upgrade the bundled RocksDB submodule to

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,10 @@ serde = { version = "1", features = ["derive"], optional = true }
 parking_lot = { version = "0.12" }
 
 [dev-dependencies]
+criterion = "0.8.2"
 tempfile = "3"
 pretty_assertions = "1"
+
+[[bench]]
+name = "hot_paths"
+harness = false

--- a/benches/hot_paths.rs
+++ b/benches/hot_paths.rs
@@ -1,0 +1,396 @@
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use rust_rocksdb::{
+    ColumnFamilyDescriptor, DB, Error, GetIntoBufferResult, IteratorMode, Options, PerfContext,
+    PerfMetric, WriteBatch, properties, with_thread_local,
+};
+use std::{hint::black_box, io::IoSlice, ops::ControlFlow};
+use tempfile::TempDir;
+
+const ENTRY_COUNT: usize = 4_096;
+const VALUE_SIZE: usize = 256;
+const MULTIGET_SIZE: usize = 32;
+
+struct Fixture {
+    _dir: TempDir,
+    db: DB,
+    keys: Vec<Vec<u8>>,
+}
+
+impl Fixture {
+    fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        let mut options = Options::default();
+        options.create_if_missing(true);
+        let db = DB::open(&options, dir.path()).unwrap();
+        let mut batch = WriteBatch::with_capacity_bytes(ENTRY_COUNT * (VALUE_SIZE + 16));
+        let mut keys = Vec::with_capacity(ENTRY_COUNT);
+
+        for index in 0..ENTRY_COUNT {
+            let key = format!("key-{index:08}").into_bytes();
+            let value = vec![(index % 251) as u8; VALUE_SIZE];
+            batch.put(&key, value);
+            keys.push(key);
+        }
+        db.write(&batch).unwrap();
+        db.flush().unwrap();
+
+        for key in &keys {
+            black_box(db.get_pinned(key).unwrap());
+        }
+
+        Self {
+            _dir: dir,
+            db,
+            keys,
+        }
+    }
+
+    fn multiget_keys(&self) -> Vec<&[u8]> {
+        self.keys[..MULTIGET_SIZE]
+            .iter()
+            .map(Vec::as_slice)
+            .collect()
+    }
+}
+
+fn point_reads(c: &mut Criterion) {
+    let fixture = Fixture::new();
+    let key = fixture.keys[ENTRY_COUNT / 2].as_slice();
+    let mut group = c.benchmark_group("point_read");
+    group.throughput(Throughput::Bytes(VALUE_SIZE as u64));
+
+    group.bench_function("owned_vec", |b| {
+        b.iter(|| black_box(fixture.db.get(black_box(key)).unwrap()))
+    });
+    group.bench_function("pinned", |b| {
+        b.iter(|| black_box(fixture.db.get_pinned(black_box(key)).unwrap()))
+    });
+    group.bench_function("caller_buffer", |b| {
+        let mut buffer = vec![0; VALUE_SIZE];
+        b.iter(|| {
+            let result = fixture
+                .db
+                .get_into_buffer(black_box(key), black_box(&mut buffer))
+                .unwrap();
+            assert_eq!(result, GetIntoBufferResult::Found(VALUE_SIZE));
+            black_box(&buffer);
+        })
+    });
+    group.finish();
+}
+
+fn snapshot_reads(c: &mut Criterion) {
+    let fixture = Fixture::new();
+    let snapshot = fixture.db.snapshot();
+    let reusable = snapshot.read_options();
+    let key = fixture.keys[ENTRY_COUNT / 2].as_slice();
+    let mut group = c.benchmark_group("snapshot_point_read");
+
+    group.bench_function("new_read_options_each_call", |b| {
+        b.iter(|| black_box(snapshot.get(black_box(key)).unwrap()))
+    });
+    group.bench_function("reused_read_options", |b| {
+        b.iter(|| black_box(reusable.get(black_box(key)).unwrap()))
+    });
+    for read_count in [1, 2, 4, 8, 64] {
+        group.bench_with_input(
+            BenchmarkId::new("new_options_batch", read_count),
+            &read_count,
+            |b, &read_count| {
+                b.iter(|| {
+                    for _ in 0..read_count {
+                        black_box(snapshot.get(black_box(key)).unwrap());
+                    }
+                })
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("reused_options_batch", read_count),
+            &read_count,
+            |b, &read_count| {
+                b.iter(|| {
+                    let reads = snapshot.read_options();
+                    for _ in 0..read_count {
+                        black_box(reads.get(black_box(key)).unwrap());
+                    }
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+fn multiget(c: &mut Criterion) {
+    let fixture = Fixture::new();
+    let keys = fixture.multiget_keys();
+    let mut group = c.benchmark_group("multiget");
+    for batch_size in [1, 4, MULTIGET_SIZE] {
+        let keys = &keys[..batch_size];
+        group.throughput(Throughput::Elements(batch_size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("scalar_pinned_gets", batch_size),
+            keys,
+            |b, keys| {
+                b.iter(|| {
+                    let bytes = keys
+                        .iter()
+                        .map(|key| {
+                            fixture
+                                .db
+                                .get_pinned(black_box(key))
+                                .unwrap()
+                                .map_or(0, |value| value.len())
+                        })
+                        .sum::<usize>();
+                    black_box(bytes)
+                })
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("owned_values", batch_size),
+            keys,
+            |b, keys| {
+                b.iter(|| {
+                    let bytes = fixture
+                        .db
+                        .multi_get(black_box(keys.iter().copied()))
+                        .into_iter()
+                        .map(|result| result.unwrap().map_or(0, |value| value.len()))
+                        .sum::<usize>();
+                    black_box(bytes)
+                })
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("individual_pinned_handles", batch_size),
+            keys,
+            |b, keys| {
+                b.iter(|| {
+                    let bytes = fixture
+                        .db
+                        .multi_get_pinned(black_box(keys.iter().copied()))
+                        .into_iter()
+                        .map(|result| result.unwrap().map_or(0, |value| value.len()))
+                        .sum::<usize>();
+                    black_box(bytes)
+                })
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("batch_owned_pinned", batch_size),
+            keys,
+            |b, keys| {
+                b.iter(|| {
+                    let batch = fixture
+                        .db
+                        .batched_multi_get_pinned_batch(black_box(keys.iter().copied()), false)
+                        .unwrap();
+                    let bytes = batch
+                        .iter()
+                        .map(|result| result.unwrap().map_or(0, <[u8]>::len))
+                        .sum::<usize>();
+                    black_box(bytes)
+                })
+            },
+        );
+    }
+    group.finish();
+}
+
+fn perf_context(c: &mut Criterion) {
+    let mut group = c.benchmark_group("perf_context");
+    group.bench_function("fresh_wrapper", |b| {
+        b.iter(|| {
+            let mut context = PerfContext::default();
+            context.reset();
+            black_box(context.metric(PerfMetric::UserKeyComparisonCount));
+        })
+    });
+    group.bench_function("caller_reused", |b| {
+        let mut context = PerfContext::default();
+        b.iter(|| {
+            context.reset();
+            black_box(context.metric(PerfMetric::UserKeyComparisonCount));
+        })
+    });
+    group.bench_function("thread_local_reused", |b| {
+        b.iter(|| {
+            with_thread_local(|context| {
+                black_box(context.metric(PerfMetric::UserKeyComparisonCount))
+            })
+        })
+    });
+    group.finish();
+}
+
+fn property_reads(c: &mut Criterion) {
+    let fixture = Fixture::new();
+    let mut group = c.benchmark_group("integer_property");
+    group.bench_function("direct_integer_api", |b| {
+        b.iter(|| {
+            black_box(
+                fixture
+                    .db
+                    .property_int_value(properties::ESTIMATE_NUM_KEYS)
+                    .unwrap(),
+            )
+        })
+    });
+    group.bench_function("numeric_string_fallback", |b| {
+        b.iter(|| {
+            black_box(
+                fixture
+                    .db
+                    .property_int_value(properties::num_files_at_level(0))
+                    .unwrap(),
+            )
+        })
+    });
+    group.bench_function("unknown_property", |b| {
+        b.iter(|| {
+            black_box(
+                fixture
+                    .db
+                    .property_int_value("rocksdb.unknown-property")
+                    .unwrap(),
+            )
+        })
+    });
+    group.finish();
+}
+
+fn multi_cf_iterator_creation(c: &mut Criterion) {
+    let dir = tempfile::tempdir().unwrap();
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let names = (0..32)
+        .map(|index| format!("cf-{index:02}"))
+        .collect::<Vec<_>>();
+    let descriptors = names
+        .iter()
+        .map(|name| ColumnFamilyDescriptor::new(name, Options::default()))
+        .collect::<Vec<_>>();
+    let db = DB::open_cf_descriptors(&options, dir.path(), descriptors).unwrap();
+    let handles = names
+        .iter()
+        .map(|name| db.cf_handle(name).unwrap())
+        .collect::<Vec<_>>();
+    let mut group = c.benchmark_group("multi_cf_iterator_creation");
+
+    for count in [1_usize, 2, 8, 32] {
+        group.throughput(Throughput::Elements(count as u64));
+        group.bench_with_input(
+            BenchmarkId::new("individual_calls", count),
+            &count,
+            |b, &count| {
+                b.iter(|| {
+                    let iterators = handles[..count]
+                        .iter()
+                        .map(|cf| db.raw_iterator_cf(cf))
+                        .collect::<Vec<_>>();
+                    black_box(iterators)
+                })
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("single_native_call", count),
+            &count,
+            |b, &count| b.iter(|| black_box(db.raw_iterators_cf(handles[..count].iter()).unwrap())),
+        );
+    }
+    group.finish();
+}
+
+fn scans(c: &mut Criterion) {
+    let fixture = Fixture::new();
+    let mut group = c.benchmark_group("full_scan");
+    group.throughput(Throughput::Elements(ENTRY_COUNT as u64));
+
+    group.bench_function("owned_iterator", |b| {
+        b.iter(|| {
+            let bytes = fixture
+                .db
+                .iterator(IteratorMode::Start)
+                .map(|item| {
+                    let (key, value) = item.unwrap();
+                    key.len() + value.len()
+                })
+                .sum::<usize>();
+            black_box(bytes)
+        })
+    });
+    group.bench_function("borrowed_callback", |b| {
+        b.iter(|| {
+            let mut bytes = 0;
+            let mut iterator = fixture.db.iterator(IteratorMode::Start);
+            let result: Result<ControlFlow<()>, Error> = iterator.try_for_each_ref(|key, value| {
+                bytes += key.len() + value.len();
+                Ok(ControlFlow::Continue(()))
+            });
+            assert!(matches!(result, Ok(ControlFlow::Continue(()))));
+            black_box(bytes)
+        })
+    });
+    group.finish();
+}
+
+fn write_batch_assembly(c: &mut Criterion) {
+    let prefix = b"tenant:";
+    let suffix = b":metadata";
+    let value_prefix = b"header:";
+    let value_suffix = vec![7; VALUE_SIZE];
+    let mut group = c.benchmark_group("write_batch_assembly");
+    group.throughput(Throughput::Elements(64));
+
+    group.bench_function("concatenated", |b| {
+        b.iter(|| {
+            let mut batch = WriteBatch::with_capacity_bytes(64 * (VALUE_SIZE + 32));
+            for index in 0_u64..64 {
+                let index = index.to_be_bytes();
+                let mut key = Vec::with_capacity(prefix.len() + index.len() + suffix.len());
+                key.extend_from_slice(prefix);
+                key.extend_from_slice(&index);
+                key.extend_from_slice(suffix);
+                let mut value = Vec::with_capacity(value_prefix.len() + value_suffix.len());
+                value.extend_from_slice(value_prefix);
+                value.extend_from_slice(&value_suffix);
+                batch.put(key, value);
+            }
+            black_box(batch)
+        })
+    });
+    group.bench_function("vectored", |b| {
+        b.iter(|| {
+            let mut batch = WriteBatch::with_capacity_bytes(64 * (VALUE_SIZE + 32));
+            for index in 0_u64..64 {
+                let index = index.to_be_bytes();
+                batch
+                    .put_vectored(
+                        &[
+                            IoSlice::new(prefix),
+                            IoSlice::new(&index),
+                            IoSlice::new(suffix),
+                        ],
+                        &[IoSlice::new(value_prefix), IoSlice::new(&value_suffix)],
+                    )
+                    .unwrap();
+            }
+            black_box(batch)
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    point_reads,
+    snapshot_reads,
+    multiget,
+    perf_context,
+    property_reads,
+    multi_cf_iterator_creation,
+    scans,
+    write_batch_assembly
+);
+criterion_main!(benches);

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -482,8 +482,12 @@ mod vendor {
 
     /// Other Cargo features that translate into preprocessor defines.
     fn apply_optional_features(cfg: &mut cc::Build, target: &Target) {
-        if cfg!(feature = "rtti") {
-            cfg.define("USE_RTTI", Some("1"));
+        if cfg!(feature = "rtti") || cfg!(feature = "coroutines") {
+            cfg.define("ROCKSDB_USE_RTTI", None);
+        } else if target.is_msvc() {
+            cfg.flag_if_supported("/GR-");
+        } else {
+            cfg.flag_if_supported("-fno-rtti");
         }
         if cfg!(feature = "malloc-usable-size") && target.os == "linux" {
             cfg.define("ROCKSDB_MALLOC_USABLE_SIZE", Some("1"));
@@ -1472,7 +1476,11 @@ mod extensions {
         }
 
         cfg.file("c-api-extensions/c_api_extensions.cc");
+        cfg.define("RUST_ROCKSDB_SYSTEM_BACKEND", None);
         cfg.cpp(true);
+        if target.is_msvc() && cfg!(feature = "mt_static") {
+            cfg.static_crt(true);
+        }
 
         // Match the vendored build's C++ standard so the extension's
         // headers compile the same way against the user's

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.cc
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.cc
@@ -12,25 +12,37 @@
 #include <cstdlib>
 #include <cstring>
 #include <memory>
+#include <limits>
 #include <string>
+#include <unordered_map>
+#include <vector>
 
+#include "rocksdb/db.h"
 #include "rocksdb/listener.h"
 #include "rocksdb/options.h"
+#include "rocksdb/slice.h"
 #include "rocksdb/table.h"
+#include "rocksdb/version.h"
+#include "rocksdb/write_batch.h"
 
 using ROCKSDB_NAMESPACE::BackgroundErrorRecoveryInfo;
 using ROCKSDB_NAMESPACE::BlockBasedTableOptions;
 using ROCKSDB_NAMESPACE::CompactRangeOptions;
 using ROCKSDB_NAMESPACE::CompactionJobInfo;
+using ROCKSDB_NAMESPACE::ColumnFamilyHandle;
 using ROCKSDB_NAMESPACE::DB;
 using ROCKSDB_NAMESPACE::EventListener;
 using ROCKSDB_NAMESPACE::ExternalFileIngestionInfo;
 using ROCKSDB_NAMESPACE::FlushJobInfo;
 using ROCKSDB_NAMESPACE::Options;
+using ROCKSDB_NAMESPACE::PinnableSlice;
 using ROCKSDB_NAMESPACE::ReadOptions;
+using ROCKSDB_NAMESPACE::Slice;
+using ROCKSDB_NAMESPACE::SliceParts;
 using ROCKSDB_NAMESPACE::Status;
 using ROCKSDB_NAMESPACE::SubcompactionJobInfo;
 using ROCKSDB_NAMESPACE::WriteStallInfo;
+using ROCKSDB_NAMESPACE::WriteBatch;
 using ROCKSDB_NAMESPACE::MemTableInfo;
 
 struct rust_rocksdb_status_t {
@@ -58,6 +70,15 @@ static bool RustSaveError(char** errptr, const Status& s) {
   }
   *errptr = copy;
   return true;
+}
+
+static void RustSaveMessage(char** errptr, const char* message) {
+  assert(errptr != nullptr);
+  char* copy = message == nullptr ? nullptr : strdup(message);
+  if (*errptr != nullptr) {
+    std::free(*errptr);
+  }
+  *errptr = copy;
 }
 
 extern "C" void rust_rocksdb_status_get_error(rust_rocksdb_status_t* status,
@@ -338,6 +359,42 @@ extern "C" unsigned char rocksdb_options_get_memtable_batch_lookup_optimization(
 }
 
 // -----------------------------------------------------------------------------
+// Options::open_files_async
+// -----------------------------------------------------------------------------
+
+#if ROCKSDB_MAJOR > 11 || (ROCKSDB_MAJOR == 11 && ROCKSDB_MINOR >= 1)
+#define RUST_ROCKSDB_HAS_OPEN_FILES_ASYNC 1
+#else
+#define RUST_ROCKSDB_HAS_OPEN_FILES_ASYNC 0
+#endif
+
+extern "C" unsigned char rust_rocksdb_options_open_files_async_supported() {
+  return RUST_ROCKSDB_HAS_OPEN_FILES_ASYNC;
+}
+
+extern "C" unsigned char rust_rocksdb_options_set_open_files_async(
+    rocksdb_options_t* opt, unsigned char enabled) {
+#if RUST_ROCKSDB_HAS_OPEN_FILES_ASYNC
+  rocksdb_options_set_open_files_async(opt, enabled);
+  return 1;
+#else
+  (void)opt;
+  (void)enabled;
+  return 0;
+#endif
+}
+
+extern "C" unsigned char rust_rocksdb_options_get_open_files_async(
+    rocksdb_options_t* opt) {
+#if RUST_ROCKSDB_HAS_OPEN_FILES_ASYNC
+  return rocksdb_options_get_open_files_async(opt);
+#else
+  (void)opt;
+  return 0;
+#endif
+}
+
+// -----------------------------------------------------------------------------
 // CompactOptions::blob_garbage_collection_age_cutoff
 // -----------------------------------------------------------------------------
 
@@ -349,4 +406,494 @@ extern "C" void rocksdb_compactoptions_set_blob_garbage_collection_age_cutoff(
 extern "C" double rocksdb_compactoptions_get_blob_garbage_collection_age_cutoff(
     rocksdb_compactoptions_t* opt) {
   return reinterpret_cast<CompactRangeOptions*>(opt)->blob_garbage_collection_age_cutoff;
+}
+
+// -----------------------------------------------------------------------------
+// Batch-owned pinned MultiGet results
+// -----------------------------------------------------------------------------
+
+struct rust_rocksdb_pinnable_batch_t {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+  std::vector<rocksdb_pinnableslice_t*> system_values;
+#else
+  std::vector<PinnableSlice> values;
+  std::vector<size_t> result_indexes;
+#endif
+  std::unordered_map<size_t, std::string> errors;
+
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+  ~rust_rocksdb_pinnable_batch_t() {
+    for (auto* value : system_values) {
+      if (value != nullptr) {
+        rocksdb_pinnableslice_destroy(value);
+      }
+    }
+  }
+#endif
+};
+
+#ifndef RUST_ROCKSDB_SYSTEM_BACKEND
+static constexpr size_t kRustRocksDbBatchNotFound =
+    std::numeric_limits<size_t>::max();
+static constexpr size_t kRustRocksDbBatchError =
+    std::numeric_limits<size_t>::max() - 1;
+#endif
+
+#ifndef RUST_ROCKSDB_SYSTEM_BACKEND
+static DB* RustRocksDbRep(rocksdb_t* db) {
+  return *reinterpret_cast<DB**>(db);
+}
+
+static ColumnFamilyHandle* RustRocksDbColumnFamilyRep(
+    rocksdb_column_family_handle_t* column_family) {
+  return *reinterpret_cast<ColumnFamilyHandle**>(column_family);
+}
+#endif
+
+extern "C" rust_rocksdb_pinnable_batch_t*
+rust_rocksdb_batched_multi_get_pinned(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, size_t num_keys,
+    const rocksdb_slice_t* keys, unsigned char sorted_input, char** errptr) {
+  try {
+    auto batch = std::make_unique<rust_rocksdb_pinnable_batch_t>();
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+    batch->system_values.resize(num_keys, nullptr);
+    std::vector<char*> errors(num_keys, nullptr);
+    using ColumnFamilyHandlePtr =
+        std::unique_ptr<rocksdb_column_family_handle_t,
+                        decltype(&rocksdb_column_family_handle_destroy)>;
+    ColumnFamilyHandlePtr owned_default(nullptr,
+                                        &rocksdb_column_family_handle_destroy);
+    if (column_family == nullptr) {
+      owned_default.reset(rocksdb_get_default_column_family_handle(db));
+      column_family = owned_default.get();
+    }
+    try {
+      rocksdb_batched_multi_get_cf_slice(
+          db, options, column_family, num_keys, keys,
+          batch->system_values.data(), errors.data(), sorted_input != 0);
+    } catch (...) {
+      for (auto* error : errors) {
+        if (error != nullptr) {
+          rocksdb_free(error);
+        }
+      }
+      throw;
+    }
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (errors[i] != nullptr) {
+        batch->errors.emplace(i, errors[i]);
+        rocksdb_free(errors[i]);
+      }
+    }
+#else
+    batch->result_indexes.resize(num_keys, kRustRocksDbBatchNotFound);
+    if (num_keys == 0) {
+      return batch.release();
+    }
+
+    DB* db_rep = RustRocksDbRep(db);
+    ColumnFamilyHandle* column_family_rep =
+        column_family == nullptr ? db_rep->DefaultColumnFamily()
+                                 : RustRocksDbColumnFamilyRep(column_family);
+    const auto* read_options = reinterpret_cast<const ReadOptions*>(options);
+    const auto* key_slices = reinterpret_cast<const Slice*>(keys);
+    std::vector<PinnableSlice> values(num_keys);
+    std::vector<Status> statuses(num_keys);
+
+    db_rep->MultiGet(*read_options, column_family_rep, num_keys, key_slices,
+                     values.data(), statuses.data(), sorted_input != 0);
+
+    size_t hit_count = 0;
+    for (const auto& status : statuses) {
+      if (status.ok()) {
+        ++hit_count;
+      }
+    }
+    batch->values.reserve(hit_count);
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (statuses[i].ok()) {
+        batch->result_indexes[i] = batch->values.size();
+        batch->values.emplace_back(std::move(values[i]));
+      } else if (!statuses[i].IsNotFound()) {
+        batch->result_indexes[i] = kRustRocksDbBatchError;
+        batch->errors.emplace(i, statuses[i].ToString());
+      }
+    }
+#endif
+    return batch.release();
+  } catch (const std::exception& error) {
+    RustSaveMessage(errptr, error.what());
+    return nullptr;
+  } catch (...) {
+    RustSaveMessage(errptr, "unknown C++ exception in pinned MultiGet");
+    return nullptr;
+  }
+}
+
+extern "C" size_t rust_rocksdb_pinnable_batch_len(
+    const rust_rocksdb_pinnable_batch_t* batch) {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+  return batch->system_values.size();
+#else
+  return batch->result_indexes.size();
+#endif
+}
+
+extern "C" unsigned char rust_rocksdb_pinnable_batch_get(
+    const rust_rocksdb_pinnable_batch_t* batch, size_t index,
+    const char** value, size_t* value_len, const char** error,
+    size_t* error_len) {
+  *value = nullptr;
+  *value_len = 0;
+  *error = nullptr;
+  *error_len = 0;
+
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+  assert(index < batch->system_values.size());
+  const auto error_iter = batch->errors.find(index);
+  if (error_iter != batch->errors.end()) {
+    *error = error_iter->second.data();
+    *error_len = error_iter->second.size();
+    return rust_rocksdb_pinnable_batch_error;
+  }
+  if (batch->system_values[index] == nullptr) {
+    return rust_rocksdb_pinnable_batch_not_found;
+  }
+  *value =
+      rocksdb_pinnableslice_value(batch->system_values[index], value_len);
+  return rust_rocksdb_pinnable_batch_found;
+#else
+  assert(index < batch->result_indexes.size());
+  const size_t result_index = batch->result_indexes[index];
+  if (result_index == kRustRocksDbBatchNotFound) {
+    return rust_rocksdb_pinnable_batch_not_found;
+  }
+  if (result_index == kRustRocksDbBatchError) {
+    const auto error_iter = batch->errors.find(index);
+    assert(error_iter != batch->errors.end());
+    *error = error_iter->second.data();
+    *error_len = error_iter->second.size();
+    return rust_rocksdb_pinnable_batch_error;
+  }
+
+  *value = batch->values[result_index].data();
+  *value_len = batch->values[result_index].size();
+  return rust_rocksdb_pinnable_batch_found;
+#endif
+}
+
+extern "C" void rust_rocksdb_pinnable_batch_destroy(
+    rust_rocksdb_pinnable_batch_t* batch) {
+  delete batch;
+}
+
+extern "C" void rust_rocksdb_batched_multi_get_cf_slice_safe(
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, size_t num_keys,
+    const rocksdb_slice_t* keys, rocksdb_pinnableslice_t** values, char** errors,
+    unsigned char sorted_input, char** errptr) {
+  for (size_t i = 0; i < num_keys; ++i) {
+    values[i] = nullptr;
+    errors[i] = nullptr;
+  }
+  try {
+    rocksdb_batched_multi_get_cf_slice(
+        db, options, column_family, num_keys, keys, values, errors,
+        sorted_input != 0);
+  } catch (const std::exception& error) {
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (values[i] != nullptr) {
+        rocksdb_pinnableslice_destroy(values[i]);
+        values[i] = nullptr;
+      }
+      if (errors[i] != nullptr) {
+        rocksdb_free(errors[i]);
+        errors[i] = nullptr;
+      }
+    }
+    RustSaveMessage(errptr, error.what());
+  } catch (...) {
+    for (size_t i = 0; i < num_keys; ++i) {
+      if (values[i] != nullptr) {
+        rocksdb_pinnableslice_destroy(values[i]);
+        values[i] = nullptr;
+      }
+      if (errors[i] != nullptr) {
+        rocksdb_free(errors[i]);
+        errors[i] = nullptr;
+      }
+    }
+    RustSaveMessage(errptr, "unknown C++ exception in batched MultiGet");
+  }
+}
+
+extern "C" void rust_rocksdb_create_iterators_safe(
+    rocksdb_t* db, rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t** column_families,
+    rocksdb_iterator_t** iterators, size_t size, char** errptr) {
+  for (size_t i = 0; i < size; ++i) {
+    iterators[i] = nullptr;
+  }
+  try {
+    rocksdb_create_iterators(db, options, column_families, iterators, size,
+                             errptr);
+  } catch (const std::exception& error) {
+    for (size_t i = 0; i < size; ++i) {
+      if (iterators[i] != nullptr) {
+        rocksdb_iter_destroy(iterators[i]);
+        iterators[i] = nullptr;
+      }
+    }
+    RustSaveMessage(errptr, error.what());
+  } catch (...) {
+    for (size_t i = 0; i < size; ++i) {
+      if (iterators[i] != nullptr) {
+        rocksdb_iter_destroy(iterators[i]);
+        iterators[i] = nullptr;
+      }
+    }
+    RustSaveMessage(errptr, "unknown C++ exception while creating iterators");
+  }
+}
+
+// -----------------------------------------------------------------------------
+// Slice-based vectored WriteBatch operations
+// -----------------------------------------------------------------------------
+
+#ifndef RUST_ROCKSDB_SYSTEM_BACKEND
+static WriteBatch* RustRocksDbWriteBatchRep(rocksdb_writebatch_t* batch) {
+  return reinterpret_cast<WriteBatch*>(batch);
+}
+
+static SliceParts RustRocksDbSliceParts(int count,
+                                       const rocksdb_slice_t* parts) {
+  return SliceParts(reinterpret_cast<const Slice*>(parts), count);
+}
+#endif
+
+template <typename Operation>
+static void RustRocksDbWriteBatchCall(char** errptr, Operation operation) {
+  try {
+    RustSaveError(errptr, operation());
+  } catch (const std::exception& error) {
+    RustSaveMessage(errptr, error.what());
+  } catch (...) {
+    RustSaveMessage(errptr, "unknown C++ exception in vectored WriteBatch");
+  }
+}
+
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+struct RustRocksDbSliceArrays {
+  std::vector<const char*> pointers;
+  std::vector<size_t> lengths;
+
+  RustRocksDbSliceArrays(int count, const rocksdb_slice_t* slices) {
+    pointers.reserve(count);
+    lengths.reserve(count);
+    for (int i = 0; i < count; ++i) {
+      pointers.push_back(slices[i].data);
+      lengths.push_back(slices[i].size);
+    }
+  }
+};
+
+static void RustRocksDbCheckWriteBatchCount(rocksdb_writebatch_t* batch,
+                                            int before, char** errptr) {
+  if (rocksdb_writebatch_count(batch) != before + 1) {
+    RustSaveMessage(errptr, "RocksDB rejected the vectored WriteBatch operation");
+  }
+}
+#endif
+
+extern "C" void rust_rocksdb_writebatch_put_slices(
+    rocksdb_writebatch_t* batch, int key_count, const rocksdb_slice_t* keys,
+    int value_count, const rocksdb_slice_t* values, char** errptr) {
+  RustRocksDbWriteBatchCall(errptr, [&] {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+    const int before = rocksdb_writebatch_count(batch);
+    RustRocksDbSliceArrays key_parts(key_count, keys);
+    RustRocksDbSliceArrays value_parts(value_count, values);
+    rocksdb_writebatch_putv(batch, key_count, key_parts.pointers.data(),
+                            key_parts.lengths.data(), value_count,
+                            value_parts.pointers.data(),
+                            value_parts.lengths.data());
+    RustRocksDbCheckWriteBatchCount(batch, before, errptr);
+    return Status::OK();
+#else
+    return RustRocksDbWriteBatchRep(batch)->Put(
+        RustRocksDbSliceParts(key_count, keys),
+        RustRocksDbSliceParts(value_count, values));
+#endif
+  });
+}
+
+extern "C" void rust_rocksdb_writebatch_put_slices_cf(
+    rocksdb_writebatch_t* batch,
+    rocksdb_column_family_handle_t* column_family, int key_count,
+    const rocksdb_slice_t* keys, int value_count,
+    const rocksdb_slice_t* values, char** errptr) {
+  RustRocksDbWriteBatchCall(errptr, [&] {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+    const int before = rocksdb_writebatch_count(batch);
+    RustRocksDbSliceArrays key_parts(key_count, keys);
+    RustRocksDbSliceArrays value_parts(value_count, values);
+    rocksdb_writebatch_putv_cf(
+        batch, column_family, key_count, key_parts.pointers.data(),
+        key_parts.lengths.data(), value_count, value_parts.pointers.data(),
+        value_parts.lengths.data());
+    RustRocksDbCheckWriteBatchCount(batch, before, errptr);
+    return Status::OK();
+#else
+    return RustRocksDbWriteBatchRep(batch)->Put(
+        RustRocksDbColumnFamilyRep(column_family),
+        RustRocksDbSliceParts(key_count, keys),
+        RustRocksDbSliceParts(value_count, values));
+#endif
+  });
+}
+
+extern "C" void rust_rocksdb_writebatch_merge_slices(
+    rocksdb_writebatch_t* batch, int key_count, const rocksdb_slice_t* keys,
+    int value_count, const rocksdb_slice_t* values, char** errptr) {
+  RustRocksDbWriteBatchCall(errptr, [&] {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+    const int before = rocksdb_writebatch_count(batch);
+    RustRocksDbSliceArrays key_parts(key_count, keys);
+    RustRocksDbSliceArrays value_parts(value_count, values);
+    rocksdb_writebatch_mergev(batch, key_count, key_parts.pointers.data(),
+                              key_parts.lengths.data(), value_count,
+                              value_parts.pointers.data(),
+                              value_parts.lengths.data());
+    RustRocksDbCheckWriteBatchCount(batch, before, errptr);
+    return Status::OK();
+#else
+    return RustRocksDbWriteBatchRep(batch)->Merge(
+        RustRocksDbSliceParts(key_count, keys),
+        RustRocksDbSliceParts(value_count, values));
+#endif
+  });
+}
+
+extern "C" void rust_rocksdb_writebatch_merge_slices_cf(
+    rocksdb_writebatch_t* batch,
+    rocksdb_column_family_handle_t* column_family, int key_count,
+    const rocksdb_slice_t* keys, int value_count,
+    const rocksdb_slice_t* values, char** errptr) {
+  RustRocksDbWriteBatchCall(errptr, [&] {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+    const int before = rocksdb_writebatch_count(batch);
+    RustRocksDbSliceArrays key_parts(key_count, keys);
+    RustRocksDbSliceArrays value_parts(value_count, values);
+    rocksdb_writebatch_mergev_cf(
+        batch, column_family, key_count, key_parts.pointers.data(),
+        key_parts.lengths.data(), value_count, value_parts.pointers.data(),
+        value_parts.lengths.data());
+    RustRocksDbCheckWriteBatchCount(batch, before, errptr);
+    return Status::OK();
+#else
+    return RustRocksDbWriteBatchRep(batch)->Merge(
+        RustRocksDbColumnFamilyRep(column_family),
+        RustRocksDbSliceParts(key_count, keys),
+        RustRocksDbSliceParts(value_count, values));
+#endif
+  });
+}
+
+extern "C" void rust_rocksdb_writebatch_delete_slices(
+    rocksdb_writebatch_t* batch, int key_count, const rocksdb_slice_t* keys,
+    char** errptr) {
+  RustRocksDbWriteBatchCall(errptr, [&] {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+    const int before = rocksdb_writebatch_count(batch);
+    RustRocksDbSliceArrays key_parts(key_count, keys);
+    rocksdb_writebatch_deletev(batch, key_count, key_parts.pointers.data(),
+                               key_parts.lengths.data());
+    RustRocksDbCheckWriteBatchCount(batch, before, errptr);
+    return Status::OK();
+#else
+    return RustRocksDbWriteBatchRep(batch)->Delete(
+        RustRocksDbSliceParts(key_count, keys));
+#endif
+  });
+}
+
+extern "C" void rust_rocksdb_writebatch_delete_slices_cf(
+    rocksdb_writebatch_t* batch,
+    rocksdb_column_family_handle_t* column_family, int key_count,
+    const rocksdb_slice_t* keys, char** errptr) {
+  RustRocksDbWriteBatchCall(errptr, [&] {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+    const int before = rocksdb_writebatch_count(batch);
+    RustRocksDbSliceArrays key_parts(key_count, keys);
+    rocksdb_writebatch_deletev_cf(batch, column_family, key_count,
+                                  key_parts.pointers.data(),
+                                  key_parts.lengths.data());
+    RustRocksDbCheckWriteBatchCount(batch, before, errptr);
+    return Status::OK();
+#else
+    return RustRocksDbWriteBatchRep(batch)->Delete(
+        RustRocksDbColumnFamilyRep(column_family),
+        RustRocksDbSliceParts(key_count, keys));
+#endif
+  });
+}
+
+extern "C" void rust_rocksdb_writebatch_delete_range_slices(
+    rocksdb_writebatch_t* batch, int begin_count,
+    const rocksdb_slice_t* begin, int end_count, const rocksdb_slice_t* end,
+    char** errptr) {
+  RustRocksDbWriteBatchCall(errptr, [&] {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+    if (begin_count != end_count) {
+      RustSaveMessage(errptr,
+                      "system RocksDB requires equal range-bound part counts");
+      return Status::OK();
+    }
+    const int before = rocksdb_writebatch_count(batch);
+    RustRocksDbSliceArrays begin_parts(begin_count, begin);
+    RustRocksDbSliceArrays end_parts(end_count, end);
+    rocksdb_writebatch_delete_rangev(
+        batch, begin_count, begin_parts.pointers.data(),
+        begin_parts.lengths.data(), end_parts.pointers.data(),
+        end_parts.lengths.data());
+    RustRocksDbCheckWriteBatchCount(batch, before, errptr);
+    return Status::OK();
+#else
+    return RustRocksDbWriteBatchRep(batch)->DeleteRange(
+        RustRocksDbSliceParts(begin_count, begin),
+        RustRocksDbSliceParts(end_count, end));
+#endif
+  });
+}
+
+extern "C" void rust_rocksdb_writebatch_delete_range_slices_cf(
+    rocksdb_writebatch_t* batch,
+    rocksdb_column_family_handle_t* column_family, int begin_count,
+    const rocksdb_slice_t* begin, int end_count, const rocksdb_slice_t* end,
+    char** errptr) {
+  RustRocksDbWriteBatchCall(errptr, [&] {
+#ifdef RUST_ROCKSDB_SYSTEM_BACKEND
+    if (begin_count != end_count) {
+      RustSaveMessage(errptr,
+                      "system RocksDB requires equal range-bound part counts");
+      return Status::OK();
+    }
+    const int before = rocksdb_writebatch_count(batch);
+    RustRocksDbSliceArrays begin_parts(begin_count, begin);
+    RustRocksDbSliceArrays end_parts(end_count, end);
+    rocksdb_writebatch_delete_rangev_cf(
+        batch, column_family, begin_count, begin_parts.pointers.data(),
+        begin_parts.lengths.data(), end_parts.pointers.data(),
+        end_parts.lengths.data());
+    RustRocksDbCheckWriteBatchCount(batch, before, errptr);
+    return Status::OK();
+#else
+    return RustRocksDbWriteBatchRep(batch)->DeleteRange(
+        RustRocksDbColumnFamilyRep(column_family),
+        RustRocksDbSliceParts(begin_count, begin),
+        RustRocksDbSliceParts(end_count, end));
+#endif
+  });
 }

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.h
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.h
@@ -77,6 +77,14 @@ extern ROCKSDB_LIBRARY_API void rocksdb_options_set_memtable_batch_lookup_optimi
 extern ROCKSDB_LIBRARY_API unsigned char rocksdb_options_get_memtable_batch_lookup_optimization(
     rocksdb_options_t*);
 
+/* Options::open_files_async compatibility wrapper. */
+extern ROCKSDB_LIBRARY_API unsigned char
+rust_rocksdb_options_open_files_async_supported(void);
+extern ROCKSDB_LIBRARY_API unsigned char
+rust_rocksdb_options_set_open_files_async(rocksdb_options_t*, unsigned char);
+extern ROCKSDB_LIBRARY_API unsigned char
+rust_rocksdb_options_get_open_files_async(rocksdb_options_t*);
+
 /* -------------------------------------------------------------------------
  * CompactOptions::blob_garbage_collection_age_cutoff
  *
@@ -87,6 +95,72 @@ extern ROCKSDB_LIBRARY_API void rocksdb_compactoptions_set_blob_garbage_collecti
     rocksdb_compactoptions_t*, double);
 extern ROCKSDB_LIBRARY_API double rocksdb_compactoptions_get_blob_garbage_collection_age_cutoff(
     rocksdb_compactoptions_t*);
+
+/* -------------------------------------------------------------------------
+ * Batch-owned pinned MultiGet results
+ *
+ * The upstream batched C API allocates one rocksdb_pinnableslice_t wrapper
+ * per successful key. This additive API keeps the PinnableSlice values in one
+ * owner so Rust can borrow every result without per-key wrapper allocation.
+ * ------------------------------------------------------------------------- */
+typedef struct rust_rocksdb_pinnable_batch_t rust_rocksdb_pinnable_batch_t;
+
+enum {
+  rust_rocksdb_pinnable_batch_not_found = 0,
+  rust_rocksdb_pinnable_batch_found = 1,
+  rust_rocksdb_pinnable_batch_error = 2,
+};
+
+extern ROCKSDB_LIBRARY_API rust_rocksdb_pinnable_batch_t*
+rust_rocksdb_batched_multi_get_pinned(
+    rocksdb_t*, const rocksdb_readoptions_t*,
+    rocksdb_column_family_handle_t*, size_t, const rocksdb_slice_t*,
+    unsigned char, char**);
+extern ROCKSDB_LIBRARY_API size_t rust_rocksdb_pinnable_batch_len(
+    const rust_rocksdb_pinnable_batch_t*);
+extern ROCKSDB_LIBRARY_API unsigned char rust_rocksdb_pinnable_batch_get(
+    const rust_rocksdb_pinnable_batch_t*, size_t, const char**, size_t*,
+    const char**, size_t*);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_pinnable_batch_destroy(
+    rust_rocksdb_pinnable_batch_t*);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_batched_multi_get_cf_slice_safe(
+    rocksdb_t*, const rocksdb_readoptions_t*,
+    rocksdb_column_family_handle_t*, size_t, const rocksdb_slice_t*,
+    rocksdb_pinnableslice_t**, char**, unsigned char, char**);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_create_iterators_safe(
+    rocksdb_t*, rocksdb_readoptions_t*, rocksdb_column_family_handle_t**,
+    rocksdb_iterator_t**, size_t, char**);
+
+/* -------------------------------------------------------------------------
+ * Slice-based vectored WriteBatch operations
+ *
+ * The upstream putv/mergev/deletev wrappers rebuild Slice arrays from
+ * separate pointer and length arrays. These variants accept ABI-compatible
+ * rocksdb_slice_t arrays directly.
+ * ------------------------------------------------------------------------- */
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_writebatch_put_slices(
+    rocksdb_writebatch_t*, int, const rocksdb_slice_t*, int,
+    const rocksdb_slice_t*, char**);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_writebatch_put_slices_cf(
+    rocksdb_writebatch_t*, rocksdb_column_family_handle_t*, int,
+    const rocksdb_slice_t*, int, const rocksdb_slice_t*, char**);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_writebatch_merge_slices(
+    rocksdb_writebatch_t*, int, const rocksdb_slice_t*, int,
+    const rocksdb_slice_t*, char**);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_writebatch_merge_slices_cf(
+    rocksdb_writebatch_t*, rocksdb_column_family_handle_t*, int,
+    const rocksdb_slice_t*, int, const rocksdb_slice_t*, char**);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_writebatch_delete_slices(
+    rocksdb_writebatch_t*, int, const rocksdb_slice_t*, char**);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_writebatch_delete_slices_cf(
+    rocksdb_writebatch_t*, rocksdb_column_family_handle_t*, int,
+    const rocksdb_slice_t*, char**);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_writebatch_delete_range_slices(
+    rocksdb_writebatch_t*, int, const rocksdb_slice_t*, int,
+    const rocksdb_slice_t*, char**);
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_writebatch_delete_range_slices_cf(
+    rocksdb_writebatch_t*, rocksdb_column_family_handle_t*, int,
+    const rocksdb_slice_t*, int, const rocksdb_slice_t*, char**);
 
 /* -------------------------------------------------------------------------
  * EventListener background error status severity and recovery callbacks

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -74,6 +74,21 @@ impl Cache {
         unsafe { ffi::rocksdb_cache_get_pinned_usage(self.0.inner.as_ptr()) }
     }
 
+    /// Returns the configured cache capacity in bytes.
+    pub fn get_capacity(&self) -> usize {
+        unsafe { ffi::rocksdb_cache_get_capacity(self.0.inner.as_ptr()) }
+    }
+
+    /// Returns the number of entries currently occupying the cache hash tables.
+    pub fn get_occupancy_count(&self) -> usize {
+        unsafe { ffi::rocksdb_cache_get_occupancy_count(self.0.inner.as_ptr()) }
+    }
+
+    /// Returns the total number of cache hash table addresses.
+    pub fn get_table_address_count(&self) -> usize {
+        unsafe { ffi::rocksdb_cache_get_table_address_count(self.0.inner.as_ptr()) }
+    }
+
     /// Sets cache capacity in bytes.
     pub fn set_capacity(&mut self, capacity: size_t) {
         unsafe {

--- a/src/db.rs
+++ b/src/db.rs
@@ -31,9 +31,10 @@ use crate::column_family::ColumnFamilyTtl;
 use crate::ffi_util::CSlice;
 use crate::{
     ColumnFamily, ColumnFamilyDescriptor, CompactOptions, DBIteratorWithThreadMode,
-    DBPinnableSlice, DBRawIteratorWithThreadMode, DBWALIterator, DEFAULT_COLUMN_FAMILY_NAME,
-    Direction, Error, FlushOptions, IngestExternalFileOptions, IteratorMode, Options, ReadOptions,
-    SnapshotWithThreadMode, WaitForCompactOptions, WriteBatch, WriteBatchWithIndex, WriteOptions,
+    DBPinnableBatch, DBPinnableSlice, DBRawIteratorWithThreadMode, DBWALIterator,
+    DEFAULT_COLUMN_FAMILY_NAME, Direction, Error, FlushOptions, IngestExternalFileOptions,
+    IteratorMode, Options, ReadOptions, SnapshotWithThreadMode, WaitForCompactOptions, WriteBatch,
+    WriteBatchWithIndex, WriteOptions,
     column_family::{AsColumnFamilyRef, BoundColumnFamily, UnboundColumnFamily},
     db_options::{ImportColumnFamilyOptions, OptionsMustOutliveDB},
     ffi,
@@ -426,6 +427,35 @@ impl<T: ThreadMode, D: DBInner> DBAccess for DBCommon<T, D> {
 
 pub struct DBWithThreadModeInner {
     inner: *mut ffi::rocksdb_t,
+}
+
+struct OwnedColumnFamilyHandle {
+    inner: *mut ffi::rocksdb_column_family_handle_t,
+}
+
+struct PinnedMultiGetOutput {
+    values: Vec<*mut ffi::rocksdb_pinnableslice_t>,
+    errors: Vec<*mut c_char>,
+}
+
+struct CreatedIterators {
+    handles: Vec<*mut ffi::rocksdb_iterator_t>,
+}
+
+impl OwnedColumnFamilyHandle {
+    fn default_for(db: *mut ffi::rocksdb_t) -> Self {
+        Self {
+            inner: unsafe { ffi::rocksdb_get_default_column_family_handle(db) },
+        }
+    }
+}
+
+impl Drop for OwnedColumnFamilyHandle {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rocksdb_column_family_handle_destroy(self.inner);
+        }
+    }
 }
 
 impl DBInner for DBWithThreadModeInner {
@@ -1549,8 +1579,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
 
     /// Returns pinned values associated with the given keys using default read options.
     ///
-    /// This iterates `get_pinned_opt` for each key and returns zero-copy
-    /// `DBPinnableSlice` values when present, avoiding value copies.
+    /// RocksDB processes the keys in one native batch. Results stay in input order.
     pub fn multi_get_pinned<K, I>(
         &'_ self,
         keys: I,
@@ -1564,8 +1593,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
 
     /// Returns pinned values associated with the given keys using the provided read options.
     ///
-    /// This iterates `get_pinned_opt` for each key and returns zero-copy
-    /// `DBPinnableSlice` values when present, avoiding value copies.
+    /// RocksDB processes the keys in one native batch. Results stay in input order.
     pub fn multi_get_pinned_opt<K, I>(
         &'_ self,
         keys: I,
@@ -1575,9 +1603,11 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         K: AsRef<[u8]>,
         I: IntoIterator<Item = K>,
     {
-        keys.into_iter()
-            .map(|k| self.get_pinned_opt(k, readopts))
-            .collect()
+        let owned_keys: Vec<K> = keys.into_iter().collect();
+        if owned_keys.len() == 1 {
+            return vec![self.get_pinned_opt(owned_keys[0].as_ref(), readopts)];
+        }
+        self.batched_multi_get_pinned_owned(&owned_keys, false, readopts)
     }
 
     /// Returns pinned values associated with the given keys and column families
@@ -1609,6 +1639,141 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         keys.into_iter()
             .map(|(cf, k)| self.get_pinned_cf_opt(cf, k, readopts))
             .collect()
+    }
+
+    /// Returns pinned values for default-column-family keys in one native batch.
+    ///
+    /// Set `sorted_input` only when keys are sorted according to the column
+    /// family's comparator. Results stay in input order, including duplicates.
+    pub fn batched_multi_get_pinned<K, I>(
+        &'_ self,
+        keys: I,
+        sorted_input: bool,
+    ) -> Vec<Result<Option<DBPinnableSlice<'_>>, Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        DEFAULT_READ_OPTS.with(|opts| self.batched_multi_get_pinned_opt(keys, sorted_input, opts))
+    }
+
+    /// Returns pinned values for default-column-family keys in one native batch
+    /// using the provided read options.
+    pub fn batched_multi_get_pinned_opt<K, I>(
+        &'_ self,
+        keys: I,
+        sorted_input: bool,
+        readopts: &ReadOptions,
+    ) -> Vec<Result<Option<DBPinnableSlice<'_>>, Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        let owned_keys: Vec<K> = keys.into_iter().collect();
+        self.batched_multi_get_pinned_owned(&owned_keys, sorted_input, readopts)
+    }
+
+    /// Returns pinned values for keys in one column family using one native batch.
+    ///
+    /// Set `sorted_input` only when keys are sorted according to the column
+    /// family's comparator. Results stay in input order, including duplicates.
+    pub fn batched_multi_get_pinned_cf<K, I>(
+        &'_ self,
+        cf: &impl AsColumnFamilyRef,
+        keys: I,
+        sorted_input: bool,
+    ) -> Vec<Result<Option<DBPinnableSlice<'_>>, Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        DEFAULT_READ_OPTS
+            .with(|opts| self.batched_multi_get_pinned_cf_opt(cf, keys, sorted_input, opts))
+    }
+
+    /// Returns pinned values for keys in one column family using one native batch
+    /// and the provided read options.
+    pub fn batched_multi_get_pinned_cf_opt<K, I>(
+        &'_ self,
+        cf: &impl AsColumnFamilyRef,
+        keys: I,
+        sorted_input: bool,
+        readopts: &ReadOptions,
+    ) -> Vec<Result<Option<DBPinnableSlice<'_>>, Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        let owned_keys: Vec<K> = keys.into_iter().collect();
+        let key_slices = Self::key_slices(&owned_keys);
+        self.batched_multi_get_pinned_inner(cf.inner(), &key_slices, sorted_input, readopts)
+    }
+
+    /// Returns one owner for all default-column-family pinned results.
+    ///
+    /// Values borrow from the returned batch, avoiding one native wrapper
+    /// allocation and one destroy call per successful key.
+    pub fn batched_multi_get_pinned_batch<K, I>(
+        &'_ self,
+        keys: I,
+        sorted_input: bool,
+    ) -> Result<DBPinnableBatch<'_>, Error>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        DEFAULT_READ_OPTS
+            .with(|opts| self.batched_multi_get_pinned_batch_opt(keys, sorted_input, opts))
+    }
+
+    /// Returns one owner for all default-column-family pinned results using
+    /// the provided read options.
+    pub fn batched_multi_get_pinned_batch_opt<K, I>(
+        &'_ self,
+        keys: I,
+        sorted_input: bool,
+        readopts: &ReadOptions,
+    ) -> Result<DBPinnableBatch<'_>, Error>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        let owned_keys: Vec<K> = keys.into_iter().collect();
+        let key_slices = Self::key_slices(&owned_keys);
+        self.create_pinnable_batch(ptr::null_mut(), &key_slices, sorted_input, readopts)
+    }
+
+    /// Returns one owner for all pinned results from one column family.
+    pub fn batched_multi_get_pinned_batch_cf<K, I>(
+        &'_ self,
+        cf: &impl AsColumnFamilyRef,
+        keys: I,
+        sorted_input: bool,
+    ) -> Result<DBPinnableBatch<'_>, Error>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        DEFAULT_READ_OPTS
+            .with(|opts| self.batched_multi_get_pinned_batch_cf_opt(cf, keys, sorted_input, opts))
+    }
+
+    /// Returns one owner for all pinned results from one column family using
+    /// the provided read options.
+    pub fn batched_multi_get_pinned_batch_cf_opt<K, I>(
+        &'_ self,
+        cf: &impl AsColumnFamilyRef,
+        keys: I,
+        sorted_input: bool,
+        readopts: &ReadOptions,
+    ) -> Result<DBPinnableBatch<'_>, Error>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        let owned_keys: Vec<K> = keys.into_iter().collect();
+        let key_slices = Self::key_slices(&owned_keys);
+        self.create_pinnable_batch(cf.inner(), &key_slices, sorted_input, readopts)
     }
 
     /// Return the values associated with the given keys and column families.
@@ -1703,45 +1868,17 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         K: AsRef<[u8]> + 'a + ?Sized,
         I: IntoIterator<Item = &'a K>,
     {
-        let (ptr_keys, keys_sizes): (Vec<_>, Vec<_>) = keys
+        let key_slices: Vec<_> = keys
             .into_iter()
             .map(|k| {
                 let k = k.as_ref();
-                (k.as_ptr() as *const c_char, k.len())
+                ffi::rocksdb_slice_t {
+                    data: k.as_ptr() as *const c_char,
+                    size: k.len(),
+                }
             })
-            .unzip();
-
-        let mut pinned_values = vec![ptr::null_mut(); ptr_keys.len()];
-        let mut errors = vec![ptr::null_mut(); ptr_keys.len()];
-
-        unsafe {
-            ffi::rocksdb_batched_multi_get_cf(
-                self.inner.inner(),
-                readopts.inner,
-                cf.inner(),
-                ptr_keys.len(),
-                ptr_keys.as_ptr(),
-                keys_sizes.as_ptr(),
-                pinned_values.as_mut_ptr(),
-                errors.as_mut_ptr(),
-                sorted_input,
-            );
-            pinned_values
-                .into_iter()
-                .zip(errors)
-                .map(|(v, e)| {
-                    if e.is_null() {
-                        if v.is_null() {
-                            Ok(None)
-                        } else {
-                            Ok(Some(DBPinnableSlice::from_c(v)))
-                        }
-                    } else {
-                        Err(convert_rocksdb_error(e))
-                    }
-                })
-                .collect()
-        }
+            .collect();
+        self.batched_multi_get_pinned_inner(cf.inner(), &key_slices, sorted_input, readopts)
     }
 
     /// Return the values associated with the given keys and the specified column family
@@ -1844,40 +1981,129 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
             })
             .collect();
 
-        if slices.is_empty() {
+        self.batched_multi_get_pinned_inner(cf.inner(), &slices, sorted_input, readopts)
+    }
+
+    fn key_slices<K: AsRef<[u8]>>(keys: &[K]) -> Vec<ffi::rocksdb_slice_t> {
+        keys.iter()
+            .map(|key| {
+                let key = key.as_ref();
+                ffi::rocksdb_slice_t {
+                    data: key.as_ptr() as *const c_char,
+                    size: key.len(),
+                }
+            })
+            .collect()
+    }
+
+    fn batched_multi_get_pinned_owned<'a, K: AsRef<[u8]>>(
+        &'a self,
+        keys: &[K],
+        sorted_input: bool,
+        readopts: &ReadOptions,
+    ) -> Vec<Result<Option<DBPinnableSlice<'a>>, Error>> {
+        let key_slices = Self::key_slices(keys);
+        if key_slices.is_empty() {
             return Vec::new();
         }
+        let default_cf = OwnedColumnFamilyHandle::default_for(self.inner.inner());
+        self.batched_multi_get_pinned_inner(default_cf.inner, &key_slices, sorted_input, readopts)
+    }
 
-        let mut pinned_values = vec![ptr::null_mut(); slices.len()];
-        let mut errors = vec![ptr::null_mut(); slices.len()];
-
-        unsafe {
-            ffi::rocksdb_batched_multi_get_cf_slice(
+    fn create_pinnable_batch<'a>(
+        &'a self,
+        cf: *mut ffi::rocksdb_column_family_handle_t,
+        keys: &[ffi::rocksdb_slice_t],
+        sorted_input: bool,
+        readopts: &ReadOptions,
+    ) -> Result<DBPinnableBatch<'a>, Error> {
+        let batch = unsafe {
+            ffi_try!(ffi::rust_rocksdb_batched_multi_get_pinned(
                 self.inner.inner(),
                 readopts.inner,
-                cf.inner(),
-                slices.len(),
-                slices.as_ptr(),
+                cf,
+                keys.len(),
+                keys.as_ptr(),
+                c_uchar::from(sorted_input),
+            ))
+        };
+        // SAFETY: The extension returns a uniquely owned batch.
+        Ok(unsafe { DBPinnableBatch::from_c(batch) })
+    }
+
+    fn batched_multi_get_pinned_inner<'a>(
+        &'a self,
+        cf: *mut ffi::rocksdb_column_family_handle_t,
+        keys: &[ffi::rocksdb_slice_t],
+        sorted_input: bool,
+        readopts: &ReadOptions,
+    ) -> Vec<Result<Option<DBPinnableSlice<'a>>, Error>> {
+        if keys.is_empty() {
+            return Vec::new();
+        }
+        let output = match self.execute_batched_multi_get(cf, keys, sorted_input, readopts) {
+            Ok(output) => output,
+            Err(error) => {
+                let message = error.to_string();
+                return (0..keys.len())
+                    .map(|_| Err(Error::new(message.clone())))
+                    .collect();
+            }
+        };
+        output
+            .values
+            .into_iter()
+            .zip(output.errors)
+            .map(|(value, error)| unsafe { Self::convert_pinned_result(value, error) })
+            .collect()
+    }
+
+    fn execute_batched_multi_get(
+        &self,
+        cf: *mut ffi::rocksdb_column_family_handle_t,
+        keys: &[ffi::rocksdb_slice_t],
+        sorted_input: bool,
+        readopts: &ReadOptions,
+    ) -> Result<PinnedMultiGetOutput, Error> {
+        let mut pinned_values = vec![ptr::null_mut(); keys.len()];
+        let mut errors = vec![ptr::null_mut(); keys.len()];
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_batched_multi_get_cf_slice_safe(
+                self.inner.inner(),
+                readopts.inner,
+                cf,
+                keys.len(),
+                keys.as_ptr(),
                 pinned_values.as_mut_ptr(),
                 errors.as_mut_ptr(),
-                sorted_input,
-            );
-            pinned_values
-                .into_iter()
-                .zip(errors)
-                .map(|(v, e)| {
-                    if e.is_null() {
-                        if v.is_null() {
-                            Ok(None)
-                        } else {
-                            Ok(Some(DBPinnableSlice::from_c(v)))
-                        }
-                    } else {
-                        Err(convert_rocksdb_error(e))
-                    }
-                })
-                .collect()
+                c_uchar::from(sorted_input),
+            ));
         }
+        Ok(PinnedMultiGetOutput {
+            values: pinned_values,
+            errors,
+        })
+    }
+
+    /// Converts one result returned by `rocksdb_batched_multi_get_cf_slice`.
+    ///
+    /// # Safety
+    ///
+    /// `value` must be null or an owned pinnable slice. `error` must be null or
+    /// an owned RocksDB error string.
+    unsafe fn convert_pinned_result<'a>(
+        value: *mut ffi::rocksdb_pinnableslice_t,
+        error: *mut c_char,
+    ) -> Result<Option<DBPinnableSlice<'a>>, Error> {
+        if error.is_null() {
+            return Ok((!value.is_null()).then(|| unsafe { DBPinnableSlice::from_c(value) }));
+        }
+        if !value.is_null() {
+            unsafe {
+                ffi::rocksdb_pinnableslice_destroy(value);
+            }
+        }
+        Err(convert_rocksdb_error(error))
     }
 
     /// Returns `false` if the given key definitely doesn't exist in the database, otherwise returns
@@ -2261,6 +2487,86 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
     ) -> DBRawIteratorWithThreadMode<'b, Self> {
         let opts = ReadOptions::default();
         DBRawIteratorWithThreadMode::new_cf(self, cf_handle.inner(), opts)
+    }
+
+    /// Opens raw iterators for multiple column families from one consistent
+    /// RocksDB state.
+    ///
+    /// The returned iterators match the input column family order and own their
+    /// native handles. This method uses default read options because one native
+    /// `rocksdb_create_iterators` call shares its options across every iterator,
+    /// while custom bounds and timestamps require one shared Rust owner.
+    pub fn raw_iterators_cf<'a, 'b, W, I>(
+        &'a self,
+        column_families: I,
+    ) -> Result<Vec<DBRawIteratorWithThreadMode<'a, Self>>, Error>
+    where
+        W: AsColumnFamilyRef + 'b,
+        I: IntoIterator<Item = &'b W>,
+    {
+        let mut cf_handles: Vec<_> = column_families
+            .into_iter()
+            .map(AsColumnFamilyRef::inner)
+            .collect();
+        if cf_handles.is_empty() {
+            return Ok(Vec::new());
+        }
+        let created = self.create_iterators_cf(&mut cf_handles)?;
+        Ok(created
+            .handles
+            .into_iter()
+            .map(DBRawIteratorWithThreadMode::from_inner_without_readopts)
+            .collect())
+    }
+
+    fn create_iterators_cf(
+        &self,
+        cf_handles: &mut [*mut ffi::rocksdb_column_family_handle_t],
+    ) -> Result<CreatedIterators, Error> {
+        let mut iterator_handles = vec![ptr::null_mut(); cf_handles.len()];
+        let readopts = ReadOptions::default();
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_create_iterators_safe(
+                self.inner.inner(),
+                readopts.inner,
+                cf_handles.as_mut_ptr(),
+                iterator_handles.as_mut_ptr(),
+                iterator_handles.len(),
+            ));
+        }
+        Self::validate_created_iterators(&iterator_handles)?;
+        Ok(CreatedIterators {
+            handles: iterator_handles,
+        })
+    }
+
+    fn validate_created_iterators(
+        iterator_handles: &[*mut ffi::rocksdb_iterator_t],
+    ) -> Result<(), Error> {
+        if iterator_handles.iter().any(|iterator| iterator.is_null()) {
+            unsafe {
+                Self::destroy_iterators(iterator_handles);
+            }
+            return Err(Error::new(
+                "rocksdb_create_iterators returned a null iterator".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Destroys non-null iterator handles owned by the caller.
+    ///
+    /// # Safety
+    ///
+    /// Every non-null pointer must identify a live, uniquely owned RocksDB iterator.
+    unsafe fn destroy_iterators(iterators: &[*mut ffi::rocksdb_iterator_t]) {
+        for &iterator in iterators {
+            if !iterator.is_null() {
+                unsafe {
+                    ffi::rocksdb_iter_destroy(iterator);
+                }
+            }
+        }
     }
 
     /// Opens a raw iterator over the database, using the given read options
@@ -3035,6 +3341,26 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         )
     }
 
+    fn property_int_value_impl(
+        name: impl CStrLike,
+        get_property: impl FnOnce(*const c_char, *mut u64) -> c_int,
+        get_string_property: impl FnOnce(*const c_char) -> *mut c_char,
+    ) -> Result<Option<u64>, Error> {
+        let prop_name = name.bake().map_err(|err| {
+            Error::new(format!("Failed to convert property name to CString: {err}"))
+        })?;
+        let mut value = 0;
+        if get_property(prop_name.as_ptr(), &raw mut value) == 0 {
+            return Ok(Some(value));
+        }
+
+        Self::property_value_impl(
+            prop_name.as_ref(),
+            get_string_property,
+            Self::parse_property_int_value,
+        )
+    }
+
     fn parse_property_int_value(value: &str) -> Result<u64, Error> {
         value.parse::<u64>().map_err(|err| {
             Error::new(format!(
@@ -3048,10 +3374,12 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
     /// Full list of properties that return int values could be find
     /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
     pub fn property_int_value(&self, name: impl CStrLike) -> Result<Option<u64>, Error> {
-        Self::property_value_impl(
+        Self::property_int_value_impl(
             name,
+            |prop_name, value| unsafe {
+                ffi::rocksdb_property_int(self.inner.inner(), prop_name, value)
+            },
             |prop_name| unsafe { ffi::rocksdb_property_value(self.inner.inner(), prop_name) },
-            Self::parse_property_int_value,
         )
     }
 
@@ -3064,12 +3392,14 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         cf: &impl AsColumnFamilyRef,
         name: impl CStrLike,
     ) -> Result<Option<u64>, Error> {
-        Self::property_value_impl(
+        Self::property_int_value_impl(
             name,
+            |prop_name, value| unsafe {
+                ffi::rocksdb_property_int_cf(self.inner.inner(), cf.inner(), prop_name, value)
+            },
             |prop_name| unsafe {
                 ffi::rocksdb_property_value_cf(self.inner.inner(), cf.inner(), prop_name)
             },
-            Self::parse_property_int_value,
         )
     }
 

--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -19,7 +19,7 @@ use crate::{
 };
 use libc::{c_char, c_uchar, size_t};
 use std::mem::ManuallyDrop;
-use std::{marker::PhantomData, slice};
+use std::{marker::PhantomData, ops::ControlFlow, slice};
 
 /// A type alias to keep compatibility. See [`DBRawIteratorWithThreadMode`] for details
 pub type DBRawIterator<'a> = DBRawIteratorWithThreadMode<'a, DB>;
@@ -86,7 +86,7 @@ pub struct DBRawIteratorWithThreadMode<'a, D: DBAccess> {
     /// And yes, we need to store the entire ReadOptions structure since C++
     /// ReadOptions keep reference to C rocksdb_readoptions_t wrapper which
     /// point to vectors we own.  See issue #660.
-    readopts: ReadOptions,
+    readopts: Option<ReadOptions>,
 
     db: PhantomData<&'a D>,
 }
@@ -114,7 +114,16 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
         let inner = std::ptr::NonNull::new(inner).unwrap();
         Self {
             inner,
-            readopts,
+            readopts: Some(readopts),
+            db: PhantomData,
+        }
+    }
+
+    pub(crate) fn from_inner_without_readopts(inner: *mut ffi::rocksdb_iterator_t) -> Self {
+        let inner = std::ptr::NonNull::new(inner).expect("RocksDB returned a null iterator");
+        Self {
+            inner,
+            readopts: None,
             db: PhantomData,
         }
     }
@@ -123,7 +132,7 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
         let value = ManuallyDrop::new(self);
         // SAFETY: value won't be used beyond this point
         let inner = unsafe { std::ptr::read(&raw const value.inner) };
-        let readopts = unsafe { std::ptr::read(&raw const value.readopts) };
+        let readopts = unsafe { std::ptr::read(&raw const value.readopts) }.unwrap_or_default();
 
         (inner, readopts)
     }
@@ -335,18 +344,42 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
     /// Seeks to the next key.
     pub fn next(&mut self) {
         if self.valid() {
-            unsafe {
-                ffi::rocksdb_iter_next(self.inner.as_ptr());
-            }
+            // SAFETY: The validity check above guarantees that RocksDB permits
+            // advancing the iterator.
+            unsafe { self.next_unchecked() }
+        }
+    }
+
+    /// Advances to the next key without checking iterator validity.
+    ///
+    /// # Safety
+    ///
+    /// The iterator must be valid.
+    #[inline]
+    unsafe fn next_unchecked(&mut self) {
+        unsafe {
+            ffi::rocksdb_iter_next(self.inner.as_ptr());
         }
     }
 
     /// Seeks to the previous key.
     pub fn prev(&mut self) {
         if self.valid() {
-            unsafe {
-                ffi::rocksdb_iter_prev(self.inner.as_ptr());
-            }
+            // SAFETY: The validity check above guarantees that RocksDB permits
+            // advancing the iterator.
+            unsafe { self.prev_unchecked() }
+        }
+    }
+
+    /// Advances to the previous key without checking iterator validity.
+    ///
+    /// # Safety
+    ///
+    /// The iterator must be valid.
+    #[inline]
+    unsafe fn prev_unchecked(&mut self) {
+        unsafe {
+            ffi::rocksdb_iter_prev(self.inner.as_ptr());
         }
     }
 
@@ -590,24 +623,113 @@ impl<'a, D: DBAccess> DBIteratorWithThreadMode<'a, D> {
         self.set_mode(mode);
         Ok(())
     }
+
+    /// Visits the remaining entries without allocating key or value buffers.
+    ///
+    /// The key and value slices are valid only for the duration of each callback.
+    /// Returning [`ControlFlow::Break`] stops the scan after consuming the current
+    /// entry. The iterator can then resume at the following entry. Callback errors
+    /// and RocksDB iterator errors are returned through `E`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use std::ops::ControlFlow;
+    ///
+    /// use rust_rocksdb::{DB, Error, IteratorMode};
+    ///
+    /// # let tempdir = tempfile::tempdir().unwrap();
+    /// let db = DB::open_default(tempdir.path()).unwrap();
+    /// db.put(b"k1", b"value").unwrap();
+    ///
+    /// let mut total_bytes = 0;
+    /// let mut iter = db.iterator(IteratorMode::Start);
+    /// let outcome: Result<ControlFlow<()>, Error> = iter.try_for_each_ref(|key, value| {
+    ///     total_bytes += key.len() + value.len();
+    ///     Ok(ControlFlow::Continue(()))
+    /// });
+    ///
+    /// assert!(matches!(outcome, Ok(ControlFlow::Continue(()))));
+    /// assert_eq!(total_bytes, 7);
+    /// ```
+    ///
+    /// Borrowed entries cannot escape the callback:
+    ///
+    /// ```compile_fail,E0521
+    /// use std::ops::ControlFlow;
+    ///
+    /// use rust_rocksdb::{DB, Error, IteratorMode};
+    ///
+    /// # let tempdir = tempfile::tempdir().unwrap();
+    /// let db = DB::open_default(tempdir.path()).unwrap();
+    /// let mut iter = db.iterator(IteratorMode::Start);
+    /// let mut saved_key = None;
+    ///
+    /// let _: Result<ControlFlow<()>, Error> = iter.try_for_each_ref(|key, _| {
+    ///     saved_key = Some(key);
+    ///     Ok(ControlFlow::Break(()))
+    /// });
+    /// ```
+    #[inline]
+    pub fn try_for_each_ref<B, E, F>(&mut self, mut visit: F) -> Result<ControlFlow<B>, E>
+    where
+        E: From<Error>,
+        F: FnMut(&[u8], &[u8]) -> Result<ControlFlow<B>, E>,
+    {
+        loop {
+            let item = self
+                .next_with(|key, value| visit(key, value))
+                .map_err(E::from)?;
+            match item {
+                Some(Ok(ControlFlow::Continue(()))) => {}
+                Some(Ok(ControlFlow::Break(value))) => return Ok(ControlFlow::Break(value)),
+                Some(Err(error)) => return Err(error),
+                None => return Ok(ControlFlow::Continue(())),
+            }
+        }
+    }
+
+    #[inline]
+    fn next_with<T>(&mut self, visit: impl FnOnce(&[u8], &[u8]) -> T) -> Result<Option<T>, Error> {
+        if self.done {
+            return Ok(None);
+        }
+
+        let Some((key, value)) = self.raw.item() else {
+            self.done = true;
+            self.raw.status()?;
+            return Ok(None);
+        };
+
+        let item = visit(key, value);
+        // SAFETY: `raw.item()` returned an entry, which proves that the
+        // iterator is valid until it is advanced.
+        unsafe { self.advance_unchecked() };
+        Ok(Some(item))
+    }
+
+    /// Advances in the configured direction without checking iterator validity.
+    ///
+    /// # Safety
+    ///
+    /// The raw iterator must be valid.
+    #[inline]
+    unsafe fn advance_unchecked(&mut self) {
+        match self.direction {
+            Direction::Forward => unsafe { self.raw.next_unchecked() },
+            Direction::Reverse => unsafe { self.raw.prev_unchecked() },
+        }
+    }
 }
 
 impl<D: DBAccess> Iterator for DBIteratorWithThreadMode<'_, D> {
     type Item = Result<KVBytes, Error>;
 
     fn next(&mut self) -> Option<Result<KVBytes, Error>> {
-        if self.done {
-            None
-        } else if let Some((key, value)) = self.raw.item() {
-            let item = (Box::from(key), Box::from(value));
-            match self.direction {
-                Direction::Forward => self.raw.next(),
-                Direction::Reverse => self.raw.prev(),
-            }
-            Some(Ok(item))
-        } else {
-            self.done = true;
-            self.raw.status().err().map(Result::Err)
+        match self.next_with(|key, value| (Box::from(key), Box::from(value))) {
+            Ok(Some(item)) => Some(Ok(item)),
+            Ok(None) => None,
+            Err(error) => Some(Err(error)),
         }
     }
 }

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3313,6 +3313,40 @@ impl Options {
         }
     }
 
+    /// Controls whether RocksDB opens and validates SST files in the background after open.
+    ///
+    /// Enabling this can reduce open latency for databases with many SST files
+    /// or high latency storage. It is mostly useful with
+    /// [`Options::set_max_open_files`] set to `-1`.
+    ///
+    /// This option is not compatible with FIFO compaction and requires
+    /// [`Options::set_skip_stats_update_on_db_open`] to be `true`. SST open
+    /// errors are no longer returned by `DB::open`; they can instead surface as
+    /// background errors or from operations that access the affected file.
+    ///
+    /// Default: `false`
+    pub fn set_open_files_async(&mut self, enabled: bool) -> Result<(), Error> {
+        let supported = unsafe {
+            ffi::rust_rocksdb_options_set_open_files_async(self.inner, c_uchar::from(enabled)) != 0
+        };
+        if !supported {
+            return Err(Error::new(
+                "open_files_async requires RocksDB 11.1 or newer".to_owned(),
+            ));
+        }
+        Ok(())
+    }
+
+    /// Returns whether SST files are opened and validated in the background after open.
+    pub fn get_open_files_async(&self) -> bool {
+        unsafe { ffi::rust_rocksdb_options_get_open_files_async(self.inner) != 0 }
+    }
+
+    /// Returns whether the linked RocksDB supports `open_files_async`.
+    pub fn supports_open_files_async() -> bool {
+        unsafe { ffi::rust_rocksdb_options_open_files_async_supported() != 0 }
+    }
+
     /// Specify the maximal number of info log files to be kept.
     ///
     /// Default: 1000

--- a/src/db_pinnable_batch.rs
+++ b/src/db_pinnable_batch.rs
@@ -1,0 +1,137 @@
+use crate::{Error, ffi};
+use std::{
+    marker::PhantomData,
+    ptr::{self, NonNull},
+    slice,
+};
+
+/// Owns all values returned by one native pinned MultiGet operation.
+///
+/// Values are borrowed directly from RocksDB and remain valid until this batch
+/// is dropped. Vendored builds store successful values in one native owner
+/// instead of allocating one wrapper per key. System builds use upstream C API
+/// handles internally to avoid depending on RocksDB's private C++ ABI.
+pub struct DBPinnableBatch<'db> {
+    inner: NonNull<ffi::rust_rocksdb_pinnable_batch_t>,
+    len: usize,
+    db: PhantomData<&'db ()>,
+}
+
+/// Iterator over a [`DBPinnableBatch`].
+pub struct DBPinnableBatchIter<'batch, 'db> {
+    batch: &'batch DBPinnableBatch<'db>,
+    index: usize,
+}
+
+unsafe impl Send for DBPinnableBatch<'_> {}
+unsafe impl Sync for DBPinnableBatch<'_> {}
+
+impl<'db> DBPinnableBatch<'db> {
+    /// Returns the number of results in the batch.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns whether the batch contains no results.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Returns one result by input index.
+    pub fn get(&self, index: usize) -> Option<Result<Option<&[u8]>, Error>> {
+        if index >= self.len() {
+            return None;
+        }
+
+        let mut value = ptr::null();
+        let mut value_len = 0;
+        let mut error = ptr::null();
+        let mut error_len = 0;
+        let state = unsafe {
+            ffi::rust_rocksdb_pinnable_batch_get(
+                self.inner.as_ptr(),
+                index,
+                &raw mut value,
+                &raw mut value_len,
+                &raw mut error,
+                &raw mut error_len,
+            )
+        };
+
+        Some(match state {
+            state if state == ffi::rust_rocksdb_pinnable_batch_not_found as u8 => Ok(None),
+            state if state == ffi::rust_rocksdb_pinnable_batch_found as u8 => {
+                let value = if value_len == 0 {
+                    &[]
+                } else {
+                    // SAFETY: RocksDB owns `value` until this batch is dropped.
+                    unsafe { slice::from_raw_parts(value.cast::<u8>(), value_len) }
+                };
+                Ok(Some(value))
+            }
+            state if state == ffi::rust_rocksdb_pinnable_batch_error as u8 => {
+                let message = if error_len == 0 {
+                    String::new()
+                } else {
+                    // SAFETY: The batch owns the error bytes until it is dropped.
+                    let bytes = unsafe { slice::from_raw_parts(error.cast::<u8>(), error_len) };
+                    String::from_utf8_lossy(bytes).into_owned()
+                };
+                Err(Error::new(message))
+            }
+            unexpected => unreachable!("unexpected pinned batch result state {unexpected}"),
+        })
+    }
+
+    /// Iterates over results in input order.
+    pub fn iter(&self) -> DBPinnableBatchIter<'_, 'db> {
+        DBPinnableBatchIter {
+            batch: self,
+            index: 0,
+        }
+    }
+
+    pub(crate) unsafe fn from_c(inner: *mut ffi::rust_rocksdb_pinnable_batch_t) -> Self {
+        let inner = NonNull::new(inner).expect("RocksDB returned a null pinned batch");
+        Self {
+            len: unsafe { ffi::rust_rocksdb_pinnable_batch_len(inner.as_ptr()) },
+            inner,
+            db: PhantomData,
+        }
+    }
+}
+
+impl Drop for DBPinnableBatch<'_> {
+    fn drop(&mut self) {
+        unsafe {
+            ffi::rust_rocksdb_pinnable_batch_destroy(self.inner.as_ptr());
+        }
+    }
+}
+
+impl<'batch> IntoIterator for &'batch DBPinnableBatch<'_> {
+    type Item = Result<Option<&'batch [u8]>, Error>;
+    type IntoIter = DBPinnableBatchIter<'batch, 'batch>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.iter()
+    }
+}
+
+impl<'batch> Iterator for DBPinnableBatchIter<'batch, '_> {
+    type Item = Result<Option<&'batch [u8]>, Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let result = self.batch.get(self.index)?;
+        self.index += 1;
+        Some(result)
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let remaining = self.batch.len() - self.index;
+        (remaining, Some(remaining))
+    }
+}
+
+impl ExactSizeIterator for DBPinnableBatchIter<'_, '_> {}
+impl std::iter::FusedIterator for DBPinnableBatchIter<'_, '_> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,6 +94,7 @@ mod comparator;
 mod db;
 mod db_iterator;
 mod db_options;
+mod db_pinnable_batch;
 mod db_pinnable_slice;
 mod env;
 pub mod event_listener;
@@ -137,14 +138,15 @@ pub use crate::{
         Options, PlainTableFactoryOptions, RateLimiterMode, ReadOptions, ReadTier,
         UniversalCompactOptions, UniversalCompactionStopStyle, WaitForCompactOptions, WriteOptions,
     },
+    db_pinnable_batch::{DBPinnableBatch, DBPinnableBatchIter},
     db_pinnable_slice::DBPinnableSlice,
     env::Env,
     ffi_util::{CSlice, CStrLike},
     iter_range::{IterateBounds, PrefixRange},
     merge_operator::MergeOperands,
-    perf::{PerfContext, PerfMetric, PerfStatsLevel},
+    perf::{PerfContext, PerfMetric, PerfStatsLevel, with_thread_local},
     slice_transform::SliceTransform,
-    snapshot::{Snapshot, SnapshotWithThreadMode},
+    snapshot::{Snapshot, SnapshotReadOptions, SnapshotWithThreadMode},
     sst_file_manager::SstFileManager,
     sst_file_writer::SstFileWriter,
     transactions::{

--- a/src/perf.rs
+++ b/src/perf.rs
@@ -13,7 +13,10 @@
 // limitations under the License.
 
 use libc::{c_int, c_uchar};
-use std::marker::PhantomData;
+use std::{
+    cell::{Cell, RefCell},
+    marker::PhantomData,
+};
 
 use crate::cache::Cache;
 use crate::ffi_util::from_cstr_and_free;
@@ -26,18 +29,20 @@ pub enum PerfStatsLevel {
     /// Unknown settings
     Uninitialized = 0,
     /// Disable perf stats
-    Disable,
+    Disable = 1,
     /// Enables only count stats
-    EnableCount,
+    EnableCount = 2,
+    /// Enables count stats and time spent waiting for RocksDB work
+    EnableWait = 3,
     /// Count stats and enable time stats except for mutexes
-    EnableTimeExceptForMutex,
+    EnableTimeExceptForMutex = 4,
     /// Other than time, also measure CPU time counters. Still don't measure
     /// time (neither wall time nor CPU time) for mutexes
-    EnableTimeAndCPUTimeExceptForMutex,
+    EnableTimeAndCPUTimeExceptForMutex = 5,
     /// Enables count and time stats
-    EnableTime,
+    EnableTime = 6,
     /// N.B must always be the last value!
-    OutOfBound,
+    OutOfBound = 7,
 }
 
 // Include the generated PerfMetric enum from perf_enum.rs
@@ -54,19 +59,39 @@ pub fn set_perf_stats(lvl: PerfStatsLevel) {
 /// and transparently.
 pub struct PerfContext {
     pub(crate) inner: *mut ffi::rocksdb_perfcontext_t,
+    reusable: bool,
+}
+
+thread_local! {
+    static ACTIVE_MANUAL_PERF_CONTEXTS: Cell<usize> = const { Cell::new(0) };
+    static REUSABLE_PERF_CONTEXT: RefCell<PerfContext> = RefCell::new({
+        let inner = unsafe { ffi::rocksdb_perfcontext_create() };
+        assert!(!inner.is_null(), "Could not create Perf Context");
+        PerfContext {
+            inner,
+            reusable: true,
+        }
+    });
 }
 
 impl Default for PerfContext {
     fn default() -> Self {
         let ctx = unsafe { ffi::rocksdb_perfcontext_create() };
         assert!(!ctx.is_null(), "Could not create Perf Context");
+        ACTIVE_MANUAL_PERF_CONTEXTS.with(|count| count.set(count.get() + 1));
 
-        Self { inner: ctx }
+        Self {
+            inner: ctx,
+            reusable: false,
+        }
     }
 }
 
 impl Drop for PerfContext {
     fn drop(&mut self) {
+        if !self.reusable {
+            ACTIVE_MANUAL_PERF_CONTEXTS.with(|count| count.set(count.get() - 1));
+        }
         unsafe {
             ffi::rocksdb_perfcontext_destroy(self.inner);
         }
@@ -94,6 +119,36 @@ impl PerfContext {
     pub fn metric(&self, id: PerfMetric) -> u64 {
         unsafe { ffi::rocksdb_perfcontext_metric(self.inner, id as c_int) }
     }
+}
+
+/// Runs `f` with a reusable thread-local [`PerfContext`].
+///
+/// The context is reset before each call. This avoids allocating and destroying
+/// the C wrapper for every measurement.
+///
+/// # Panics
+///
+/// Panics if called reentrantly or while a manually created [`PerfContext`] is
+/// alive on the same thread. RocksDB returns the same underlying context to all
+/// wrappers on a thread, so resetting it would discard the manual measurement.
+pub fn with_thread_local<F, R>(f: F) -> R
+where
+    F: FnOnce(&mut PerfContext) -> R,
+{
+    ACTIVE_MANUAL_PERF_CONTEXTS.with(|count| {
+        assert_eq!(
+            count.get(),
+            0,
+            "with_thread_local cannot run while a manual PerfContext is alive on the same thread"
+        );
+    });
+    REUSABLE_PERF_CONTEXT.with(|ctx| {
+        let mut ctx = ctx.try_borrow_mut().unwrap_or_else(|_| {
+            panic!("with_thread_local cannot be called reentrantly on the same thread")
+        });
+        ctx.reset();
+        f(&mut ctx)
+    })
 }
 
 /// Memory usage stats
@@ -259,7 +314,68 @@ pub fn get_memory_usage_stats(
 mod tests {
     use super::*;
     use crate::{DB, Options};
+    use std::panic;
     use tempfile::TempDir;
+
+    #[test]
+    fn perf_stats_level_matches_rocksdb_11_1_2() {
+        assert_eq!(PerfStatsLevel::Uninitialized as i32, 0);
+        assert_eq!(PerfStatsLevel::Disable as i32, 1);
+        assert_eq!(PerfStatsLevel::EnableCount as i32, 2);
+        assert_eq!(PerfStatsLevel::EnableWait as i32, 3);
+        assert_eq!(PerfStatsLevel::EnableTimeExceptForMutex as i32, 4);
+        assert_eq!(PerfStatsLevel::EnableTimeAndCPUTimeExceptForMutex as i32, 5);
+        assert_eq!(PerfStatsLevel::EnableTime as i32, 6);
+        assert_eq!(PerfStatsLevel::OutOfBound as i32, 7);
+    }
+
+    #[test]
+    fn with_thread_local_reuses_context_after_unwind() {
+        let first = with_thread_local(|ctx| ctx.inner);
+        let panic_result = panic::catch_unwind(|| {
+            with_thread_local(|_| panic!("test panic"));
+        });
+        assert!(panic_result.is_err());
+        let second = with_thread_local(|ctx| ctx.inner);
+
+        assert_eq!(first, second);
+    }
+
+    #[test]
+    fn with_thread_local_resets_context_before_use() {
+        let temp_dir = TempDir::new().unwrap();
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        let db = DB::open(&opts, temp_dir.path()).unwrap();
+        db.put(b"key", b"value").unwrap();
+
+        set_perf_stats(PerfStatsLevel::EnableCount);
+        let comparison_count = with_thread_local(|ctx| {
+            db.get(b"key").unwrap();
+            ctx.metric(PerfMetric::UserKeyComparisonCount)
+        });
+        assert!(comparison_count > 0);
+        assert_eq!(
+            with_thread_local(|ctx| ctx.metric(PerfMetric::UserKeyComparisonCount)),
+            0
+        );
+        set_perf_stats(PerfStatsLevel::Disable);
+    }
+
+    #[test]
+    #[should_panic(expected = "with_thread_local cannot be called reentrantly on the same thread")]
+    fn with_thread_local_rejects_reentrant_use() {
+        with_thread_local(|_| with_thread_local(|_| ()));
+    }
+
+    #[test]
+    #[should_panic(
+        expected = "with_thread_local cannot run while a manual PerfContext is alive on the same thread"
+    )]
+    fn with_thread_local_rejects_active_manual_context() {
+        let _manual = PerfContext::default();
+        with_thread_local(|_| ());
+    }
 
     #[test]
     fn test_perf_context_with_db_operations() {

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -20,6 +20,29 @@ use crate::{
 /// A type alias to keep compatibility. See [`SnapshotWithThreadMode`] for details
 pub type Snapshot<'a> = SnapshotWithThreadMode<'a, DB>;
 
+/// Reusable read state bound to a [`SnapshotWithThreadMode`].
+///
+/// Creating this value configures one native [`ReadOptions`] with the snapshot.
+/// Its get and multi-get methods reuse those options until the session is
+/// dropped. Custom options can be supplied with
+/// [`SnapshotWithThreadMode::read_options_opt`].
+///
+/// The session cannot outlive its snapshot:
+///
+/// ```compile_fail,E0597
+/// use rust_rocksdb::DB;
+///
+/// let db = DB::open_default("foo").unwrap();
+/// let _read_options = {
+///     let snapshot = db.snapshot();
+///     snapshot.read_options()
+/// };
+/// ```
+pub struct SnapshotReadOptions<'snapshot, 'db, D: DBAccess = DB> {
+    snapshot: &'snapshot SnapshotWithThreadMode<'db, D>,
+    readopts: ReadOptions,
+}
+
 /// A consistent view of the database at the point of creation.
 ///
 /// # Examples
@@ -68,6 +91,23 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
     /// Returns the sequence number of the snapshot.
     pub fn sequence_number(&self) -> u64 {
         unsafe { ffi::rocksdb_snapshot_get_sequence_number(self.inner) }
+    }
+
+    /// Creates reusable default read options bound to this snapshot.
+    pub fn read_options(&'_ self) -> SnapshotReadOptions<'_, 'a, D> {
+        self.read_options_opt(ReadOptions::default())
+    }
+
+    /// Creates reusable custom read options bound to this snapshot.
+    ///
+    /// Any snapshot already configured on `readopts` is replaced with this
+    /// snapshot.
+    pub fn read_options_opt(&'_ self, mut readopts: ReadOptions) -> SnapshotReadOptions<'_, 'a, D> {
+        readopts.set_snapshot(self);
+        SnapshotReadOptions {
+            snapshot: self,
+            readopts,
+        }
     }
 
     /// Creates an iterator over the data in this snapshot, using the default read options.
@@ -147,8 +187,7 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
 
     /// Returns the bytes associated with a key value with default read options.
     pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Error> {
-        let readopts = ReadOptions::default();
-        self.get_opt(key, readopts)
+        self.read_options().get(key)
     }
 
     /// Returns the bytes associated with a key value and given column family with default read
@@ -158,18 +197,16 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
         cf: &impl AsColumnFamilyRef,
         key: K,
     ) -> Result<Option<Vec<u8>>, Error> {
-        let readopts = ReadOptions::default();
-        self.get_cf_opt(cf, key.as_ref(), readopts)
+        self.read_options().get_cf(cf, key)
     }
 
     /// Returns the bytes associated with a key value and given read options.
     pub fn get_opt<K: AsRef<[u8]>>(
         &self,
         key: K,
-        mut readopts: ReadOptions,
+        readopts: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
-        readopts.set_snapshot(self);
-        self.db.get_opt(key.as_ref(), &readopts)
+        self.read_options_opt(readopts).get(key)
     }
 
     /// Returns the bytes associated with a key value, given column family and read options.
@@ -177,10 +214,9 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
         &self,
         cf: &impl AsColumnFamilyRef,
         key: K,
-        mut readopts: ReadOptions,
+        readopts: ReadOptions,
     ) -> Result<Option<Vec<u8>>, Error> {
-        readopts.set_snapshot(self);
-        self.db.get_cf_opt(cf, key.as_ref(), &readopts)
+        self.read_options_opt(readopts).get_cf(cf, key)
     }
 
     /// Return the value associated with a key using RocksDB's PinnableSlice
@@ -190,8 +226,7 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
         &'_ self,
         key: K,
     ) -> Result<Option<DBPinnableSlice<'_>>, Error> {
-        let readopts = ReadOptions::default();
-        self.get_pinned_opt(key, readopts)
+        self.read_options().get_pinned(key)
     }
 
     /// Return the value associated with a key using RocksDB's PinnableSlice
@@ -202,8 +237,7 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
         cf: &impl AsColumnFamilyRef,
         key: K,
     ) -> Result<Option<DBPinnableSlice<'_>>, Error> {
-        let readopts = ReadOptions::default();
-        self.get_pinned_cf_opt(cf, key.as_ref(), readopts)
+        self.read_options().get_pinned_cf(cf, key)
     }
 
     /// Return the value associated with a key using RocksDB's PinnableSlice
@@ -211,10 +245,9 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
     pub fn get_pinned_opt<K: AsRef<[u8]>>(
         &'_ self,
         key: K,
-        mut readopts: ReadOptions,
+        readopts: ReadOptions,
     ) -> Result<Option<DBPinnableSlice<'_>>, Error> {
-        readopts.set_snapshot(self);
-        self.db.get_pinned_opt(key.as_ref(), &readopts)
+        self.read_options_opt(readopts).get_pinned(key)
     }
 
     /// Return the value associated with a key using RocksDB's PinnableSlice
@@ -224,10 +257,9 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
         &'_ self,
         cf: &impl AsColumnFamilyRef,
         key: K,
-        mut readopts: ReadOptions,
+        readopts: ReadOptions,
     ) -> Result<Option<DBPinnableSlice<'_>>, Error> {
-        readopts.set_snapshot(self);
-        self.db.get_pinned_cf_opt(cf, key.as_ref(), &readopts)
+        self.read_options_opt(readopts).get_pinned_cf(cf, key)
     }
 
     /// Returns the bytes associated with the given key values and default read options.
@@ -235,8 +267,7 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
     where
         I: IntoIterator<Item = K>,
     {
-        let readopts = ReadOptions::default();
-        self.multi_get_opt(keys, readopts)
+        self.read_options().multi_get(keys)
     }
 
     /// Returns the bytes associated with the given key values and default read options.
@@ -246,37 +277,88 @@ impl<'a, D: DBAccess> SnapshotWithThreadMode<'a, D> {
         I: IntoIterator<Item = (&'b W, K)>,
         W: AsColumnFamilyRef + 'b,
     {
-        let readopts = ReadOptions::default();
-        self.multi_get_cf_opt(keys_cf, readopts)
+        self.read_options().multi_get_cf(keys_cf)
     }
 
     /// Returns the bytes associated with the given key values and given read options.
     pub fn multi_get_opt<K, I>(
         &self,
         keys: I,
-        mut readopts: ReadOptions,
+        readopts: ReadOptions,
     ) -> Vec<Result<Option<Vec<u8>>, Error>>
     where
         K: AsRef<[u8]>,
         I: IntoIterator<Item = K>,
     {
-        readopts.set_snapshot(self);
-        self.db.multi_get_opt(keys, &readopts)
+        self.read_options_opt(readopts).multi_get(keys)
     }
 
     /// Returns the bytes associated with the given key values, given column family and read options.
     pub fn multi_get_cf_opt<'b, K, I, W>(
         &self,
         keys_cf: I,
-        mut readopts: ReadOptions,
+        readopts: ReadOptions,
     ) -> Vec<Result<Option<Vec<u8>>, Error>>
     where
         K: AsRef<[u8]>,
         I: IntoIterator<Item = (&'b W, K)>,
         W: AsColumnFamilyRef + 'b,
     {
-        readopts.set_snapshot(self);
-        self.db.multi_get_cf_opt(keys_cf, &readopts)
+        self.read_options_opt(readopts).multi_get_cf(keys_cf)
+    }
+}
+
+impl<'db, D: DBAccess> SnapshotReadOptions<'_, 'db, D> {
+    /// Returns the bytes associated with a key.
+    pub fn get<K: AsRef<[u8]>>(&self, key: K) -> Result<Option<Vec<u8>>, Error> {
+        self.snapshot.db.get_opt(key, &self.readopts)
+    }
+
+    /// Returns the bytes associated with a key in a column family.
+    pub fn get_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        key: K,
+    ) -> Result<Option<Vec<u8>>, Error> {
+        self.snapshot.db.get_cf_opt(cf, key, &self.readopts)
+    }
+
+    /// Returns a pinned value associated with a key.
+    pub fn get_pinned<K: AsRef<[u8]>>(
+        &self,
+        key: K,
+    ) -> Result<Option<DBPinnableSlice<'db>>, Error> {
+        let db: &'db D = self.snapshot.db;
+        db.get_pinned_opt(key, &self.readopts)
+    }
+
+    /// Returns a pinned value associated with a key in a column family.
+    pub fn get_pinned_cf<K: AsRef<[u8]>>(
+        &self,
+        cf: &impl AsColumnFamilyRef,
+        key: K,
+    ) -> Result<Option<DBPinnableSlice<'db>>, Error> {
+        let db: &'db D = self.snapshot.db;
+        db.get_pinned_cf_opt(cf, key, &self.readopts)
+    }
+
+    /// Returns the values associated with the given keys.
+    pub fn multi_get<K, I>(&self, keys: I) -> Vec<Result<Option<Vec<u8>>, Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = K>,
+    {
+        self.snapshot.db.multi_get_opt(keys, &self.readopts)
+    }
+
+    /// Returns the values associated with the given keys and column families.
+    pub fn multi_get_cf<'b, K, I, W>(&self, keys_cf: I) -> Vec<Result<Option<Vec<u8>>, Error>>
+    where
+        K: AsRef<[u8]>,
+        I: IntoIterator<Item = (&'b W, K)>,
+        W: AsColumnFamilyRef + 'b,
+    {
+        self.snapshot.db.multi_get_cf_opt(keys_cf, &self.readopts)
     }
 }
 
@@ -290,5 +372,5 @@ impl<D: DBAccess> Drop for SnapshotWithThreadMode<'_, D> {
 
 /// `Send` and `Sync` implementations for `SnapshotWithThreadMode` are safe, because `SnapshotWithThreadMode` is
 /// immutable and can be safely shared between threads.
-unsafe impl<D: DBAccess> Send for SnapshotWithThreadMode<'_, D> {}
-unsafe impl<D: DBAccess> Sync for SnapshotWithThreadMode<'_, D> {}
+unsafe impl<D: DBAccess + Sync> Send for SnapshotWithThreadMode<'_, D> {}
+unsafe impl<D: DBAccess + Sync> Sync for SnapshotWithThreadMode<'_, D> {}

--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -1185,6 +1185,26 @@ impl TransactionDB<MultiThreaded> {
         )
     }
 
+    fn property_int_value_impl(
+        name: impl CStrLike,
+        get_property: impl FnOnce(*const c_char, *mut u64) -> c_int,
+        get_string_property: impl FnOnce(*const c_char) -> *mut c_char,
+    ) -> Result<Option<u64>, Error> {
+        let prop_name = name.bake().map_err(|err| {
+            Error::new(format!("Failed to convert property name to CString: {err}"))
+        })?;
+        let mut value = 0;
+        if get_property(prop_name.as_ptr(), &raw mut value) == 0 {
+            return Ok(Some(value));
+        }
+
+        Self::property_value_impl(
+            prop_name.as_ref(),
+            get_string_property,
+            Self::parse_property_int_value,
+        )
+    }
+
     fn parse_property_int_value(value: &str) -> Result<u64, Error> {
         value.parse::<u64>().map_err(|err| {
             Error::new(format!(
@@ -1198,10 +1218,12 @@ impl TransactionDB<MultiThreaded> {
     /// Full list of properties that return int values could be find
     /// [here](https://github.com/facebook/rocksdb/blob/08809f5e6cd9cc4bc3958dd4d59457ae78c76660/include/rocksdb/db.h#L654-L689).
     pub fn property_int_value(&self, name: impl CStrLike) -> Result<Option<u64>, Error> {
-        Self::property_value_impl(
+        Self::property_int_value_impl(
             name,
+            |prop_name, value| unsafe {
+                ffi::rocksdb_transactiondb_property_int(self.inner, prop_name, value)
+            },
             |prop_name| unsafe { ffi::rocksdb_transactiondb_property_value(self.inner, prop_name) },
-            Self::parse_property_int_value,
         )
     }
 }

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -13,8 +13,71 @@
 // limitations under the License.
 
 use crate::{AsColumnFamilyRef, ffi};
-use libc::{c_char, c_void, size_t};
-use std::slice;
+use libc::{c_char, c_int, c_void, size_t};
+use std::{io::IoSlice, slice};
+
+const INLINE_WRITE_BATCH_PARTS: usize = 4;
+
+enum WriteBatchPartStorage {
+    Inline([ffi::rocksdb_slice_t; INLINE_WRITE_BATCH_PARTS]),
+    Heap(Vec<ffi::rocksdb_slice_t>),
+}
+
+struct WriteBatchParts {
+    storage: WriteBatchPartStorage,
+    count: c_int,
+}
+
+impl WriteBatchParts {
+    fn new(parts: &[IoSlice<'_>], name: &str) -> Result<Self, crate::Error> {
+        let count = c_int::try_from(parts.len()).map_err(|_| {
+            crate::Error::new(format!(
+                "{name} has {} parts; expected at most {}",
+                parts.len(),
+                c_int::MAX
+            ))
+        })?;
+        let storage = if parts.len() <= INLINE_WRITE_BATCH_PARTS {
+            Self::inline(parts)
+        } else {
+            Self::heap(parts)
+        };
+        Ok(Self { storage, count })
+    }
+
+    fn inline(parts: &[IoSlice<'_>]) -> WriteBatchPartStorage {
+        let mut slices = std::array::from_fn(|_| ffi::rocksdb_slice_t {
+            data: std::ptr::null(),
+            size: 0,
+        });
+        for (index, part) in parts.iter().enumerate() {
+            slices[index] = ffi::rocksdb_slice_t {
+                data: part.as_ptr().cast(),
+                size: part.len(),
+            };
+        }
+        WriteBatchPartStorage::Inline(slices)
+    }
+
+    fn heap(parts: &[IoSlice<'_>]) -> WriteBatchPartStorage {
+        WriteBatchPartStorage::Heap(
+            parts
+                .iter()
+                .map(|part| ffi::rocksdb_slice_t {
+                    data: part.as_ptr().cast(),
+                    size: part.len(),
+                })
+                .collect(),
+        )
+    }
+
+    fn as_ptr(&self) -> *const ffi::rocksdb_slice_t {
+        match &self.storage {
+            WriteBatchPartStorage::Inline(slices) => slices.as_ptr(),
+            WriteBatchPartStorage::Heap(slices) => slices.as_ptr(),
+        }
+    }
+}
 
 /// A type alias to keep compatibility. See [`WriteBatchWithTransaction`] for details
 pub type WriteBatch = WriteBatchWithTransaction<false>;
@@ -272,6 +335,30 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
         }
     }
 
+    /// Inserts one key and value assembled from multiple byte slices.
+    ///
+    /// This avoids concatenating the parts in Rust. RocksDB copies the key and
+    /// value parts into the write batch during this call, so the slices do not
+    /// need to outlive the method.
+    pub fn put_vectored(
+        &mut self,
+        key: &[IoSlice<'_>],
+        value: &[IoSlice<'_>],
+    ) -> Result<(), crate::Error> {
+        let key = WriteBatchParts::new(key, "key")?;
+        let value = WriteBatchParts::new(value, "value")?;
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_writebatch_put_slices(
+                self.inner,
+                key.count,
+                key.as_ptr(),
+                value.count,
+                value.as_ptr(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Insert a value into the specific column family of the database under the given key.
     pub fn put_cf<K, V>(&mut self, cf: &impl AsColumnFamilyRef, key: K, value: V)
     where
@@ -291,6 +378,32 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
                 value.len() as size_t,
             );
         }
+    }
+
+    /// Inserts one key and value assembled from multiple byte slices into a column family.
+    ///
+    /// This avoids concatenating the parts in Rust. RocksDB copies the key and
+    /// value parts into the write batch during this call, so the slices do not
+    /// need to outlive the method.
+    pub fn put_cf_vectored(
+        &mut self,
+        cf: &impl AsColumnFamilyRef,
+        key: &[IoSlice<'_>],
+        value: &[IoSlice<'_>],
+    ) -> Result<(), crate::Error> {
+        let key = WriteBatchParts::new(key, "key")?;
+        let value = WriteBatchParts::new(value, "value")?;
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_writebatch_put_slices_cf(
+                self.inner,
+                cf.inner(),
+                key.count,
+                key.as_ptr(),
+                value.count,
+                value.as_ptr(),
+            ));
+        }
+        Ok(())
     }
 
     /// Insert a value into the specific column family of the database
@@ -337,6 +450,30 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
         }
     }
 
+    /// Merges one key and value assembled from multiple byte slices.
+    ///
+    /// This avoids concatenating the parts in Rust. RocksDB copies the key and
+    /// value parts into the write batch during this call, so the slices do not
+    /// need to outlive the method.
+    pub fn merge_vectored(
+        &mut self,
+        key: &[IoSlice<'_>],
+        value: &[IoSlice<'_>],
+    ) -> Result<(), crate::Error> {
+        let key = WriteBatchParts::new(key, "key")?;
+        let value = WriteBatchParts::new(value, "value")?;
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_writebatch_merge_slices(
+                self.inner,
+                key.count,
+                key.as_ptr(),
+                value.count,
+                value.as_ptr(),
+            ));
+        }
+        Ok(())
+    }
+
     pub fn merge_cf<K, V>(&mut self, cf: &impl AsColumnFamilyRef, key: K, value: V)
     where
         K: AsRef<[u8]>,
@@ -357,6 +494,32 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
         }
     }
 
+    /// Merges one key and value assembled from multiple byte slices in a column family.
+    ///
+    /// This avoids concatenating the parts in Rust. RocksDB copies the key and
+    /// value parts into the write batch during this call, so the slices do not
+    /// need to outlive the method.
+    pub fn merge_cf_vectored(
+        &mut self,
+        cf: &impl AsColumnFamilyRef,
+        key: &[IoSlice<'_>],
+        value: &[IoSlice<'_>],
+    ) -> Result<(), crate::Error> {
+        let key = WriteBatchParts::new(key, "key")?;
+        let value = WriteBatchParts::new(value, "value")?;
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_writebatch_merge_slices_cf(
+                self.inner,
+                cf.inner(),
+                key.count,
+                key.as_ptr(),
+                value.count,
+                value.as_ptr(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Removes the database entry for key. Does nothing if the key was not found.
     pub fn delete<K: AsRef<[u8]>>(&mut self, key: K) {
         let key = key.as_ref();
@@ -368,6 +531,23 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
                 key.len() as size_t,
             );
         }
+    }
+
+    /// Removes the entry for one key assembled from multiple byte slices.
+    ///
+    /// This avoids concatenating the parts in Rust. RocksDB copies the key
+    /// parts into the write batch during this call, so the slices do not need
+    /// to outlive the method.
+    pub fn delete_vectored(&mut self, key: &[IoSlice<'_>]) -> Result<(), crate::Error> {
+        let key = WriteBatchParts::new(key, "key")?;
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_writebatch_delete_slices(
+                self.inner,
+                key.count,
+                key.as_ptr(),
+            ));
+        }
+        Ok(())
     }
 
     /// Removes the database entry in the specific column family for key.
@@ -383,6 +563,28 @@ impl<const TRANSACTION: bool> WriteBatchWithTransaction<TRANSACTION> {
                 key.len() as size_t,
             );
         }
+    }
+
+    /// Removes the entry for one key assembled from multiple byte slices in a column family.
+    ///
+    /// This avoids concatenating the parts in Rust. RocksDB copies the key
+    /// parts into the write batch during this call, so the slices do not need
+    /// to outlive the method.
+    pub fn delete_cf_vectored(
+        &mut self,
+        cf: &impl AsColumnFamilyRef,
+        key: &[IoSlice<'_>],
+    ) -> Result<(), crate::Error> {
+        let key = WriteBatchParts::new(key, "key")?;
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_writebatch_delete_slices_cf(
+                self.inner,
+                cf.inner(),
+                key.count,
+                key.as_ptr(),
+            ));
+        }
+        Ok(())
     }
 
     /// Removes the database entry in the specific column family with timestamp for key.
@@ -457,6 +659,37 @@ impl WriteBatchWithTransaction<false> {
         }
     }
 
+    /// Removes entries in a range whose bounds are assembled from byte slices.
+    ///
+    /// The range includes `from` and excludes `to`. The two bounds must have
+    /// RocksDB copies both bounds into the write batch during this call, so the
+    /// slices do not need to outlive the method.
+    pub fn delete_range_vectored(
+        &mut self,
+        from: &[IoSlice<'_>],
+        to: &[IoSlice<'_>],
+    ) -> Result<(), crate::Error> {
+        if from.len() != to.len() {
+            return Err(crate::Error::new(format!(
+                "range start has {} parts but range end has {} parts; expected equal counts",
+                from.len(),
+                to.len()
+            )));
+        }
+        let from = WriteBatchParts::new(from, "range start")?;
+        let to = WriteBatchParts::new(to, "range end")?;
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_writebatch_delete_range_slices(
+                self.inner,
+                from.count,
+                from.as_ptr(),
+                to.count,
+                to.as_ptr(),
+            ));
+        }
+        Ok(())
+    }
+
     /// Remove database entries in column family from start key to end key.
     ///
     /// Removes the database entries in the range ["begin_key", "end_key"), i.e.,
@@ -475,6 +708,39 @@ impl WriteBatchWithTransaction<false> {
                 end_key.len() as size_t,
             );
         }
+    }
+
+    /// Removes entries in a column family range whose bounds are assembled from byte slices.
+    ///
+    /// The range includes `from` and excludes `to`. The two bounds must have
+    /// RocksDB copies both bounds into the write batch during this call, so the
+    /// slices do not need to outlive the method.
+    pub fn delete_range_cf_vectored(
+        &mut self,
+        cf: &impl AsColumnFamilyRef,
+        from: &[IoSlice<'_>],
+        to: &[IoSlice<'_>],
+    ) -> Result<(), crate::Error> {
+        if from.len() != to.len() {
+            return Err(crate::Error::new(format!(
+                "range start has {} parts but range end has {} parts; expected equal counts",
+                from.len(),
+                to.len()
+            )));
+        }
+        let from = WriteBatchParts::new(from, "range start")?;
+        let to = WriteBatchParts::new(to, "range end")?;
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_writebatch_delete_range_slices_cf(
+                self.inner,
+                cf.inner(),
+                from.count,
+                from.as_ptr(),
+                to.count,
+                to.as_ptr(),
+            ));
+        }
+        Ok(())
     }
 }
 

--- a/src/write_buffer_manager.rs
+++ b/src/write_buffer_manager.rs
@@ -82,6 +82,27 @@ impl WriteBufferManager {
         unsafe { ffi::rocksdb_write_buffer_manager_memory_usage(self.0.inner.as_ptr()) }
     }
 
+    /// Returns the memory used by active memtables in bytes.
+    pub fn get_mutable_memtable_memory_usage(&self) -> usize {
+        unsafe {
+            ffi::rocksdb_write_buffer_manager_mutable_memtable_memory_usage(self.0.inner.as_ptr())
+        }
+    }
+
+    /// Returns the cache capacity reserved by dummy entries in bytes.
+    ///
+    /// This returns zero when the manager was created without a cache.
+    pub fn get_dummy_entries_in_cache_usage(&self) -> usize {
+        unsafe {
+            ffi::rocksdb_write_buffer_manager_dummy_entries_in_cache_usage(self.0.inner.as_ptr())
+        }
+    }
+
+    /// Returns whether memtable memory is accounted against a cache.
+    pub fn cost_to_cache(&self) -> bool {
+        unsafe { ffi::rocksdb_write_buffer_manager_cost_to_cache(self.0.inner.as_ptr()) }
+    }
+
     /// Returns the current buffer size in bytes.
     pub fn get_buffer_size(&self) -> usize {
         unsafe { ffi::rocksdb_write_buffer_manager_buffer_size(self.0.inner.as_ptr()) }

--- a/tests/test_batched_pinned_multiget.rs
+++ b/tests/test_batched_pinned_multiget.rs
@@ -1,0 +1,270 @@
+// Copyright 2020 Tyler Neely
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod util;
+
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+use rust_rocksdb::{
+    ColumnFamilyDescriptor, DB, DBPinnableSlice, Error, MergeOperands, Options, ReadOptions,
+    statistics::Ticker,
+};
+use util::DBPath;
+
+struct CountedKey {
+    bytes: &'static [u8],
+    calls: Arc<AtomicUsize>,
+}
+
+impl AsRef<[u8]> for CountedKey {
+    fn as_ref(&self) -> &[u8] {
+        self.calls.fetch_add(1, Ordering::Relaxed);
+        self.bytes
+    }
+}
+
+fn copied_values(results: Vec<Result<Option<DBPinnableSlice<'_>>, Error>>) -> Vec<Option<Vec<u8>>> {
+    results
+        .into_iter()
+        .map(|result| result.unwrap().map(|value| value.to_vec()))
+        .collect()
+}
+
+#[test]
+fn multi_get_pinned_uses_one_native_batch() {
+    let path = DBPath::new("_rust_rocksdb_multi_get_pinned_native_batch");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.enable_statistics();
+    let db = DB::open(&options, &path).unwrap();
+    db.put(b"a", b"va").unwrap();
+    db.put(b"c", b"vc").unwrap();
+
+    let as_ref_calls = Arc::new(AtomicUsize::new(0));
+    let keys = [b"c".as_slice(), b"missing", b"a", b"c"].map(|bytes| CountedKey {
+        bytes,
+        calls: Arc::clone(&as_ref_calls),
+    });
+    let calls_before = options.get_ticker_count(Ticker::NumberMultigetCalls);
+    let keys_before = options.get_ticker_count(Ticker::NumberMultigetKeysRead);
+
+    let values = copied_values(db.multi_get_pinned(keys));
+
+    assert_eq!(
+        values,
+        vec![
+            Some(b"vc".to_vec()),
+            None,
+            Some(b"va".to_vec()),
+            Some(b"vc".to_vec()),
+        ]
+    );
+    assert_eq!(as_ref_calls.load(Ordering::Relaxed), 4);
+    assert_eq!(
+        options.get_ticker_count(Ticker::NumberMultigetCalls) - calls_before,
+        1
+    );
+    assert_eq!(
+        options.get_ticker_count(Ticker::NumberMultigetKeysRead) - keys_before,
+        4
+    );
+}
+
+#[test]
+fn multi_get_pinned_keeps_single_key_on_point_read_path() {
+    let path = DBPath::new("_rust_rocksdb_multi_get_pinned_single_key");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.enable_statistics();
+    let db = DB::open(&options, &path).unwrap();
+    db.put(b"a", b"va").unwrap();
+    let calls_before = options.get_ticker_count(Ticker::NumberMultigetCalls);
+
+    let values = copied_values(db.multi_get_pinned([b"a".as_slice()]));
+
+    assert_eq!(values, vec![Some(b"va".to_vec())]);
+    assert_eq!(
+        options.get_ticker_count(Ticker::NumberMultigetCalls),
+        calls_before
+    );
+}
+
+#[test]
+fn batched_multi_get_pinned_handles_sorted_duplicates_and_empty_input() {
+    let path = DBPath::new("_rust_rocksdb_batched_multi_get_pinned_sorted");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.enable_statistics();
+    let db = DB::open(&options, &path).unwrap();
+    db.put(b"a", b"va").unwrap();
+    db.put(b"b", b"vb").unwrap();
+
+    let mut results = db.batched_multi_get_pinned([b"a".as_slice(), b"a", b"b", b"z"], true);
+    assert_eq!(results.len(), 4);
+    assert!(results.pop().unwrap().unwrap().is_none());
+    assert_eq!(results.pop().unwrap().unwrap().unwrap().as_ref(), b"vb");
+    let second = results.pop().unwrap().unwrap().unwrap();
+    let first = results.pop().unwrap().unwrap().unwrap();
+    assert_eq!(first.as_ref(), b"va");
+    drop(first);
+    assert_eq!(second.as_ref(), b"va");
+
+    let calls_before = options.get_ticker_count(Ticker::NumberMultigetCalls);
+    let empty = db.batched_multi_get_pinned(Vec::<Vec<u8>>::new(), false);
+    assert!(empty.is_empty());
+    assert_eq!(
+        options.get_ticker_count(Ticker::NumberMultigetCalls),
+        calls_before
+    );
+}
+
+#[test]
+fn batched_multi_get_pinned_cf_honors_snapshot_and_column_family() {
+    let path = DBPath::new("_rust_rocksdb_batched_multi_get_pinned_cf_snapshot");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    options.enable_statistics();
+    let db = DB::open_cf_descriptors(
+        &options,
+        &path,
+        [ColumnFamilyDescriptor::new("cf", Options::default())],
+    )
+    .unwrap();
+    let cf = db.cf_handle("cf").unwrap();
+
+    db.put(b"same", b"default").unwrap();
+    db.put_cf(&cf, b"same", b"before").unwrap();
+    let snapshot = db.snapshot();
+    db.put_cf(&cf, b"same", b"after").unwrap();
+    let mut readopts = ReadOptions::default();
+    readopts.set_snapshot(&snapshot);
+    let calls_before = options.get_ticker_count(Ticker::NumberMultigetCalls);
+
+    let values = copied_values(db.batched_multi_get_pinned_cf_opt(
+        &cf,
+        [b"same".as_slice(), b"missing", b"same"],
+        false,
+        &readopts,
+    ));
+
+    assert_eq!(
+        values,
+        vec![Some(b"before".to_vec()), None, Some(b"before".to_vec()),]
+    );
+    assert_eq!(
+        options.get_ticker_count(Ticker::NumberMultigetCalls) - calls_before,
+        1
+    );
+
+    let calls_before = options.get_ticker_count(Ticker::NumberMultigetCalls);
+    let empty = db.batched_multi_get_pinned_cf(&cf, Vec::<Vec<u8>>::new(), false);
+    assert!(empty.is_empty());
+    assert_eq!(
+        options.get_ticker_count(Ticker::NumberMultigetCalls),
+        calls_before
+    );
+}
+
+fn failing_merge(_key: &[u8], _value: Option<&[u8]>, _operands: &MergeOperands) -> Option<Vec<u8>> {
+    None
+}
+
+#[test]
+fn batched_multi_get_pinned_preserves_mixed_results() {
+    let path = DBPath::new("_rust_rocksdb_batched_multi_get_pinned_mixed");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.set_merge_operator_associative("failing merge", failing_merge);
+    let db = DB::open(&options, &path).unwrap();
+
+    db.put(b"ok", b"value").unwrap();
+    db.put(b"bad", b"base").unwrap();
+    db.merge(b"bad", b"operand").unwrap();
+
+    let results = db.batched_multi_get_pinned([b"ok".as_slice(), b"bad", b"missing"], false);
+
+    assert_eq!(
+        results[0].as_ref().unwrap().as_ref().unwrap().as_ref(),
+        b"value"
+    );
+    let error = match &results[1] {
+        Err(error) => error,
+        Ok(_) => panic!("expected the failing merge to return an error"),
+    };
+    assert!(error.to_string().contains("Merge operator failed"));
+    assert!(results[2].as_ref().unwrap().is_none());
+}
+
+#[test]
+fn batch_owned_multiget_borrows_values_without_per_key_handles() {
+    let path = DBPath::new("_rust_rocksdb_batch_owned_multiget");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.set_merge_operator_associative("failing merge", failing_merge);
+    let db = DB::open(&options, &path).unwrap();
+
+    db.put(b"a", b"value-a").unwrap();
+    db.put(b"empty", b"").unwrap();
+    db.put(b"bad", b"base").unwrap();
+    db.merge(b"bad", b"operand").unwrap();
+
+    let batch = db
+        .batched_multi_get_pinned_batch(
+            [b"a".as_slice(), b"empty", b"missing", b"bad", b"a"],
+            false,
+        )
+        .unwrap();
+
+    assert_eq!(batch.len(), 5);
+    assert!(!batch.is_empty());
+    assert_eq!(batch.get(0).unwrap().unwrap().unwrap(), b"value-a");
+    assert_eq!(batch.get(1).unwrap().unwrap().unwrap(), b"");
+    assert!(batch.get(2).unwrap().unwrap().is_none());
+    assert!(
+        batch
+            .get(3)
+            .unwrap()
+            .unwrap_err()
+            .to_string()
+            .contains("Merge operator failed")
+    );
+    assert_eq!(batch.get(4).unwrap().unwrap().unwrap(), b"value-a");
+    assert!(batch.get(5).is_none());
+
+    let values = batch
+        .iter()
+        .map(|result| result.map(|value| value.map(<[u8]>::to_vec)))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        values[0].as_ref().unwrap().as_deref(),
+        Some(b"value-a".as_slice())
+    );
+    assert_eq!(values[1].as_ref().unwrap().as_deref(), Some(b"".as_slice()));
+    assert!(values[2].as_ref().unwrap().is_none());
+    assert!(values[3].is_err());
+    assert_eq!(
+        values[4].as_ref().unwrap().as_deref(),
+        Some(b"value-a".as_slice())
+    );
+
+    let empty = db
+        .batched_multi_get_pinned_batch(Vec::<Vec<u8>>::new(), false)
+        .unwrap();
+    assert!(empty.is_empty());
+    assert_eq!(empty.iter().len(), 0);
+}

--- a/tests/test_borrowed_iterator.rs
+++ b/tests/test_borrowed_iterator.rs
@@ -1,0 +1,130 @@
+// Copyright 2020 Tyler Neely
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod util;
+
+use std::{
+    alloc::{GlobalAlloc, Layout, System},
+    ops::ControlFlow,
+    sync::atomic::{AtomicUsize, Ordering},
+};
+
+use rust_rocksdb::{DB, Error, IteratorMode};
+use util::DBPath;
+
+static ALLOCATION_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+struct CountingAllocator;
+
+unsafe impl GlobalAlloc for CountingAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        ALLOCATION_COUNT.fetch_add(1, Ordering::Relaxed);
+        unsafe { System.alloc(layout) }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        unsafe { System.dealloc(ptr, layout) }
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: CountingAllocator = CountingAllocator;
+
+#[derive(Debug, PartialEq)]
+enum ScanError {
+    RocksDb(Error),
+    Callback,
+}
+
+impl From<Error> for ScanError {
+    fn from(error: Error) -> Self {
+        Self::RocksDb(error)
+    }
+}
+
+fn assert_allocation_free_forward_scan(db: &DB) {
+    let mut item_count = 0;
+    let mut total_bytes = 0;
+    let mut iter = db.iterator(IteratorMode::Start);
+    ALLOCATION_COUNT.store(0, Ordering::Relaxed);
+    let outcome: Result<ControlFlow<()>, ScanError> = iter.try_for_each_ref(|key, value| {
+        item_count += 1;
+        total_bytes += key.len() + value.len();
+        Ok(ControlFlow::Continue(()))
+    });
+    let scan_allocations = ALLOCATION_COUNT.load(Ordering::Relaxed);
+
+    assert_eq!(outcome, Ok(ControlFlow::Continue(())));
+    assert_eq!(item_count, 3);
+    assert_eq!(total_bytes, 12);
+    assert_eq!(scan_allocations, 0);
+    assert_eq!(iter.next(), None);
+}
+
+fn assert_reverse_scan(db: &DB) {
+    let mut reverse_keys = [0; 3];
+    let mut reverse_index = 0;
+    let mut reverse = db.iterator(IteratorMode::End);
+    let outcome: Result<ControlFlow<()>, ScanError> = reverse.try_for_each_ref(|key, _| {
+        reverse_keys[reverse_index] = key[1];
+        reverse_index += 1;
+        Ok(ControlFlow::Continue(()))
+    });
+    assert_eq!(outcome, Ok(ControlFlow::Continue(())));
+    assert_eq!(reverse_keys, *b"321");
+}
+
+fn assert_break_resumes_after_consumed_item(db: &DB) {
+    let mut stopped = db.iterator(IteratorMode::Start);
+    let outcome: Result<ControlFlow<usize>, ScanError> = stopped.try_for_each_ref(|key, _| {
+        if key == b"k2" {
+            Ok(ControlFlow::Break(2))
+        } else {
+            Ok(ControlFlow::Continue(()))
+        }
+    });
+    assert_eq!(outcome, Ok(ControlFlow::Break(2)));
+    let (key, value) = stopped.next().unwrap().unwrap();
+    assert_eq!(key.as_ref(), b"k3");
+    assert_eq!(value.as_ref(), b"v3");
+}
+
+fn assert_callback_error_resumes_after_consumed_item(db: &DB) {
+    let mut failed = db.iterator(IteratorMode::Start);
+    let outcome: Result<ControlFlow<()>, ScanError> = failed.try_for_each_ref(|key, _| {
+        if key == b"k2" {
+            Err(ScanError::Callback)
+        } else {
+            Ok(ControlFlow::Continue(()))
+        }
+    });
+    assert_eq!(outcome, Err(ScanError::Callback));
+    let (key, value) = failed.next().unwrap().unwrap();
+    assert_eq!(key.as_ref(), b"k3");
+    assert_eq!(value.as_ref(), b"v3");
+}
+
+#[test]
+fn borrowed_scan_is_allocation_free_and_resumable() {
+    let path = DBPath::new("_rust_rocksdb_borrowed_iterator");
+    let db = DB::open_default(&path).unwrap();
+    db.put(b"k1", b"v1").unwrap();
+    db.put(b"k2", b"v2").unwrap();
+    db.put(b"k3", b"v3").unwrap();
+
+    assert_allocation_free_forward_scan(&db);
+    assert_reverse_scan(&db);
+    assert_break_resumes_after_consumed_item(&db);
+    assert_callback_error_resumes_after_consumed_item(&db);
+}

--- a/tests/test_direct_property_int.rs
+++ b/tests/test_direct_property_int.rs
@@ -1,0 +1,75 @@
+// Copyright 2020 Tyler Neely
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod util;
+
+use rust_rocksdb::{DB, MultiThreaded, Options, TransactionDB, TransactionDBOptions, properties};
+use util::DBPath;
+
+const UNKNOWN_PROPERTY: &str = "rocksdb.this-property-does-not-exist";
+
+#[test]
+fn db_integer_properties_preserve_unavailable_property_semantics() {
+    let path = DBPath::new("_rust_rocksdb_direct_property_int");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let db = DB::open_cf(&options, &path, ["cf"]).unwrap();
+    let cf = db.cf_handle("cf").unwrap();
+
+    assert_eq!(
+        db.property_int_value(properties::ESTIMATE_LIVE_DATA_SIZE)
+            .unwrap(),
+        Some(0)
+    );
+    assert!(db.property_int_value(properties::STATS).is_err());
+    assert_eq!(db.property_int_value(UNKNOWN_PROPERTY).unwrap(), None);
+    assert_eq!(
+        db.property_int_value_cf(&cf, properties::ESTIMATE_NUM_KEYS)
+            .unwrap(),
+        Some(0)
+    );
+    assert_eq!(
+        db.property_int_value_cf(&cf, UNKNOWN_PROPERTY).unwrap(),
+        None
+    );
+    assert!(db.property_int_value("rocksdb.bad\0property").is_err());
+
+    db.put(b"key", b"value").unwrap();
+    db.flush().unwrap();
+    assert_eq!(
+        db.property_int_value(properties::num_files_at_level(0))
+            .unwrap(),
+        Some(1)
+    );
+}
+
+#[test]
+fn transaction_db_integer_properties_use_direct_api() {
+    let path = DBPath::new("_rust_rocksdb_transaction_db_direct_property_int");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    let transaction_options = TransactionDBOptions::default();
+    let db = TransactionDB::<MultiThreaded>::open(&options, &transaction_options, &path).unwrap();
+    db.put(b"key", b"value").unwrap();
+
+    assert_eq!(
+        db.property_int_value(properties::ESTIMATE_NUM_KEYS)
+            .unwrap(),
+        Some(1)
+    );
+    assert!(db.property_int_value(properties::STATS).is_err());
+    assert_eq!(db.property_int_value(UNKNOWN_PROPERTY).unwrap(), None);
+    assert!(db.property_int_value("rocksdb.bad\0property").is_err());
+}

--- a/tests/test_low_level_efficiency_apis.rs
+++ b/tests/test_low_level_efficiency_apis.rs
@@ -1,0 +1,242 @@
+// Copyright 2020 Tyler Neely
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod util;
+
+use std::io::IoSlice;
+
+use rust_rocksdb::{
+    Cache, ColumnFamilyDescriptor, DB, MergeOperands, Options, WriteBatch, WriteBufferManager,
+};
+use util::{DBPath, U64Comparator, U64Timestamp};
+
+fn concatenate_merge(
+    _key: &[u8],
+    existing_value: Option<&[u8]>,
+    operands: &MergeOperands,
+) -> Option<Vec<u8>> {
+    let mut value = existing_value.unwrap_or_default().to_vec();
+    for operand in operands {
+        value.extend_from_slice(operand);
+    }
+    Some(value)
+}
+
+#[test]
+fn write_batch_vectored_operations_copy_and_apply_parts() {
+    let path = DBPath::new("write_batch_vectored_operations");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.set_merge_operator_associative("concatenate", concatenate_merge);
+    let db = DB::open(&options, &path).unwrap();
+
+    db.put(b"merge-key", b"base").unwrap();
+    db.put(b"delete-key", b"value").unwrap();
+    db.put(b"range-a", b"value").unwrap();
+    db.put(b"range-b", b"value").unwrap();
+    db.put(b"range-z", b"value").unwrap();
+
+    let mut key_tail = b"key".to_vec();
+    let mut value_tail = b"value".to_vec();
+    let mut batch = WriteBatch::default();
+    batch
+        .put_vectored(
+            &[IoSlice::new(b"put-"), IoSlice::new(&key_tail)],
+            &[IoSlice::new(b"put-"), IoSlice::new(&value_tail)],
+        )
+        .unwrap();
+    let many_key_parts = vec![IoSlice::new(b"h"); 17];
+    batch
+        .put_vectored(&many_key_parts, &[IoSlice::new(b"heap-value")])
+        .unwrap();
+    key_tail.fill(b'x');
+    value_tail.fill(b'x');
+
+    batch
+        .merge_vectored(
+            &[IoSlice::new(b"merge-"), IoSlice::new(b"key")],
+            &[IoSlice::new(b"-"), IoSlice::new(b"merged")],
+        )
+        .unwrap();
+    batch
+        .delete_vectored(&[IoSlice::new(b"delete-"), IoSlice::new(b"key")])
+        .unwrap();
+    batch
+        .delete_range_vectored(
+            &[IoSlice::new(b"range-"), IoSlice::new(b"a")],
+            &[IoSlice::new(b"range-"), IoSlice::new(b"z")],
+        )
+        .unwrap();
+
+    db.write(&batch).unwrap();
+
+    assert_eq!(db.get(b"put-key").unwrap().unwrap(), b"put-value");
+    assert_eq!(db.get(vec![b'h'; 17]).unwrap().unwrap(), b"heap-value");
+    assert_eq!(db.get(b"merge-key").unwrap().unwrap(), b"base-merged");
+    assert_eq!(db.get(b"delete-key").unwrap(), None);
+    assert_eq!(db.get(b"range-a").unwrap(), None);
+    assert_eq!(db.get(b"range-b").unwrap(), None);
+    assert_eq!(db.get(b"range-z").unwrap().unwrap(), b"value");
+}
+
+#[test]
+fn write_batch_cf_vectored_operations_apply_parts() {
+    let path = DBPath::new("write_batch_cf_vectored_operations");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+
+    let mut cf_options = Options::default();
+    cf_options.set_merge_operator_associative("concatenate", concatenate_merge);
+    let descriptor = ColumnFamilyDescriptor::new("cf", cf_options);
+    let db = DB::open_cf_descriptors(&options, &path, vec![descriptor]).unwrap();
+    let cf = db.cf_handle("cf").unwrap();
+
+    db.put_cf(&cf, b"merge-key", b"base").unwrap();
+    db.put_cf(&cf, b"delete-key", b"value").unwrap();
+    db.put_cf(&cf, b"range-a", b"value").unwrap();
+    db.put_cf(&cf, b"range-b", b"value").unwrap();
+    db.put_cf(&cf, b"range-z", b"value").unwrap();
+
+    let mut batch = WriteBatch::default();
+    batch
+        .put_cf_vectored(
+            &cf,
+            &[IoSlice::new(b"put-"), IoSlice::new(b"key")],
+            &[IoSlice::new(b"put-"), IoSlice::new(b"value")],
+        )
+        .unwrap();
+    batch
+        .merge_cf_vectored(
+            &cf,
+            &[IoSlice::new(b"merge-"), IoSlice::new(b"key")],
+            &[IoSlice::new(b"-"), IoSlice::new(b"merged")],
+        )
+        .unwrap();
+    batch
+        .delete_cf_vectored(&cf, &[IoSlice::new(b"delete-"), IoSlice::new(b"key")])
+        .unwrap();
+    batch
+        .delete_range_cf_vectored(
+            &cf,
+            &[IoSlice::new(b"range-"), IoSlice::new(b"a")],
+            &[IoSlice::new(b"range-"), IoSlice::new(b"z")],
+        )
+        .unwrap();
+
+    db.write(&batch).unwrap();
+
+    assert_eq!(db.get_cf(&cf, b"put-key").unwrap().unwrap(), b"put-value");
+    assert_eq!(
+        db.get_cf(&cf, b"merge-key").unwrap().unwrap(),
+        b"base-merged"
+    );
+    assert_eq!(db.get_cf(&cf, b"delete-key").unwrap(), None);
+    assert_eq!(db.get_cf(&cf, b"range-a").unwrap(), None);
+    assert_eq!(db.get_cf(&cf, b"range-b").unwrap(), None);
+    assert_eq!(db.get_cf(&cf, b"range-z").unwrap().unwrap(), b"value");
+}
+
+#[test]
+fn write_batch_cf_vectored_operations_report_timestamp_errors() {
+    let path = DBPath::new("write_batch_cf_vectored_timestamp_errors");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+
+    let mut cf_options = Options::default();
+    cf_options.set_comparator_with_ts(
+        U64Comparator::NAME,
+        U64Timestamp::SIZE,
+        Box::new(U64Comparator::compare),
+        Box::new(U64Comparator::compare_ts),
+        Box::new(U64Comparator::compare_without_ts),
+    );
+    let db = DB::open_cf_descriptors(
+        &options,
+        &path,
+        [ColumnFamilyDescriptor::new("timestamped", cf_options)],
+    )
+    .unwrap();
+    let cf = db.cf_handle("timestamped").unwrap();
+    let key = [IoSlice::new(b"key")];
+    let value = [IoSlice::new(b"value")];
+    let mut batch = WriteBatch::default();
+
+    assert!(batch.put_cf_vectored(&cf, &key, &value).is_err());
+    assert!(batch.merge_cf_vectored(&cf, &key, &value).is_err());
+    assert!(batch.delete_cf_vectored(&cf, &key).is_err());
+    assert!(
+        batch
+            .delete_range_cf_vectored(&cf, &key, &[IoSlice::new(b"z")])
+            .is_err()
+    );
+    assert!(batch.is_empty());
+}
+
+#[test]
+fn write_batch_vectored_ranges_require_matching_part_counts() {
+    let mut batch = WriteBatch::default();
+    let error = batch
+        .delete_range_vectored(
+            &[IoSlice::new(b"a")],
+            &[IoSlice::new(b"b"), IoSlice::new(b"c")],
+        )
+        .unwrap_err();
+    assert!(error.to_string().contains("expected equal counts"));
+    assert!(batch.is_empty());
+}
+
+#[test]
+fn options_cache_and_write_buffer_accounting_apis() {
+    let mut options = Options::default();
+    assert!(!options.get_open_files_async());
+    assert!(Options::supports_open_files_async());
+    options.set_open_files_async(true).unwrap();
+    assert!(options.get_open_files_async());
+
+    let mut cache = Cache::new_lru_cache(8 * 1024 * 1024);
+    assert_eq!(cache.get_capacity(), 8 * 1024 * 1024);
+    assert_eq!(cache.get_occupancy_count(), 0);
+    assert!(cache.get_table_address_count() >= cache.get_occupancy_count());
+    cache.set_capacity(16 * 1024 * 1024);
+    assert_eq!(cache.get_capacity(), 16 * 1024 * 1024);
+
+    let manager = WriteBufferManager::new_write_buffer_manager(4 * 1024 * 1024, false);
+    assert!(!manager.cost_to_cache());
+    assert_eq!(manager.get_mutable_memtable_memory_usage(), 0);
+    assert_eq!(manager.get_dummy_entries_in_cache_usage(), 0);
+
+    let manager = WriteBufferManager::new_write_buffer_manager_with_cache(
+        4 * 1024 * 1024,
+        false,
+        cache.clone(),
+    );
+    assert!(manager.cost_to_cache());
+    assert_eq!(manager.get_mutable_memtable_memory_usage(), 0);
+    assert_eq!(manager.get_dummy_entries_in_cache_usage(), 0);
+
+    let path = DBPath::new("write_buffer_accounting_apis");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.set_write_buffer_manager(&manager);
+    let db = DB::open(&options, &path).unwrap();
+    db.put(b"key", vec![0; 512 * 1024]).unwrap();
+
+    assert!(manager.get_mutable_memtable_memory_usage() > 0);
+    assert!(manager.get_usage() >= manager.get_mutable_memtable_memory_usage());
+    assert!(manager.get_dummy_entries_in_cache_usage() > 0);
+    assert!(cache.get_occupancy_count() > 0);
+    assert!(cache.get_table_address_count() >= cache.get_occupancy_count());
+}

--- a/tests/test_multi_cf_iterators.rs
+++ b/tests/test_multi_cf_iterators.rs
@@ -1,0 +1,106 @@
+// Copyright 2020 Tyler Neely
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod util;
+
+use rust_rocksdb::{ColumnFamilyDescriptor, DB, DBAccess, DBRawIteratorWithThreadMode, Options};
+use util::DBPath;
+
+fn collect_entries<D: DBAccess>(
+    iterator: &mut DBRawIteratorWithThreadMode<'_, D>,
+) -> Vec<(Vec<u8>, Vec<u8>)> {
+    iterator.seek_to_first();
+    let mut entries = Vec::new();
+    while iterator.valid() {
+        entries.push((
+            iterator.key().unwrap().to_vec(),
+            iterator.value().unwrap().to_vec(),
+        ));
+        iterator.next();
+    }
+    iterator.status().unwrap();
+    entries
+}
+
+#[test]
+fn raw_iterators_cf_preserve_order_ownership_and_consistent_view() {
+    let path = DBPath::new("_rust_rocksdb_multi_cf_iterators");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let db = DB::open_cf_descriptors(
+        &options,
+        &path,
+        [
+            ColumnFamilyDescriptor::new("first", Options::default()),
+            ColumnFamilyDescriptor::new("second", Options::default()),
+        ],
+    )
+    .unwrap();
+    let first = db.cf_handle("first").unwrap();
+    let second = db.cf_handle("second").unwrap();
+    db.put_cf(&first, b"shared", b"first-old").unwrap();
+    db.put_cf(&second, b"shared", b"second-old").unwrap();
+
+    let mut iterators = db.raw_iterators_cf([&second, &first]).unwrap();
+    db.put_cf(&first, b"later", b"first-new").unwrap();
+    db.put_cf(&second, b"later", b"second-new").unwrap();
+
+    let mut first_requested = iterators.remove(0);
+    let second_requested = &mut iterators[0];
+    assert_eq!(
+        collect_entries(&mut first_requested),
+        vec![(b"shared".to_vec(), b"second-old".to_vec())]
+    );
+    drop(first_requested);
+    assert_eq!(
+        collect_entries(second_requested),
+        vec![(b"shared".to_vec(), b"first-old".to_vec())]
+    );
+}
+
+#[test]
+fn raw_iterators_cf_handles_empty_input() {
+    let path = DBPath::new("_rust_rocksdb_multi_cf_iterators_empty");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let db = DB::open_cf(&options, &path, ["cf"]).unwrap();
+    let cf = db.cf_handle("cf").unwrap();
+    let empty = [&cf; 0];
+
+    assert!(db.raw_iterators_cf(empty).unwrap().is_empty());
+}
+
+#[cfg(feature = "multi-threaded-cf")]
+#[test]
+fn raw_iterators_cf_do_not_borrow_temporary_arc_handles() {
+    let path = DBPath::new("_rust_rocksdb_multi_cf_iterators_temporary_handles");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let db = DB::open_cf(&options, &path, ["first", "second"]).unwrap();
+
+    let mut iterators = db
+        .raw_iterators_cf([
+            &db.cf_handle("first").unwrap(),
+            &db.cf_handle("second").unwrap(),
+        ])
+        .unwrap();
+    assert_eq!(iterators.len(), 2);
+    for iterator in &mut iterators {
+        iterator.seek_to_first();
+        assert!(!iterator.valid());
+    }
+}

--- a/tests/test_public_api.rs
+++ b/tests/test_public_api.rs
@@ -25,6 +25,11 @@ use rust_rocksdb::{
     // `key_may_exist_*_pinned_value` helpers. Users who want to hold
     // onto the pinned value past the immediate call site need the name.
     ColumnFamilyMetaData,
+    // Returned by batch-owned pinned MultiGet APIs.
+    DBPinnableBatch,
+    DBPinnableBatchIter,
+    // Returned by `Snapshot::read_options{,_opt}`.
+    SnapshotReadOptions,
 };
 
 #[test]
@@ -34,4 +39,7 @@ fn newly_exported_types_resolve() {
     // obvious in CI logs.
     let _ = std::any::type_name::<ColumnFamilyMetaData>();
     let _ = std::any::type_name::<CSlice>();
+    let _ = std::any::type_name::<DBPinnableBatch<'static>>();
+    let _ = std::any::type_name::<DBPinnableBatchIter<'static, 'static>>();
+    let _ = std::any::type_name::<SnapshotReadOptions<'static, 'static>>();
 }

--- a/tests/test_snapshot_read_options.rs
+++ b/tests/test_snapshot_read_options.rs
@@ -1,0 +1,142 @@
+// Copyright 2020 Tyler Neely
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+mod util;
+
+use rust_rocksdb::{DB, Options, ReadOptions, TransactionDB};
+use util::DBPath;
+
+fn assert_send_sync<T: Send + Sync>(_: &T) {}
+
+fn seed_default_column_family(db: &DB) {
+    db.put(b"k1", b"old1").unwrap();
+    db.put(b"k2", b"old2").unwrap();
+}
+
+#[test]
+fn snapshot_read_options_reuse_gets() {
+    let path = DBPath::new("_rust_rocksdb_snapshot_read_options_gets");
+    let db = DB::open_default(&path).unwrap();
+    seed_default_column_family(&db);
+    let snapshot = db.snapshot();
+    db.put(b"k1", b"new1").unwrap();
+    let reads = snapshot.read_options();
+    assert_send_sync(&reads);
+
+    for _ in 0..3 {
+        assert_eq!(
+            reads.get(b"k1").unwrap().as_deref(),
+            Some(b"old1".as_slice())
+        );
+    }
+
+    let pinned = reads.get_pinned(b"k1").unwrap().unwrap();
+    assert_eq!(pinned.as_ref(), b"old1");
+
+    let values = reads.multi_get([b"k1".as_slice(), b"k2", b"missing"]);
+    assert_eq!(
+        values[0].as_ref().unwrap().as_deref(),
+        Some(b"old1".as_slice())
+    );
+    assert_eq!(
+        values[1].as_ref().unwrap().as_deref(),
+        Some(b"old2".as_slice())
+    );
+    assert_eq!(values[2].as_ref().unwrap().as_deref(), None);
+}
+
+#[test]
+fn snapshot_read_options_reuse_custom_options_and_column_family() {
+    let path = DBPath::new("_rust_rocksdb_snapshot_read_options_cf");
+    let mut options = Options::default();
+    options.create_if_missing(true);
+    options.create_missing_column_families(true);
+    let db = DB::open_cf(&options, &path, ["cf"]).unwrap();
+    let cf = db.cf_handle("cf").unwrap();
+    db.put_cf(&cf, b"cf-key", b"cf-old").unwrap();
+    let snapshot = db.snapshot();
+    db.put_cf(&cf, b"cf-key", b"cf-new").unwrap();
+
+    let mut custom = ReadOptions::default();
+    custom.fill_cache(false);
+    let reads = snapshot.read_options_opt(custom);
+    assert_eq!(
+        reads.get_cf(&cf, b"cf-key").unwrap().as_deref(),
+        Some(b"cf-old".as_slice())
+    );
+    let cf_pinned = reads.get_pinned_cf(&cf, b"cf-key").unwrap().unwrap();
+    assert_eq!(cf_pinned.as_ref(), b"cf-old");
+    let cf_values = reads.multi_get_cf([(&cf, b"cf-key".as_slice())]);
+    assert_eq!(
+        cf_values[0].as_ref().unwrap().as_deref(),
+        Some(b"cf-old".as_slice())
+    );
+}
+
+#[test]
+fn snapshot_read_options_are_shareable() {
+    let path = DBPath::new("_rust_rocksdb_snapshot_read_options_shared");
+    let db = DB::open_default(&path).unwrap();
+    db.put(b"k1", b"old1").unwrap();
+    let snapshot = db.snapshot();
+    let reads = snapshot.read_options();
+    std::thread::scope(|scope| {
+        for _ in 0..2 {
+            scope.spawn(|| {
+                assert_eq!(reads.get_pinned(b"k1").unwrap().unwrap().as_ref(), b"old1");
+            });
+        }
+    });
+}
+
+#[test]
+fn snapshot_compatibility_methods_keep_snapshot_semantics() {
+    let path = DBPath::new("_rust_rocksdb_snapshot_compatibility");
+    let db = DB::open_default(&path).unwrap();
+    seed_default_column_family(&db);
+    let snapshot = db.snapshot();
+    db.put(b"k1", b"new1").unwrap();
+    assert_eq!(
+        snapshot.get(b"k1").unwrap().as_deref(),
+        Some(b"old1".as_slice())
+    );
+    assert_eq!(
+        snapshot.get_pinned(b"k1").unwrap().unwrap().as_ref(),
+        b"old1"
+    );
+    let values = snapshot.multi_get([b"k1".as_slice(), b"k2"]);
+    assert_eq!(
+        values[0].as_ref().unwrap().as_deref(),
+        Some(b"old1".as_slice())
+    );
+    assert_eq!(
+        values[1].as_ref().unwrap().as_deref(),
+        Some(b"old2".as_slice())
+    );
+}
+
+#[test]
+fn snapshot_read_options_support_transaction_db() {
+    let path = DBPath::new("_rust_rocksdb_snapshot_read_options_transaction_db");
+    let db: TransactionDB = TransactionDB::open_default(&path).unwrap();
+    db.put(b"k1", b"old1").unwrap();
+    let snapshot = db.snapshot();
+    db.put(b"k1", b"new1").unwrap();
+    let reads = snapshot.read_options();
+
+    assert_eq!(
+        reads.get(b"k1").unwrap().as_deref(),
+        Some(b"old1".as_slice())
+    );
+}


### PR DESCRIPTION
## Summary

This adds lower-overhead APIs for common read, scan, batch, and monitoring paths while keeping the existing interfaces available.

- add borrowed iterator callbacks that avoid copying each key and value
- add reusable snapshot read options for repeated reads
- batch pinned MultiGet calls and add a batch-owned result type
- add slice-based vectored WriteBatch operations with error propagation
- add single-call multi-column-family iterator creation
- use RocksDB integer properties directly when supported, with the old string fallback for compatibility
- reuse PerfContext wrappers without resetting active manual measurements
- expose open_files_async, cache occupancy, and write buffer manager accounting
- align PerfStatsLevel values and RTTI flags with RocksDB 11.1.2

## Why

Several wrapper paths were doing avoidable work around RocksDB:

- the standard iterator allocated and copied both fields for every row
- snapshot point reads created and destroyed ReadOptions on every call
- pinned MultiGet performed separate point reads instead of one native batch
- integer properties always allocated a string and parsed it
- creating iterators for multiple column families allocated one ReadOptions wrapper per iterator
- callers building composite keys or values had to concatenate them before adding them to a WriteBatch

The new APIs let callers avoid that work without changing existing owned-value behavior.

## Behavior notes

- multi_get_pinned keeps the scalar path for one key and uses native batching for larger requests
- batch-owned pinned results use one native owner in vendored builds and exported C API handles in system builds
- vectored WriteBatch methods return RocksDB errors, including timestamp-column-family errors that upstream C wrappers otherwise hide
- integer properties fall back to the previous string path when RocksDB does not support the direct integer form
- transaction-backed snapshots are no longer marked Send or Sync unless the backing database type is Sync
- system builds use exported RocksDB C APIs for the new batch and vectored paths

## Local benchmark signal

A quick Criterion run on macOS ARM64 showed:

- borrowed full scan: about 302 us versus 487 us for the owned iterator over 4,096 entries
- vectored WriteBatch assembly: about 3.70 us versus 4.89 us with Rust-side concatenation
- direct integer property: about 47 ns versus 224 ns for the numeric string fallback
- reusable snapshot options started helping after roughly two reads
- reusable PerfContext wrapper: about 11 ns versus 28 ns for a fresh wrapper

These numbers describe this checkout and machine. The benchmark target is included so other environments can measure the same paths.

## Validation

- cargo test --all
- cargo test --all --features multi-threaded-cf
- cargo clippy --all-targets -- -D warnings
- cargo clippy --all-targets --features "rtti multi-threaded-cf serde1 malloc-usable-size zstd-static-linking-only" -- -D warnings
- cargo rustdoc -- -D warnings
- cargo bench --bench hot_paths -- --quick
- system-backend cargo check against RocksDB 11.1.2 headers and library

## Scope

This does not include the WriteBatchWithIndex allocator work in #250 or build invalidation and prebuilt-bundle work.

## Upstream tracking

- facebook/rocksdb#14988 adds the batch-owned pinned MultiGet C API.
- facebook/rocksdb#14989 adds the error-reporting WriteBatch slice-part C APIs.
- facebook/rocksdb#14809 tracks the event-listener recovery C API already used by this fork.

The matching local extensions can be removed after these changes land in a RocksDB release used by rust-rocksdb.