### PR TITLE
Fix a use-after-free introduced in #253, and the rest of the review fallout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+This release contains breaking API changes (marked `fix!` below) and needs
+a minor version bump.
+
 ### Memory safety
 
 - fix: stop handing `malloc`ed buffers to Rust's allocator.
@@ -13,21 +16,25 @@
   Works by accident with the system allocator, corrupts the heap under
   any `#[global_allocator]` or on Windows. Also leaked the `malloc(0)`
   block for every empty value.
-- fix: `WriteBatchWithIndex::iterator_with_base{,_cf}` returned an
+- fix!: `WriteBatchWithIndex::iterator_with_base{,_cf}` returned an
   iterator tied only to the base iterator, so the batch could be dropped
-  while the iterator was still reading its skip list.
-- fix: `WriteBatchWithIndex::get_pinned_from_batch_and_db{,_cf}` let
+  while the iterator was still reading its skip list. The iterator now
+  borrows the batch, which is a source-breaking signature change.
+- fix!: `WriteBatchWithIndex::get_pinned_from_batch_and_db{,_cf}` let
   elision tie the pinned slice to the batch rather than to the DB whose
-  block cache it pins.
-- fix: `Snapshot::iterator` and `iterator_opt` returned the DB lifetime
+  block cache it pins. Source-breaking in both directions: the slice may
+  now outlive the batch, and may no longer outlive the DB.
+- fix!: `Snapshot::iterator` and `iterator_opt` returned the DB lifetime
   instead of the `&self` borrow, so the iterator could outlive the
   snapshot. Every other iterator constructor in the file already got
-  this right.
+  this right. Source-breaking for code that relied on the longer
+  lifetime.
 - fix: the callback logger ran `str::from_utf8_unchecked` over RocksDB
   log text and transmuted the level into a `#[repr(i32)]` enum. Paths
   reach RocksDB through `OsStr::as_bytes` and are not UTF-8 validated.
-- fix: `SstFileWriter::open` took `&self` while mutating the writer,
-  which combined with the `Sync` impl let two threads race on it.
+- fix!: `SstFileWriter::open` took `&self` while mutating the writer,
+  which combined with the `Sync` impl let two threads race on it. It now
+  takes `&mut self`, so callers need a `mut` binding.
 - fix: guard `slice::from_raw_parts` on zero-length keys and values in
   the iterator accessors, `DBPinnableSlice::deref` and `CSlice::as_ref`.
 - fix: `prefix_exists` held a `RefCell` borrow across an FFI call that
@@ -56,14 +63,16 @@
 
 - perf: enable hardware CRC32C on aarch64. The `-march=...+crc` flag was
   gated on `CARGO_CFG_TARGET_FEATURE`, which is only `neon` on stock
-  `aarch64-unknown-linux-gnu`, `aarch64-linux-android` and
-  `aarch64-pc-windows-msvc`, so `HAVE_ARM64_CRC` was never defined,
+  `aarch64-unknown-linux-gnu` and `aarch64-linux-android`, so
+  `HAVE_ARM64_CRC` was never defined,
   `util/crc32c_arm64.cc` compiled to an empty object, and every block
   read and write used the software CRC table. RocksDB picks the ARM path
   at runtime via `getauxval(AT_HWCAP)`, so the flag is now gated on the
   compiler accepting it, as upstream does. Scoped to the two crc32c
   translation units so folly's `F14IntrinsicsMode` stays consistent with
-  the prebuilt libfolly in coroutines builds.
+  the prebuilt libfolly in coroutines builds, and applied regardless of
+  `-Ctarget-cpu`. MSVC is excluded: it has no `-march` and would need
+  `/arch:` instead.
 - perf: build the vendored snappy with its accelerated paths on. snappy
   expects a generated `config.h`; we never produced one or defined
   `HAVE_CONFIG_H`, so every `#if HAVE_*` was 0 and the NEON/SSSE3

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -377,18 +377,29 @@ mod vendor {
 
     /// Compile RocksDB from the bundled submodule sources.
     pub(super) fn build(target: &Target) {
-        let (mut cfg, layout) = configure(target);
+        let (mut cfg, layout) = configure(target, CpuBaseline::FromTargetCpu);
 
         // These are pulled out into their own build below when they need
         // different `-march` flags than the rest of the library.
         let crc_sources = arm_crc32c_sources(target);
 
+        let mut moved = 0;
         for src in collect_sources(target, layout) {
             if crc_sources.contains(&src) {
+                moved += 1;
                 continue;
             }
             cfg.file(format!("rocksdb/{src}"));
         }
+        // Names are matched against rocksdb_lib_sources.txt by string. If a
+        // rename upstream ever broke that match we would compile these twice
+        // and hit duplicate symbols, so fail here with a readable message
+        // instead.
+        assert_eq!(
+            moved,
+            crc_sources.len(),
+            "crc32c source names no longer match rocksdb_lib_sources.txt"
+        );
         cfg.file("build_version.cc");
         // Local C-API extensions are compiled as a regular translation
         // unit alongside the submodule's `db/c.cc`. The two end up in the
@@ -398,7 +409,12 @@ mod vendor {
         cfg.compile("librocksdb.a");
 
         if !crc_sources.is_empty() {
-            let (mut crc_cfg, _) = configure(target);
+            // `CpuBaseline::Ignore`: these two files pin their own `-march`, and
+            // a user's `-mcpu` on top of it would be a second, conflicting
+            // baseline flag. Dropping it costs nothing — they are self-contained
+            // CRC routines, so per-CPU scheduling tuning is irrelevant, and the
+            // only thing that matters is that `+crc` is available.
+            let (mut crc_cfg, _) = configure(target, CpuBaseline::Ignore);
             crc_cfg.flag_if_supported(ARM_CRC32C_MARCH);
             for src in &crc_sources {
                 crc_cfg.file(format!("rocksdb/{src}"));
@@ -413,16 +429,29 @@ mod vendor {
         }
     }
 
+    /// Whether a `configure` call should forward the user's `-Ctarget-cpu`.
+    #[derive(Copy, Clone, PartialEq, Eq)]
+    enum CpuBaseline {
+        /// Pass `-Ctarget-cpu` through as `-march`/`-mcpu`, as usual.
+        FromTargetCpu,
+        /// Ignore `-Ctarget-cpu`. Used for the aarch64 CRC32C translation
+        /// units, which pin their own `-march` and would otherwise end up with
+        /// two conflicting baseline flags.
+        Ignore,
+    }
+
     /// Everything about the build except which files go into it. Shared by the
     /// main library and the separate aarch64 CRC32C build so the two can't
     /// drift apart.
-    fn configure(target: &Target) -> (cc::Build, SourceLayout) {
+    fn configure(target: &Target, baseline: CpuBaseline) -> (cc::Build, SourceLayout) {
         let mut cfg = base_cfg(target);
 
         apply_compression_features(&mut cfg);
         apply_optional_features(&mut cfg, target);
         apply_jemalloc(&mut cfg, target);
-        apply_target_cpu(&mut cfg, target);
+        if baseline == CpuBaseline::FromTargetCpu {
+            apply_target_cpu(&mut cfg, target);
+        }
         apply_target_arch(&mut cfg, target);
         let layout = apply_target_os(&mut cfg, target);
         apply_lfs_defines(&mut cfg, target, layout);
@@ -468,9 +497,15 @@ mod vendor {
     /// `crc32c.cc` under `HAVE_ARM64_CRC` and declared `extern` in
     /// `crc32c_arm64.cc`.
     fn arm_crc32c_sources(target: &Target) -> Vec<&'static str> {
-        // A user-specified CPU already went out as `-mcpu=<cpu>`; overriding it
-        // with `-march` here would narrow the baseline they asked for.
-        if target.arch != "aarch64" || target.rust_target_cpu.is_some() {
+        if target.arch != "aarch64" {
+            return Vec::new();
+        }
+        // `cl.exe` has no `-march`, and treats unknown options as a D9002
+        // warning rather than an error, so `flag_if_supported` would happily
+        // pass it through and spam every translation unit for no benefit.
+        // MSVC infers the CRC intrinsics from `/arch:` instead, which is a
+        // separate change.
+        if target.is_msvc() {
             return Vec::new();
         }
         vec!["util/crc32c.cc", "util/crc32c_arm64.cc"]

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.cc
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.cc
@@ -38,6 +38,7 @@ using ROCKSDB_NAMESPACE::Options;
 using ROCKSDB_NAMESPACE::PinnableSlice;
 using ROCKSDB_NAMESPACE::ReadOptions;
 using ROCKSDB_NAMESPACE::Slice;
+using ROCKSDB_NAMESPACE::Snapshot;
 using ROCKSDB_NAMESPACE::SliceParts;
 using ROCKSDB_NAMESPACE::Status;
 using ROCKSDB_NAMESPACE::SubcompactionJobInfo;
@@ -312,8 +313,10 @@ extern "C" void rust_rocksdb_options_add_eventlistener(
 // every test that round-trips a value through one of our setters will
 // fail loudly: the setter would write to one offset and rocksdb's
 // internal code would read from another. The integration tests in
-// `tests/test_rocksdb_options.rs` cover all three options that this file
-// exposes, so a layout regression is detectable.
+// `tests/test_rocksdb_options.rs` cover the options this file exposes,
+// and `transaction_snapshot_sequence_number_without_set_snapshot` in
+// `tests/test_transaction_db.rs` covers the `rocksdb_snapshot_t` cast
+// below, so a layout regression is detectable.
 
 // -----------------------------------------------------------------------------
 // ReadOptions::optimize_multiget_for_io
@@ -912,8 +915,7 @@ extern "C" unsigned char rust_rocksdb_snapshot_try_get_sequence_number(
   if (snapshot == nullptr) {
     return 0;
   }
-  const ROCKSDB_NAMESPACE::Snapshot* rep =
-      *reinterpret_cast<const ROCKSDB_NAMESPACE::Snapshot* const*>(snapshot);
+  const Snapshot* rep = *reinterpret_cast<const Snapshot* const*>(snapshot);
   if (rep == nullptr) {
     // A transaction started without `set_snapshot(true)` yields a wrapper whose
     // `rep` is null; upstream's getter would dereference it.

--- a/src/db.rs
+++ b/src/db.rs
@@ -584,6 +584,10 @@ impl<T: ThreadMode> DBWithThreadMode<T> {
     ///
     /// This applies the given `ttl` to all column families created without an explicit TTL.
     /// See [`DB::open_cf_descriptors_with_ttl`] for more control over individual column family TTLs.
+    ///
+    /// RocksDB stores the TTL as a 32-bit second count, so a `ttl` longer than
+    /// `i32::MAX` seconds (about 68 years) is clamped to that maximum rather
+    /// than wrapping.
     pub fn open_with_ttl<P: AsRef<Path>>(
         opts: &Options,
         path: P,
@@ -2376,7 +2380,13 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
             if ffi::rocksdb_iter_valid(iter) != 0 {
                 let mut key_len: size_t = 0;
                 let key_ptr = ffi::rocksdb_iter_key(iter, &raw mut key_len);
-                let key = slice::from_raw_parts(key_ptr.cast::<u8>(), key_len as usize);
+                // An empty key is legal, and `from_raw_parts` wants a
+                // dereferenceable pointer even at length 0.
+                let key = if key_len == 0 {
+                    &[][..]
+                } else {
+                    slice::from_raw_parts(key_ptr.cast::<u8>(), key_len as usize)
+                };
                 Ok(key.starts_with(prefix))
             } else if let Err(e) = (|| {
                 // Check status to differentiate end-of-range vs error
@@ -2476,7 +2486,13 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
             if ffi::rocksdb_iter_valid(iter) != 0 {
                 let mut key_len: size_t = 0;
                 let key_ptr = ffi::rocksdb_iter_key(iter, &raw mut key_len);
-                let key = slice::from_raw_parts(key_ptr.cast::<u8>(), key_len as usize);
+                // An empty key is legal, and `from_raw_parts` wants a
+                // dereferenceable pointer even at length 0.
+                let key = if key_len == 0 {
+                    &[][..]
+                } else {
+                    slice::from_raw_parts(key_ptr.cast::<u8>(), key_len as usize)
+                };
                 Ok(key.starts_with(prefix))
             } else if let Err(e) = (|| {
                 ffi_try!(ffi::rocksdb_iter_get_error(iter));
@@ -3432,10 +3448,20 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
     /// sizes will be one-tenth the size of the corresponding user data size.
     ///
     /// Due to lack of abi, only data flushed to disk is taken into account.
+    /// # Errors
+    ///
+    /// Returns the RocksDB error if the size estimate fails, for instance on an
+    /// I/O error reading the manifest. No partial sizes are reported in that
+    /// case.
     pub fn get_approximate_sizes(&self, ranges: &[Range]) -> Result<Vec<u64>, Error> {
         self.get_approximate_sizes_cfopt(None::<&ColumnFamily>, ranges)
     }
 
+    /// Like [`Self::get_approximate_sizes`], for a single column family.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::get_approximate_sizes`].
     pub fn get_approximate_sizes_cf(
         &self,
         cf: &impl AsColumnFamilyRef,
@@ -3734,11 +3760,12 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
 
     /// Marks the column family as dropped in RocksDB.
     ///
-    /// Deliberately does not take ownership of the handle. Callers must destroy
-    /// their handle (and forget the column family) only after this succeeds:
-    /// destroying it on failure would leave the column family still present in
-    /// the DB with no reachable handle, so the only way to touch it again would
-    /// be to reopen the database.
+    /// Deliberately does not take ownership of the handle. Callers must take
+    /// the handle out of their map first, so that only one caller can ever
+    /// reach a given handle, and must put it back if this fails: destroying it
+    /// on failure would leave the column family still present in the DB with no
+    /// reachable handle, so the only way to touch it again would be to reopen
+    /// the database.
     fn mark_column_family_dropped(
         &self,
         cf_inner: *mut ffi::rocksdb_column_family_handle_t,
@@ -3849,13 +3876,20 @@ impl<I: DBInner> DBCommon<SingleThreaded, I> {
 
     /// Drops the column family with the given name
     pub fn drop_cf(&mut self, name: &str) -> Result<(), Error> {
-        let Some(cf) = self.cfs.cfs.get(name) else {
+        let Some(cf) = self.cfs.cfs.remove(name) else {
             return Err(Error::new(format!("Invalid column family: {name}")));
         };
-        self.mark_column_family_dropped(cf.inner)?;
-        // Only now reclaim resources (mem, files) by destroying the last handle.
-        drop(self.cfs.cfs.remove(name));
-        Ok(())
+        match self.mark_column_family_dropped(cf.inner) {
+            // `cf` is dropped here, which destroys the handle and reclaims the
+            // memory and files behind it.
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // The column family is still there, so put the handle back
+                // rather than destroying the only way to reach it.
+                self.cfs.cfs.insert(name.to_owned(), cf);
+                Err(e)
+            }
+        }
     }
 
     /// Returns the underlying column family handle
@@ -3920,13 +3954,25 @@ impl<I: DBInner> DBCommon<MultiThreaded, I> {
     /// Drops the column family with the given name by internally locking the inner column
     /// family map. This avoids needing `&mut self` reference
     pub fn drop_cf(&self, name: &str) -> Result<(), Error> {
-        let Some(inner) = self.cfs.cfs.read().get(name).map(|cf| cf.inner) else {
+        // Take the handle out under the write lock before touching RocksDB.
+        // Looking it up under a read lock and removing it afterwards would let
+        // two concurrent callers observe the same handle: the first would drop
+        // and destroy it, and the second would then hand a freed pointer to
+        // `rocksdb_drop_column_family`.
+        let Some(cf) = self.cfs.cfs.write().remove(name) else {
             return Err(Error::new(format!("Invalid column family: {name}")));
         };
-        self.mark_column_family_dropped(inner)?;
-        // Only now reclaim resources (mem, files) by destroying the last handle.
-        drop(self.cfs.cfs.write().remove(name));
-        Ok(())
+        match self.mark_column_family_dropped(cf.inner) {
+            // `cf` is dropped here, which destroys the handle and reclaims the
+            // memory and files behind it.
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // The column family is still there, so put the handle back
+                // rather than destroying the only way to reach it.
+                self.cfs.cfs.write().insert(name.to_owned(), cf);
+                Err(e)
+            }
+        }
     }
 
     /// Returns the underlying column family handle
@@ -4212,9 +4258,13 @@ unsafe impl Sync for ExportImportFilesMetaData {}
 /// `Duration::as_secs` is a `u64`, so a plain `as i32` cast wraps: a TTL of
 /// `Duration::from_secs(4_294_967_301)` (~136 years, i.e. "effectively never")
 /// became `5`, and RocksDB then compaction-deleted the whole column family a few
-/// seconds after the data was written. RocksDB only treats `ttl <= 0` specially,
-/// so there is no sentinel for "no expiry"; `i32::MAX` (~68 years) is the
-/// longest expressible TTL and is what `ColumnFamilyTtl::Disabled` already uses.
+/// seconds after the data was written.
+///
+/// Clamping to `i32::MAX` (~68 years) rather than mapping an over-large TTL to
+/// RocksDB's never-expire sentinel (`ttl <= 0`, see `DBWithTTLImpl::IsStale`) is
+/// deliberate: silently turning a finite TTL the caller asked for into "keep
+/// forever" is a worse surprise than expiring it 68 years out, and `i32::MAX` is
+/// the longest TTL the C API can express anyway.
 fn ttl_to_seconds(ttl: Duration) -> c_int {
     c_int::try_from(ttl.as_secs()).unwrap_or(c_int::MAX)
 }

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -3661,23 +3661,31 @@ impl Options {
     extern "C" fn logger_callback(func: *mut c_void, level: u32, msg: *mut c_char, len: usize) {
         use std::process;
 
-        // `level` and `msg` come straight from RocksDB's `vsnprintf` output, so
-        // neither can be trusted:
+        // Neither argument can be trusted:
         //
-        //  * `LogLevel` is `#[repr(i32)]`, so transmuting an out-of-range level
-        //    would materialise an invalid discriminant.
-        //  * Log lines routinely embed filesystem paths and `Status::ToString()`
-        //    text. Paths reach RocksDB via `OsStr::as_bytes()`, which is not
-        //    UTF-8 validated, so `from_utf8_unchecked` was unsound.
+        //  * `LogLevel` is `#[repr(i32)]`, and `level` is whatever
+        //    `InfoLogLevel` the C layer cast to an unsigned, so transmuting it
+        //    could materialise an invalid discriminant.
+        //  * `msg` is raw `vsnprintf` output. Log lines routinely embed
+        //    filesystem paths and `Status::ToString()` text, and paths reach
+        //    RocksDB via `OsStr::as_bytes()`, which is not UTF-8 validated, so
+        //    `from_utf8_unchecked` was unsound.
         //
         // `from_utf8_lossy` returns `Cow::Borrowed` for valid UTF-8, so the
         // common path still does not allocate.
         let level = LogLevel::try_from_raw(level as i32).unwrap_or(LogLevel::Info);
-        let slice = unsafe { slice::from_raw_parts(msg.cast_const().cast::<u8>(), len) };
+        let slice = if len == 0 {
+            &[][..]
+        } else {
+            unsafe { slice::from_raw_parts(msg.cast_const().cast::<u8>(), len) }
+        };
         let msg = String::from_utf8_lossy(slice);
 
-        let holder = unsafe { &mut *func.cast::<LogCallback>() };
-        let mut callback_in_catch_unwind = AssertUnwindSafe(&mut holder.callback);
+        // Shared reference, not `&mut`: RocksDB logs from several background
+        // threads at once, so a `&mut` here would alias. `LogCallbackFn` is a
+        // `dyn Fn`, so a shared reference is all it needs.
+        let holder = unsafe { &*func.cast::<LogCallback>() };
+        let callback_in_catch_unwind = AssertUnwindSafe(&holder.callback);
         if catch_unwind(move || callback_in_catch_unwind(level, &msg)).is_err() {
             process::abort();
         }
@@ -5407,10 +5415,16 @@ unsafe extern "C" fn logger_callback(
     len: size_t,
 ) {
     let rust_callback: &LoggerCallback = unsafe { &*(raw_cb as LoggerCallbackPtr) };
-    let raw_msg = unsafe { std::slice::from_raw_parts(msg.cast_const().cast::<u8>(), len) };
+    let raw_msg = if len == 0 {
+        &[][..]
+    } else {
+        unsafe { std::slice::from_raw_parts(msg.cast_const().cast::<u8>(), len) }
+    };
     let msg = String::from_utf8_lossy(raw_msg);
-    let level =
-        LogLevel::try_from_raw(level as i32).expect("rocksdb generated an invalid log level");
+    // Don't panic on an unexpected level: this runs in an `extern "C"` frame,
+    // where unwinding aborts the process. Losing the exact level of one log
+    // line is not worth taking the process down for.
+    let level = LogLevel::try_from_raw(level as i32).unwrap_or(LogLevel::Info);
     (rust_callback)(level, &msg);
 }
 

--- a/src/sst_file_writer.rs
+++ b/src/sst_file_writer.rs
@@ -70,7 +70,7 @@ impl<'a> SstFileWriter<'a> {
     ///
     /// Takes `&mut self` because the underlying `rocksdb::SstFileWriter::Open`
     /// mutates the writer (it installs a new `WritableFileWriter` and table
-    /// builder) and is not thread safe. With `&self` and the `Sync` impl below,
+    /// builder) and is not thread safe. With `&self` and the `Sync` impl above,
     /// two threads could call this concurrently on the same writer from safe
     /// code and race on those fields.
     pub fn open<P: AsRef<Path>>(&mut self, path: P) -> Result<(), Error> {

--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -1071,10 +1071,11 @@ impl<T: ThreadMode> TransactionDB<T> {
 
     /// Marks the column family as dropped in RocksDB.
     ///
-    /// Deliberately does not take ownership of the handle. Callers must destroy
-    /// their handle (and forget the column family) only after this succeeds:
-    /// destroying it on failure would leave the column family still present in
-    /// the DB with no reachable handle.
+    /// Deliberately does not take ownership of the handle. Callers must take
+    /// the handle out of their map first, so that only one caller can ever
+    /// reach a given handle, and must put it back if this fails: destroying it
+    /// on failure would leave the column family still present in the DB with no
+    /// reachable handle.
     fn mark_column_family_dropped(
         &self,
         cf_inner: *mut ffi::rocksdb_column_family_handle_t,
@@ -1106,13 +1107,20 @@ impl TransactionDB<SingleThreaded> {
 
     /// Drops the column family with the given name
     pub fn drop_cf(&mut self, name: &str) -> Result<(), Error> {
-        let Some(cf) = self.cfs.cfs.get(name) else {
+        let Some(cf) = self.cfs.cfs.remove(name) else {
             return Err(Error::new(format!("Invalid column family: {name}")));
         };
-        self.mark_column_family_dropped(cf.inner)?;
-        // Only now reclaim resources (mem, files) by destroying the last handle.
-        drop(self.cfs.cfs.remove(name));
-        Ok(())
+        match self.mark_column_family_dropped(cf.inner) {
+            // `cf` is dropped here, which destroys the handle and reclaims the
+            // memory and files behind it.
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // The column family is still there, so put the handle back
+                // rather than destroying the only way to reach it.
+                self.cfs.cfs.insert(name.to_owned(), cf);
+                Err(e)
+            }
+        }
     }
 }
 
@@ -1143,13 +1151,25 @@ impl TransactionDB<MultiThreaded> {
     /// Drops the column family with the given name by internally locking the inner column
     /// family map. This avoids needing `&mut self` reference
     pub fn drop_cf(&self, name: &str) -> Result<(), Error> {
-        let Some(inner) = self.cfs.cfs.read().get(name).map(|cf| cf.inner) else {
+        // Take the handle out under the write lock before touching RocksDB.
+        // Looking it up under a read lock and removing it afterwards would let
+        // two concurrent callers observe the same handle: the first would drop
+        // and destroy it, and the second would then hand a freed pointer to
+        // `rocksdb_drop_column_family`.
+        let Some(cf) = self.cfs.cfs.write().remove(name) else {
             return Err(Error::new(format!("Invalid column family: {name}")));
         };
-        self.mark_column_family_dropped(inner)?;
-        // Only now reclaim resources (mem, files) by destroying the last handle.
-        drop(self.cfs.cfs.write().remove(name));
-        Ok(())
+        match self.mark_column_family_dropped(cf.inner) {
+            // `cf` is dropped here, which destroys the handle and reclaims the
+            // memory and files behind it.
+            Ok(()) => Ok(()),
+            Err(e) => {
+                // The column family is still there, so put the handle back
+                // rather than destroying the only way to reach it.
+                self.cfs.cfs.write().insert(name.to_owned(), cf);
+                Err(e)
+            }
+        }
     }
 
     /// Implementation for property_value et al methods.

--- a/src/write_batch_with_index.rs
+++ b/src/write_batch_with_index.rs
@@ -1,4 +1,5 @@
 use crate::db::DBInner;
+use crate::ffi_util::raw_data_and_free;
 use crate::{
     AsColumnFamilyRef, DBAccess, DBCommon, DBPinnableSlice, DBRawIteratorWithThreadMode, Error,
     Options, ReadOptions, ThreadMode, ffi,
@@ -98,7 +99,7 @@ impl WriteBatchWithIndex {
 
             // `value_data` was allocated by `malloc` on the C++ side; copy it
             // out and release it with `rocksdb_free`.
-            Ok(crate::ffi_util::raw_data_and_free(value_data, value_size))
+            Ok(raw_data_and_free(value_data, value_size))
         }
     }
 
@@ -125,7 +126,7 @@ impl WriteBatchWithIndex {
 
             // `value_data` was allocated by `malloc` on the C++ side; copy it
             // out and release it with `rocksdb_free`.
-            Ok(crate::ffi_util::raw_data_and_free(value_data, value_size))
+            Ok(raw_data_and_free(value_data, value_size))
         }
     }
 
@@ -162,7 +163,7 @@ impl WriteBatchWithIndex {
 
             // `value_data` was allocated by `malloc` on the C++ side; copy it
             // out and release it with `rocksdb_free`.
-            Ok(crate::ffi_util::raw_data_and_free(value_data, value_size))
+            Ok(raw_data_and_free(value_data, value_size))
         }
     }
 
@@ -242,7 +243,7 @@ impl WriteBatchWithIndex {
 
             // `value_data` was allocated by `malloc` on the C++ side; copy it
             // out and release it with `rocksdb_free`.
-            Ok(crate::ffi_util::raw_data_and_free(value_data, value_size))
+            Ok(raw_data_and_free(value_data, value_size))
         }
     }
 

--- a/tests/test_column_family.rs
+++ b/tests/test_column_family.rs
@@ -494,3 +494,59 @@ fn test_no_leaked_column_family() {
         drop(db);
     }
 }
+
+/// `drop_cf` on a `MultiThreaded` DB takes `&self`, so several threads can call
+/// it for the same column family at once. Exactly one of them may reach
+/// `rocksdb_drop_column_family` with the handle; the rest must find it already
+/// gone.
+///
+/// This is a regression test. An earlier version looked the handle up under a
+/// read lock and only removed it from the map after the FFI call, so two
+/// callers could both come away with the same pointer: the first destroyed it,
+/// the second passed the freed pointer to RocksDB. The assertion below fails
+/// deterministically on that version because both threads report success, and
+/// CI's AddressSanitizer job catches the use-after-free itself.
+#[test]
+#[cfg(feature = "multi-threaded-cf")]
+fn test_concurrent_drop_cf_has_exactly_one_winner() {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    let n = DBPath::new("_rust_rocksdb_concurrent_drop_cf");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        let db: Arc<DB> = Arc::new(DB::open(&opts, &n).unwrap());
+
+        for round in 0..25 {
+            let cf_name = format!("cf{round}");
+            db.create_cf(&cf_name, &Options::default()).unwrap();
+            db.put_cf(&db.cf_handle(&cf_name).unwrap(), b"k", b"v")
+                .unwrap();
+
+            let successes = Arc::new(AtomicUsize::new(0));
+            std::thread::scope(|scope| {
+                for _ in 0..4 {
+                    let db = Arc::clone(&db);
+                    let successes = Arc::clone(&successes);
+                    let cf_name = cf_name.clone();
+                    scope.spawn(move || {
+                        if db.drop_cf(&cf_name).is_ok() {
+                            successes.fetch_add(1, Ordering::Relaxed);
+                        }
+                    });
+                }
+            });
+
+            assert_eq!(
+                successes.load(Ordering::Relaxed),
+                1,
+                "exactly one thread should win the race to drop {cf_name}"
+            );
+            assert!(
+                db.cf_handle(&cf_name).is_none(),
+                "{cf_name} should be gone from the handle map"
+            );
+        }
+    }
+}

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -752,7 +752,7 @@ fn test_open_with_huge_ttl_does_not_wrap() {
     assert_eq!(
         db.get(b"key1").unwrap().as_deref(),
         Some(&b"value1"[..]),
-        "a ~136 year TTL must not expire after 5 seconds"
+        "a ~136 year TTL must not expire after 2 seconds"
     );
 }
 

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -946,9 +946,10 @@ fn test_crc32_build() {
         }
     } else if cfg!(target_arch = "aarch64") {
         // On aarch64 the answer is a property of the CPU, not of the build:
-        // build.rs always passes `-march=armv8-a+crc+crypto` (when the compiler
-        // accepts it), so `HAVE_ARM64_CRC` is defined and RocksDB decides at
-        // runtime via `crc32c_runtime_check()` / `getauxval(AT_HWCAP)`.
+        // build.rs compiles the crc32c sources with `-march=armv8-a+crc+crypto`
+        // on every non-MSVC aarch64 target, so `HAVE_ARM64_CRC` is defined and
+        // RocksDB decides at runtime via `crc32c_runtime_check()` /
+        // `getauxval(AT_HWCAP)`.
         //
         // CRC32 is optional in ARMv8.0 and mandatory from ARMv8.1, so a machine
         // without it is possible in principle. Asserting "Supported" here would
@@ -985,14 +986,20 @@ fn test_crc32_build() {
     // this may fail if RocksDB changes its string formatting
     let expected_arch = if cfg!(target_arch = "x86_64") {
         "x86".to_string()
-    } else if cfg!(target_arch = "aarch64") {
-        // Always "Arm64": build.rs unconditionally enables the ARM CRC32
-        // intrinsics on aarch64, so `HAVE_ARM64_CRC` is defined and
-        // `IsFastCrc32Supported` takes its Arm64 branch regardless of what the
-        // runtime check reports. Seeing "x86" here means the `-march` flag was
-        // lost and the whole hardware CRC32C path silently reverted to the
-        // table-driven software implementation.
+    } else if cfg!(all(target_arch = "aarch64", not(target_env = "msvc"))) {
+        // Always "Arm64" on non-MSVC aarch64: build.rs pins
+        // `-march=armv8-a+crc+crypto` on the crc32c sources regardless of
+        // `-Ctarget-cpu`, so `HAVE_ARM64_CRC` is defined and
+        // `IsFastCrc32Supported` takes its Arm64 branch whatever the runtime
+        // check reports. Seeing "x86" here means the flag was lost and the
+        // hardware CRC32C path silently reverted to the software table.
+        // MSVC has no `-march` and is not covered by that, so it is excluded.
         "Arm64".to_string()
+    } else if cfg!(all(target_arch = "aarch64", target_env = "msvc")) {
+        // aarch64 MSVC gets no `-march`, so `HAVE_ARM64_CRC` stays undefined
+        // and `IsFastCrc32Supported` falls through to its x86 branch. Enabling
+        // the intrinsics there needs `/arch:`, which is a separate change.
+        "x86".to_string()
     } else if cfg!(target_arch = "powerpc64") {
         "PPC".to_string()
     } else {


### PR DESCRIPTION
Follow-up to #253. I had that reviewed properly after it merged, and it turned
up a use-after-free that **I introduced in #253 itself** — so this wants to go
in before the next release.

### The regression

#253 changed `drop_cf` so it wouldn't destroy the column family handle when
`rocksdb_drop_column_family` fails. The `MultiThreaded` variant does that under
`&self`, and I rewrote it as: look the handle up under a read lock, release the
lock, call into RocksDB, then remove it from the map.

That isn't atomic. Two threads calling `drop_cf("x")` both come away with the
same pointer; the first destroys it on the way out, and the second hands a freed
`rocksdb_column_family_handle_t*` to RocksDB.

The code I replaced did `write().remove(name)` in one shot and had no such
window. So this was a straight regression, and a worse bug than the one it was
fixing — `drop_cf` takes `&self` precisely so it can be called concurrently.

Fix is to take the handle out under the write lock first and put it back if the
drop fails. That keeps the original atomicity and still doesn't destroy a handle
for a column family that's still there. I deliberately did **not** hold the lock
across the FFI call the way `create_cf` does: `parking_lot::RwLock` isn't
reentrant, so an `EventListener` calling `cf_handle()` would deadlock, and the
old code didn't hold it either.

`test_concurrent_drop_cf_has_exactly_one_winner` SIGSEGVs against the merged
version and passes here. The AddressSanitizer job covers it too.

### Everything else

Two more real bugs:

- The logger callback took `&mut` to the shared `LogCallback`. RocksDB logs from
  several background threads at once, so those references alias. `LogCallbackFn`
  is a `dyn Fn` and only ever needed `&`. Two characters, in the function I'd
  already rewritten for the `from_utf8_unchecked` fix.
- The *other* logger callback used `.expect()` on an unrecognised log level.
  That's an `extern "C"` frame, so it takes the process down over a cosmetic
  field.

Build flags:

- `arm_crc32c_sources` fired on `aarch64-pc-windows-msvc`, where `cl.exe` has no
  `-march` and treats unknown options as a D9002 warning rather than an error —
  so `flag_if_supported` would have accepted it and spammed every TU for no
  gain. MSVC needs `/arch:`, which is a separate change.
- The flag now applies regardless of `-Ctarget-cpu`. Bailing out when the user
  pinned a CPU meant `-Ctarget-cpu=generic` silently reverted to the software
  CRC, and made `test_crc32_build`'s "always Arm64" assertion untrue. The two
  crc32c files are self-contained, so dropping the user's `-mcpu` for them costs
  nothing and makes the behaviour unconditional and actually testable.
- Added an assert that the crc32c filenames still match
  `rocksdb_lib_sources.txt`. Silent rot is the entire subject of #253.

Correctness and docs:

- Zero-length `from_raw_parts` guards in `prefix_exists{,_cf}` and both logger
  callbacks. I added these everywhere else and missed these.
- `ttl_to_seconds` claimed RocksDB has no never-expire sentinel. It does:
  `ttl <= 0`, see `DBWithTTLImpl::IsStale`. Clamping to `i32::MAX` is still
  right — quietly turning a finite TTL into "keep forever" is worse than
  expiring 68 years out — but the comment stated something false.
- **Marked four breaking changes that shipped unflagged.** `SstFileWriter::open`
  now needs a `mut` binding, and the three lifetime fixes are all
  source-breaking. Only `get_approximate_sizes` and `sequence_number` were
  called out. The unreleased section now says up front that this needs a minor
  bump.
- Comment fixes: the `Sync` impl is above `open()`, not below; the TTL test
  sleeps 2 seconds, not 5; the log level doesn't come from `vsnprintf`; the
  `c_api_extensions` layout note no longer claims it covers "all three" casts
  when there are now four.
- Docs for the newly-fallible `get_approximate_sizes` and the `i32::MAX` clamp
  on `open_with_ttl`.

### Not addressed

`Transaction::snapshot()` still hands out a snapshot with a null `rep` when the
transaction didn't ask for one. #253 stopped `sequence_number()` crashing on it,
but `read_options()`, `iterator()` and `set_snapshot` all still silently accept
it and mean "no snapshot" — i.e. reads see latest data instead of a consistent
view. The real fix is `Transaction::snapshot() -> Option<...>`, which is a
bigger break and worth doing on its own.
