### PR TITLE
feat: expose disable_file_deletions and enable_file_deletions on OptimisticTransactionDB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,11 @@ a minor version bump.
   11.1.2, and prevent transaction-backed snapshots from being shared
   across threads.
 
+### Features
+
+- feat: expose `disable_file_deletions` and `enable_file_deletions` on
+  `OptimisticTransactionDB`.
+
 ## 0.51.0 (2026-06-26)
 
 - fix(librocksdb-sys): upgrade the bundled RocksDB submodule to

--- a/src/db.rs
+++ b/src/db.rs
@@ -1084,35 +1084,6 @@ impl<T: ThreadMode> DBWithThreadMode<T> {
             Ok(())
         }
     }
-
-    /// Suspend deleting obsolete files. Compactions will continue to occur,
-    /// but no obsolete files will be deleted. To resume file deletions, each
-    /// call to disable_file_deletions() must be matched by a subsequent call to
-    /// enable_file_deletions(). For more details, see enable_file_deletions().
-    pub fn disable_file_deletions(&self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(ffi::rocksdb_disable_file_deletions(self.inner.inner()));
-        }
-        Ok(())
-    }
-
-    /// Resume deleting obsolete files, following up on `disable_file_deletions()`.
-    ///
-    /// File deletions disabling and enabling is not controlled by a binary flag,
-    /// instead it's represented as a counter to allow different callers to
-    /// independently disable file deletion. Disabling file deletion can be
-    /// critical for operations like making a backup. So the counter implementation
-    /// makes the file deletion disabled as long as there is one caller requesting
-    /// so, and only when every caller agrees to re-enable file deletion, it will
-    /// be enabled. Two threads can call this method concurrently without
-    /// synchronization -- i.e., file deletions will be enabled only after both
-    /// threads call enable_file_deletions()
-    pub fn enable_file_deletions(&self) -> Result<(), Error> {
-        unsafe {
-            ffi_try!(ffi::rocksdb_enable_file_deletions(self.inner.inner()));
-        }
-        Ok(())
-    }
 }
 
 /// Common methods of `DBWithThreadMode` and `OptimisticTransactionDB`.
@@ -1174,6 +1145,35 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
                 self.inner.inner(),
                 c_uchar::from(sync)
             ));
+        }
+        Ok(())
+    }
+
+    /// Suspend deleting obsolete files. Compactions will continue to occur,
+    /// but no obsolete files will be deleted. To resume file deletions, each
+    /// call to disable_file_deletions() must be matched by a subsequent call to
+    /// enable_file_deletions(). For more details, see enable_file_deletions().
+    pub fn disable_file_deletions(&self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_disable_file_deletions(self.inner.inner()));
+        }
+        Ok(())
+    }
+
+    /// Resume deleting obsolete files, following up on `disable_file_deletions()`.
+    ///
+    /// File deletions disabling and enabling is not controlled by a binary flag,
+    /// instead it's represented as a counter to allow different callers to
+    /// independently disable file deletion. Disabling file deletion can be
+    /// critical for operations like making a backup. So the counter implementation
+    /// makes the file deletion disabled as long as there is one caller requesting
+    /// so, and only when every caller agrees to re-enable file deletion, it will
+    /// be enabled. Two threads can call this method concurrently without
+    /// synchronization -- i.e., file deletions will be enabled only after both
+    /// threads call enable_file_deletions()
+    pub fn enable_file_deletions(&self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rocksdb_enable_file_deletions(self.inner.inner()));
         }
         Ok(())
     }

--- a/tests/test_optimistic_transaction_db.rs
+++ b/tests/test_optimistic_transaction_db.rs
@@ -609,3 +609,55 @@ fn delete_range_test() {
         assert!(db.get_cf(&cf1, b"k3").unwrap().is_none());
     }
 }
+
+#[test]
+fn test_enable_and_disable_file_deletions() {
+    let path = DBPath::new("_rust_rocksdb_optimistic_enable_and_disable_file_deletions");
+
+    {
+        let get_sst_files = || {
+            std::fs::read_dir((&path).as_ref())
+                .unwrap()
+                .filter_map(Result::ok)
+                .filter(|f| f.file_name().to_string_lossy().ends_with(".sst"))
+                .map(|f| f.path())
+                .collect::<Vec<_>>()
+        };
+
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+
+        let db: OptimisticTransactionDB<SingleThreaded> =
+            OptimisticTransactionDB::open(&opts, &path).unwrap();
+        db.disable_file_deletions().unwrap();
+
+        // insert some data and flush to create first sst.
+        for i in 0..10 {
+            db.put(format!("k{}", i).as_bytes(), format!("v{}", i).as_bytes())
+                .unwrap();
+        }
+        db.flush().unwrap();
+
+        assert_eq!(get_sst_files().len(), 1);
+
+        // insert some data and flush to create second sst.
+        for i in 10..20 {
+            db.put(format!("k{}", i).as_bytes(), format!("v{}", i).as_bytes())
+                .unwrap();
+        }
+        db.flush().unwrap();
+
+        assert_eq!(get_sst_files().len(), 2);
+
+        // normally after compaction we should have 1 file, but due to disabled
+        // flag we should have 3.
+        db.compact_range(None::<&[u8]>, None::<&[u8]>);
+        assert_eq!(get_sst_files().len(), 3);
+
+        // turn file deletions back on and compact.
+        db.enable_file_deletions().unwrap();
+        db.compact_range(None::<&[u8]>, None::<&[u8]>);
+
+        assert_eq!(get_sst_files().len(), 1);
+    }
+}


### PR DESCRIPTION
Move disable_file_deletions and enable_file_deletions from DBWithThreadMode to DBCommon so they're available on both DB and OptimisticTransactionDB.

Add test coverage for the optimistic transaction variant.

Co–authored–by: Claude Opus 4.8