### PR TITLE
Fix regressions from the FFI hardening and build-size changes

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -274,10 +274,23 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y llvm clang
 
+      # `--lib --bins` skipped `tests/`, which is where nearly all of the FFI
+      # coverage lives, so the job was running almost none of the code it was
+      # meant to check. CFLAGS/CXXFLAGS carry the sanitizer into the `cc`
+      # build, without which an overflow performed by uninstrumented C++ has no
+      # instrumented load to trip on. `build.rs` looks for "sanitize" in those
+      # vars and keeps its dev-profile size optimizations out of the way.
+      #
+      # LeakSanitizer stays off. It is the tool that would catch a leak in this
+      # crate's FFI layer, but RocksDB keeps process-lifetime singletons and
+      # background threads that it reports at exit, so turning it on needs a
+      # suppression list built from an actual run.
       - name: Run tests with AddressSanitizer
         env:
           RUSTFLAGS: -Zsanitizer=address
           RUSTDOCFLAGS: -Zsanitizer=address
+          CFLAGS: -fsanitize=address -fno-omit-frame-pointer
+          CXXFLAGS: -fsanitize=address -fno-omit-frame-pointer
           ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:print_stats=1
         run: |
-          cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --all --lib --bins
+          cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --all --lib --bins --tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,28 @@ a minor version bump.
 - fix: `prefix_exists` held a `RefCell` borrow across an FFI call that
   can re-enter through a user comparator, so a re-entrant probe hit
   `BorrowMutError` and aborted from an `extern "C"` frame.
+- fix!: `SnapshotWithThreadMode`'s `Send`/`Sync` impls now require
+  `D: Sync`. `Transaction` is `Send` but not `Sync`, so a
+  transaction-backed snapshot was `Send + Sync` when it had no right to
+  be. Source-breaking for code that moved one across threads.
+- fix: `DB::raw_iterators_cf` dropped the `ReadOptions` the iterators
+  were created from before returning them. RocksDB's `DBIter` keeps raw
+  `Slice*` into that object for the iterate bounds and read timestamps,
+  and `Refresh` re-reads them. Harmless as shipped, because the options
+  were always the default and those pointers were null, but the next
+  caller to pass a bound would have read freed memory. All the iterators
+  from one call now share the options object through an `Arc`, and the
+  iterator type no longer allows one without options.
+- fix: bounds-check `rust_rocksdb_pinnable_batch_get` instead of
+  asserting. The vendored build defines `NDEBUG`, so the asserts
+  compiled away and left an unchecked `std::vector` index feeding a
+  pointer and length into `slice::from_raw_parts`.
+- fix: report an error rather than silent success when the C extension
+  cannot allocate an error string. It left `errptr` null, which Rust
+  reads as ok, so a failed vectored `WriteBatch` operation looked like it
+  had been applied.
+- fix: release the per-key error strings from a System-backend batched
+  MultiGet if draining them into the batch throws partway through.
 
 ### Correctness
 
@@ -78,6 +100,20 @@ a minor version bump.
   `HAVE_CONFIG_H`, so every `#if HAVE_*` was 0 and the NEON/SSSE3
   `IncrementalCopy`, `__builtin_expect`, `__builtin_ctz` and
   `__builtin_prefetch` were all disabled. snappy is a default feature.
+  `SNAPPY_HAVE_SSSE3` now carries `-mssse3` with it. Defining it alone
+  made `snappy-internal.h` call `_mm_shuffle_epi8` from a function
+  compiled without the ISA, which is a compile error, not a slow path, so
+  x86_64 builds with `-Ctarget-cpu=native` (or `haswell`, or
+  `x86-64-v2` and newer) failed. The snappy build has its own
+  `cc::Build` and never went through `apply_x86`, so nothing else
+  supplied the flag. `SNAPPY_HAVE_NEON` is now gated on the `neon`
+  target feature rather than on the architecture, for the few aarch64
+  targets that build without SIMD.
+- perf: pass `-msse4.2` and `-mbmi2` to the vendored snappy build when
+  the target has them. snappy derives `SNAPPY_HAVE_X86_CRC32` and
+  `SNAPPY_HAVE_BMI2` from `__SSE4_2__`/`__BMI2__`, and nothing was
+  passing the flags that define those, so the CRC32 compressor hash and
+  `_bzhi_u32` were off on every x86 build.
 - perf: pass `-fno-builtin-memcmp` on non-MSVC, as upstream does, so key
   comparisons use glibc's SIMD `memcmp` rather than GCC's inline
   expansion.
@@ -91,6 +127,15 @@ a minor version bump.
   whole `perf` API silently returned zeros. Upstream defaults both on.
 - fix: define `ROCKSDB_AUXV_GETAUXVAL_PRESENT` on Android, without which
   the aarch64 CRC32 runtime check always fails.
+- fix: define `NDEBUG` when compiling `c_api_extensions.cc` for the
+  System backend, and give it the same dev-profile defaults as the rest
+  of the native build. One source file was getting two different
+  `assert` and `rocksdb/slice.h` inline-function semantics depending on
+  which backend built it, against a prebuilt librocksdb that was itself
+  built with `NDEBUG`.
+- fix: allow `ROCKSDB_COMPILE=1` on FreeBSD instead of rejecting it up
+  front, and skip jemalloc there. This reverses the FreeBSD note in
+  0.51.0.
 
 ### Performance
 
@@ -107,6 +152,9 @@ a minor version bump.
   `TransactionDB::transaction` and
   `OptimisticTransactionDB::transaction`, which each built a fresh C++
   options object per call.
+- perf: `multi_get_pinned{,_opt}` no longer collects the keys before
+  deciding whether the batch is worth it. A single key was paying for a
+  key vector on top of the point lookup it falls back to.
 - perf: `#[inline]` on the non-generic accessors a downstream crate
   can't inline without LTO: `AsColumnFamilyRef::inner`, `DBInner::inner`,
   the `DBPinnableSlice`/`DBPinnableBatch` accessors, `MergeOperands` and
@@ -123,8 +171,11 @@ a minor version bump.
 - feat: expose `open_files_async`, cache occupancy metrics, and detailed
   write buffer manager memory accounting.
 - fix: align `PerfStatsLevel` values and RTTI build flags with RocksDB
-  11.1.2, and prevent transaction-backed snapshots from being shared
-  across threads.
+  11.1.2. The enum was missing `EnableWait`, so every level above it was
+  off by one and RocksDB was given a different level than the caller
+  asked for. Callers now get the level they named, which for
+  `EnableTimeAndCPUTimeExceptForMutex` means the per-operation CPU-time
+  clock reads it always implied.
 
 ### Features
 

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1164,8 +1164,38 @@ mod snappy {
         true
     }
 
+    /// Enable an instruction set for the snappy build, and optionally the
+    /// macro that selects the code using it.
+    ///
+    /// `define` is `None` where snappy derives the macro from a compiler
+    /// predefine on its own, so only the flag is needed.
+    ///
+    /// If the compiler rejects the flag, neither the flag nor the macro is
+    /// applied and snappy keeps its portable path. Setting the macro anyway
+    /// would break the build rather than slow it down.
+    ///
+    /// MSVC gets the macro with no flag: `cl.exe` exposes every intrinsic
+    /// regardless of `/arch:` and has no `-m` options. It also reports unknown
+    /// options as a D9002 *warning* and exits 0, so `is_flag_supported` cannot
+    /// tell an accepted flag from an ignored one there. Same reasoning as
+    /// `arm_crc32c_sources`.
+    fn enable_isa(cfg: &mut cc::Build, target: &Target, flag: &str, define: Option<&str>) {
+        if !target.is_msvc() {
+            if !cfg.is_flag_supported(flag).unwrap_or(false) {
+                return;
+            }
+            cfg.flag(flag);
+        }
+        if let Some(define) = define {
+            cfg.define(define, Some("1"));
+        }
+    }
+
     fn build_vendored(target: &Target) {
         let mut cfg = cc::Build::new();
+        // Set before any `enable_isa` call: `is_flag_supported` probes with a
+        // `.cpp` or `.c` file depending on this, and snappy is C++.
+        cfg.cpp(true);
         cfg.include("snappy/")
             .include(".")
             .define("NDEBUG", Some("1"))
@@ -1199,16 +1229,33 @@ mod snappy {
             cfg.define("HAVE_BUILTIN_PREFETCH", Some("1"));
         }
         // SNAPPY_HAVE_{SSSE3,NEON} drive SNAPPY_HAVE_VECTOR_BYTE_SHUFFLE, which
-        // selects the vectorized pattern copy in `IncrementalCopy` — the hottest
-        // loop in snappy decompression. NEON is architecturally guaranteed on
-        // aarch64, so it was being left on the table even on Apple Silicon.
-        // (SNAPPY_HAVE_BMI2 and SNAPPY_HAVE_X86_CRC32 need no help: snappy.cc
-        // derives those from __BMI2__/__SSE4_2__ itself.)
-        if target.arch == "aarch64" {
+        // selects the vectorized pattern copy in `IncrementalCopy`.
+        //
+        // A `SNAPPY_HAVE_*` macro is not an optimization hint. Setting one
+        // makes `snappy-internal.h` call the matching intrinsic from a plain
+        // inline function, so the ISA has to be enabled on the command line or
+        // the translation unit fails to compile. NEON is the exception: it is
+        // mandatory in AArch64, so the baseline already provides it.
+        //
+        // This build has its own `cc::Build` and never runs through
+        // `apply_x86`/`apply_target_cpu`, so nothing else here will supply the
+        // flag.
+        if target.has_feature("neon") {
             cfg.define("SNAPPY_HAVE_NEON", Some("1"));
         }
         if target.has_feature("ssse3") {
-            cfg.define("SNAPPY_HAVE_SSSE3", Some("1"));
+            enable_isa(&mut cfg, target, "-mssse3", Some("SNAPPY_HAVE_SSSE3"));
+        }
+        // snappy.cc derives SNAPPY_HAVE_X86_CRC32 and SNAPPY_HAVE_BMI2 from
+        // __SSE4_2__ and __BMI2__ itself, so these need the flag and no macro.
+        // Without the flag the compiler never defines either predefine, which
+        // left the CRC32 compressor hash and `_bzhi_u32` off on every x86
+        // build regardless of what the user asked for.
+        if target.has_feature("sse4.2") {
+            enable_isa(&mut cfg, target, "-msse4.2", None);
+        }
+        if target.has_feature("bmi2") {
+            enable_isa(&mut cfg, target, "-mbmi2", None);
         }
 
         for src in [
@@ -1219,7 +1266,6 @@ mod snappy {
             cfg.file(src);
         }
         apply_native_dev_defaults(&mut cfg);
-        cfg.cpp(true);
         cfg.compile("libsnappy.a");
     }
 }
@@ -1654,6 +1700,13 @@ mod extensions {
 
         cfg.file("c-api-extensions/c_api_extensions.cc");
         cfg.define("RUST_ROCKSDB_SYSTEM_BACKEND", None);
+        // `base_cfg` defines this for the vendored build, where the same
+        // source file is compiled into librocksdb.a. Without it here, one
+        // source file gets two different `assert` and `rocksdb/slice.h`
+        // inline-function semantics depending on which backend built it, and
+        // the prebuilt system librocksdb this links against was itself almost
+        // certainly built with NDEBUG.
+        cfg.define("NDEBUG", Some("1"));
         cfg.cpp(true);
         if target.is_msvc() && cfg!(feature = "mt_static") {
             cfg.static_crt(true);
@@ -1672,6 +1725,7 @@ mod extensions {
             cfg.flag("-include").flag("cstdint");
         }
 
+        apply_native_dev_defaults(&mut cfg);
         cfg.compile("rust_rocksdb_c_api_extensions");
     }
 }

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.cc
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.cc
@@ -54,17 +54,37 @@ struct rust_rocksdb_background_error_recovery_info_t {
   const BackgroundErrorRecoveryInfo* rep;
 };
 
+// Copy a message into a `malloc` block, which is what the Rust side releases
+// it with (`rocksdb_free` is plain `free`).
+//
+// Falls back to a short fixed string if the copy does not fit. Rust reads a
+// null `errptr` as success, so losing the allocation must not be allowed to
+// turn a failed operation into a silent one. A truncated reason is recoverable;
+// a missing error is not.
+static char* RustDupMessage(const char* message, size_t len) {
+  char* copy = static_cast<char*>(std::malloc(len + 1));
+  if (copy != nullptr) {
+    std::memcpy(copy, message, len);
+    copy[len] = '\0';
+    return copy;
+  }
+
+  static const char kFallback[] = "out of memory while formatting error";
+  copy = static_cast<char*>(std::malloc(sizeof(kFallback)));
+  if (copy != nullptr) {
+    std::memcpy(copy, kFallback, sizeof(kFallback));
+  }
+  return copy;
+}
+
 static bool RustSaveError(char** errptr, const Status& s) {
   assert(errptr != nullptr);
   if (s.ok()) {
     return false;
   }
 
-  std::string message = s.ToString();
-  char* copy = static_cast<char*>(std::malloc(message.size() + 1));
-  if (copy != nullptr) {
-    std::memcpy(copy, message.c_str(), message.size() + 1);
-  }
+  const std::string message = s.ToString();
+  char* copy = RustDupMessage(message.data(), message.size());
 
   if (*errptr != nullptr) {
     std::free(*errptr);
@@ -75,7 +95,8 @@ static bool RustSaveError(char** errptr, const Status& s) {
 
 static void RustSaveMessage(char** errptr, const char* message) {
   assert(errptr != nullptr);
-  char* copy = message == nullptr ? nullptr : strdup(message);
+  char* copy =
+      message == nullptr ? nullptr : RustDupMessage(message, std::strlen(message));
   if (*errptr != nullptr) {
     std::free(*errptr);
   }
@@ -463,6 +484,22 @@ rust_rocksdb_batched_multi_get_pinned(
 #ifdef RUST_ROCKSDB_SYSTEM_BACKEND
     batch->system_values.resize(num_keys, nullptr);
     std::vector<char*> errors(num_keys, nullptr);
+    // Releases every per-key error string still held in `errors`, including
+    // when the drain loop below throws partway through. Destroying the vector
+    // only reclaims the array, not the strings it points at. The loop clears
+    // each slot as it takes ownership, so nothing is freed twice.
+    struct ErrorArrayGuard {
+      std::vector<char*>& errors;
+      ~ErrorArrayGuard() {
+        for (auto*& error : errors) {
+          if (error != nullptr) {
+            rocksdb_free(error);
+            error = nullptr;
+          }
+        }
+      }
+    } error_guard{errors};
+
     using ColumnFamilyHandlePtr =
         std::unique_ptr<rocksdb_column_family_handle_t,
                         decltype(&rocksdb_column_family_handle_destroy)>;
@@ -472,22 +509,14 @@ rust_rocksdb_batched_multi_get_pinned(
       owned_default.reset(rocksdb_get_default_column_family_handle(db));
       column_family = owned_default.get();
     }
-    try {
-      rocksdb_batched_multi_get_cf_slice(
-          db, options, column_family, num_keys, keys,
-          batch->system_values.data(), errors.data(), sorted_input != 0);
-    } catch (...) {
-      for (auto* error : errors) {
-        if (error != nullptr) {
-          rocksdb_free(error);
-        }
-      }
-      throw;
-    }
+    rocksdb_batched_multi_get_cf_slice(
+        db, options, column_family, num_keys, keys,
+        batch->system_values.data(), errors.data(), sorted_input != 0);
     for (size_t i = 0; i < num_keys; ++i) {
       if (errors[i] != nullptr) {
         batch->errors.emplace(i, errors[i]);
         rocksdb_free(errors[i]);
+        errors[i] = nullptr;
       }
     }
 #else
@@ -553,8 +582,14 @@ extern "C" unsigned char rust_rocksdb_pinnable_batch_get(
   *error = nullptr;
   *error_len = 0;
 
+  // Bounds are checked here rather than asserted. The vendored build defines
+  // NDEBUG, so an assert would compile away and leave an unchecked
+  // `std::vector::operator[]` feeding a pointer and length straight into
+  // `slice::from_raw_parts` on the Rust side.
 #ifdef RUST_ROCKSDB_SYSTEM_BACKEND
-  assert(index < batch->system_values.size());
+  if (index >= batch->system_values.size()) {
+    return rust_rocksdb_pinnable_batch_out_of_range;
+  }
   const auto error_iter = batch->errors.find(index);
   if (error_iter != batch->errors.end()) {
     *error = error_iter->second.data();
@@ -568,17 +603,24 @@ extern "C" unsigned char rust_rocksdb_pinnable_batch_get(
       rocksdb_pinnableslice_value(batch->system_values[index], value_len);
   return rust_rocksdb_pinnable_batch_found;
 #else
-  assert(index < batch->result_indexes.size());
+  if (index >= batch->result_indexes.size()) {
+    return rust_rocksdb_pinnable_batch_out_of_range;
+  }
   const size_t result_index = batch->result_indexes[index];
   if (result_index == kRustRocksDbBatchNotFound) {
     return rust_rocksdb_pinnable_batch_not_found;
   }
   if (result_index == kRustRocksDbBatchError) {
     const auto error_iter = batch->errors.find(index);
-    assert(error_iter != batch->errors.end());
+    if (error_iter == batch->errors.end()) {
+      return rust_rocksdb_pinnable_batch_out_of_range;
+    }
     *error = error_iter->second.data();
     *error_len = error_iter->second.size();
     return rust_rocksdb_pinnable_batch_error;
+  }
+  if (result_index >= batch->values.size()) {
+    return rust_rocksdb_pinnable_batch_out_of_range;
   }
 
   *value = batch->values[result_index].data();

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.h
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.h
@@ -109,27 +109,45 @@ enum {
   rust_rocksdb_pinnable_batch_not_found = 0,
   rust_rocksdb_pinnable_batch_found = 1,
   rust_rocksdb_pinnable_batch_error = 2,
+  /* index outside the batch, or a batch whose internal state does not agree
+     with itself. No out-params are written. */
+  rust_rocksdb_pinnable_batch_out_of_range = 3,
 };
 
+/* A null `column_family` selects the default column family. */
 extern ROCKSDB_LIBRARY_API rust_rocksdb_pinnable_batch_t*
 rust_rocksdb_batched_multi_get_pinned(
-    rocksdb_t*, const rocksdb_readoptions_t*,
-    rocksdb_column_family_handle_t*, size_t, const rocksdb_slice_t*,
-    unsigned char, char**);
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, size_t num_keys,
+    const rocksdb_slice_t* keys, unsigned char sorted_input, char** errptr);
 extern ROCKSDB_LIBRARY_API size_t rust_rocksdb_pinnable_batch_len(
-    const rust_rocksdb_pinnable_batch_t*);
+    const rust_rocksdb_pinnable_batch_t* batch);
+/* `value` and `error` are borrowed from `batch` and dangle once it is
+   destroyed. Do not free them. */
 extern ROCKSDB_LIBRARY_API unsigned char rust_rocksdb_pinnable_batch_get(
-    const rust_rocksdb_pinnable_batch_t*, size_t, const char**, size_t*,
-    const char**, size_t*);
+    const rust_rocksdb_pinnable_batch_t* batch, size_t index,
+    const char** value, size_t* value_len, const char** error,
+    size_t* error_len);
 extern ROCKSDB_LIBRARY_API void rust_rocksdb_pinnable_batch_destroy(
-    rust_rocksdb_pinnable_batch_t*);
+    rust_rocksdb_pinnable_batch_t* batch);
+/* `column_family` must not be null, unlike
+   `rust_rocksdb_batched_multi_get_pinned` above.
+   The caller owns and must release: each non-null `values[i]` with
+   `rocksdb_pinnableslice_destroy`, each non-null per-key `errors[i]` with
+   `rocksdb_free`, and `*errptr` with `rocksdb_free`. */
 extern ROCKSDB_LIBRARY_API void rust_rocksdb_batched_multi_get_cf_slice_safe(
-    rocksdb_t*, const rocksdb_readoptions_t*,
-    rocksdb_column_family_handle_t*, size_t, const rocksdb_slice_t*,
-    rocksdb_pinnableslice_t**, char**, unsigned char, char**);
+    rocksdb_t* db, const rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t* column_family, size_t num_keys,
+    const rocksdb_slice_t* keys, rocksdb_pinnableslice_t** values,
+    char** errors, unsigned char sorted_input, char** errptr);
+/* On success the caller owns every `iterators[i]` and must release it with
+   `rocksdb_iter_destroy`. On failure no iterator is returned and `*errptr` is
+   set. `options` must outlive the returned iterators: RocksDB keeps raw
+   pointers to its iterate bounds and timestamps. */
 extern ROCKSDB_LIBRARY_API void rust_rocksdb_create_iterators_safe(
-    rocksdb_t*, rocksdb_readoptions_t*, rocksdb_column_family_handle_t**,
-    rocksdb_iterator_t**, size_t, char**);
+    rocksdb_t* db, rocksdb_readoptions_t* options,
+    rocksdb_column_family_handle_t** column_families,
+    rocksdb_iterator_t** iterators, size_t size, char** errptr);
 
 /* -------------------------------------------------------------------------
  * Slice-based vectored WriteBatch operations

--- a/src/db.rs
+++ b/src/db.rs
@@ -462,7 +462,11 @@ struct PinnedMultiGetOutput {
     errors: Vec<*mut c_char>,
 }
 
+/// The result of one `rocksdb_create_iterators` call: the iterator handles
+/// plus the single `ReadOptions` they were all created from, which each
+/// iterator must keep alive.
 struct CreatedIterators {
+    readopts: Arc<ReadOptions>,
     handles: Vec<*mut ffi::rocksdb_iterator_t>,
 }
 
@@ -1632,10 +1636,20 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         K: AsRef<[u8]>,
         I: IntoIterator<Item = K>,
     {
-        let owned_keys: Vec<K> = keys.into_iter().collect();
-        if owned_keys.len() == 1 {
-            return vec![self.get_pinned_opt(owned_keys[0].as_ref(), readopts)];
-        }
+        let mut keys = keys.into_iter();
+        let Some(first) = keys.next() else {
+            return Vec::new();
+        };
+        // Decide before collecting. A single key does not benefit from the
+        // native batch, and buying a key-slice vector, two result vectors and
+        // a default column family handle to do one point lookup is a loss.
+        let Some(second) = keys.next() else {
+            return vec![self.get_pinned_opt(first.as_ref(), readopts)];
+        };
+        let mut owned_keys = Vec::with_capacity(2 + keys.size_hint().0);
+        owned_keys.push(first);
+        owned_keys.push(second);
+        owned_keys.extend(keys);
         self.batched_multi_get_pinned_owned(&owned_keys, false, readopts)
     }
 
@@ -2056,6 +2070,14 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
                 c_uchar::from(sorted_input),
             ))
         };
+        if batch.is_null() {
+            // `ffi_try!` only returns early when the extension set `errptr`.
+            // A null batch with no error means the extension could not even
+            // allocate the message, so report it instead of unwrapping.
+            return Err(Error::new(
+                "rust_rocksdb_batched_multi_get_pinned returned no batch".to_owned(),
+            ));
+        }
         // SAFETY: The extension returns a uniquely owned batch.
         Ok(unsafe { DBPinnableBatch::from_c(batch) })
     }
@@ -2526,9 +2548,9 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
     /// RocksDB state.
     ///
     /// The returned iterators match the input column family order and own their
-    /// native handles. This method uses default read options because one native
-    /// `rocksdb_create_iterators` call shares its options across every iterator,
-    /// while custom bounds and timestamps require one shared Rust owner.
+    /// native handles. They share one `ReadOptions`, because one native
+    /// `rocksdb_create_iterators` call applies a single options object to every
+    /// iterator it creates.
     pub fn raw_iterators_cf<'a, 'b, W, I>(
         &'a self,
         column_families: I,
@@ -2548,7 +2570,9 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         Ok(created
             .handles
             .into_iter()
-            .map(DBRawIteratorWithThreadMode::from_inner_without_readopts)
+            .map(|handle| {
+                DBRawIteratorWithThreadMode::from_inner(handle, Arc::clone(&created.readopts))
+            })
             .collect())
     }
 
@@ -2557,7 +2581,12 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         cf_handles: &mut [*mut ffi::rocksdb_column_family_handle_t],
     ) -> Result<CreatedIterators, Error> {
         let mut iterator_handles = vec![ptr::null_mut(); cf_handles.len()];
-        let readopts = ReadOptions::default();
+        // Every iterator gets a handle on this. RocksDB's `DBIter` stores raw
+        // `Slice*` into the options for iterate_lower_bound, iterate_upper_bound
+        // and the read timestamps, and `ArenaWrappedDBIter::Refresh` re-reads
+        // them, so the options have to outlive the last iterator rather than
+        // this function. See issue #660.
+        let readopts = Arc::new(ReadOptions::default());
         unsafe {
             ffi_try!(ffi::rust_rocksdb_create_iterators_safe(
                 self.inner.inner(),
@@ -2569,6 +2598,7 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         }
         Self::validate_created_iterators(&iterator_handles)?;
         Ok(CreatedIterators {
+            readopts,
             handles: iterator_handles,
         })
     }
@@ -3762,10 +3792,15 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
     ///
     /// Deliberately does not take ownership of the handle. Callers must take
     /// the handle out of their map first, so that only one caller can ever
-    /// reach a given handle, and must put it back if this fails: destroying it
-    /// on failure would leave the column family still present in the DB with no
-    /// reachable handle, so the only way to touch it again would be to reopen
-    /// the database.
+    /// *destroy* a given handle, and must put it back if this fails: destroying
+    /// it on failure would leave the column family still present in the DB with
+    /// no reachable handle, so the only way to touch it again would be to
+    /// reopen the database.
+    ///
+    /// Taking it out of the map does not make the caller the only *reader*. In
+    /// `MultiThreaded` mode `cf_handle` clones the same `Arc`, so other threads
+    /// can still hold a live `BoundColumnFamily` for this handle. That is fine:
+    /// the refcount keeps the handle alive until the last of them is gone.
     fn mark_column_family_dropped(
         &self,
         cf_inner: *mut ffi::rocksdb_column_family_handle_t,
@@ -3880,8 +3915,10 @@ impl<I: DBInner> DBCommon<SingleThreaded, I> {
             return Err(Error::new(format!("Invalid column family: {name}")));
         };
         match self.mark_column_family_dropped(cf.inner) {
-            // `cf` is dropped here, which destroys the handle and reclaims the
-            // memory and files behind it.
+            // `cf` is dropped here. In single-threaded mode that destroys the
+            // handle; in `MultiThreaded` mode it drops one `Arc` reference and
+            // the handle is destroyed once the last `BoundColumnFamily` clone
+            // handed out by `cf_handle` is gone.
             Ok(()) => Ok(()),
             Err(e) => {
                 // The column family is still there, so put the handle back
@@ -3963,8 +4000,10 @@ impl<I: DBInner> DBCommon<MultiThreaded, I> {
             return Err(Error::new(format!("Invalid column family: {name}")));
         };
         match self.mark_column_family_dropped(cf.inner) {
-            // `cf` is dropped here, which destroys the handle and reclaims the
-            // memory and files behind it.
+            // `cf` is dropped here. In single-threaded mode that destroys the
+            // handle; in `MultiThreaded` mode it drops one `Arc` reference and
+            // the handle is destroyed once the last `BoundColumnFamily` clone
+            // handed out by `cf_handle` is gone.
             Ok(()) => Ok(()),
             Err(e) => {
                 // The column family is still there, so put the handle back
@@ -4306,4 +4345,51 @@ pub(crate) fn convert_values(
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{ColumnFamilyDescriptor, DB, Options};
+
+    /// One `rocksdb_create_iterators` call applies a single `ReadOptions` to
+    /// every iterator it builds, and RocksDB's `DBIter` keeps raw `Slice*`
+    /// into that object for the iterate bounds and read timestamps. So all the
+    /// returned iterators have to keep the *same* options object alive, not a
+    /// copy each and not none at all. Dropping it at the end of
+    /// `create_iterators_cf` left those pointers dangling. See issue #660.
+    #[test]
+    fn raw_iterators_cf_share_one_live_readopts() {
+        let dir = tempfile::Builder::new()
+            .prefix("rocksdb-raw-iterators-cf-readopts")
+            .tempdir()
+            .unwrap();
+
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        opts.create_missing_column_families(true);
+        let db = DB::open_cf_descriptors(
+            &opts,
+            dir.path(),
+            [
+                ColumnFamilyDescriptor::new("first", Options::default()),
+                ColumnFamilyDescriptor::new("second", Options::default()),
+            ],
+        )
+        .unwrap();
+
+        let first = db.cf_handle("first").unwrap();
+        let second = db.cf_handle("second").unwrap();
+        let iterators = db.raw_iterators_cf([&first, &second]).unwrap();
+        assert_eq!(iterators.len(), 2);
+
+        let shared = iterators[0].readopts_ptr();
+        assert!(!shared.is_null());
+        for iterator in &iterators {
+            assert_eq!(
+                iterator.readopts_ptr(),
+                shared,
+                "each iterator must hold the options object it was created from"
+            );
+        }
+    }
 }

--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -19,10 +19,43 @@ use crate::{
 };
 use libc::{c_char, c_uchar, size_t};
 use std::mem::ManuallyDrop;
+use std::sync::Arc;
 use std::{marker::PhantomData, ops::ControlFlow, slice};
 
 /// A type alias to keep compatibility. See [`DBRawIteratorWithThreadMode`] for details
 pub type DBRawIterator<'a> = DBRawIteratorWithThreadMode<'a, DB>;
+
+/// Keeps an iterator's [`ReadOptions`] alive for as long as the iterator is.
+///
+/// `rocksdb_create_iterators` builds N iterators from one options object, so
+/// that case needs a shared owner. Every other constructor makes one iterator
+/// from one options object and keeps it outright, which costs nothing.
+pub(crate) enum IterReadOptions {
+    Owned(ReadOptions),
+    Shared(Arc<ReadOptions>),
+}
+
+impl IterReadOptions {
+    #[inline]
+    pub(crate) fn as_ptr(&self) -> *mut ffi::rocksdb_readoptions_t {
+        match self {
+            Self::Owned(readopts) => readopts.inner,
+            Self::Shared(readopts) => readopts.inner,
+        }
+    }
+}
+
+impl From<ReadOptions> for IterReadOptions {
+    fn from(readopts: ReadOptions) -> Self {
+        Self::Owned(readopts)
+    }
+}
+
+impl From<Arc<ReadOptions>> for IterReadOptions {
+    fn from(readopts: Arc<ReadOptions>) -> Self {
+        Self::Shared(readopts)
+    }
+}
 
 /// A low-level iterator over a database or column family, created by [`DB::raw_iterator`]
 /// and other `raw_iterator_*` methods.
@@ -86,7 +119,10 @@ pub struct DBRawIteratorWithThreadMode<'a, D: DBAccess> {
     /// And yes, we need to store the entire ReadOptions structure since C++
     /// ReadOptions keep reference to C rocksdb_readoptions_t wrapper which
     /// point to vectors we own.  See issue #660.
-    readopts: Option<ReadOptions>,
+    ///
+    /// This is deliberately not an `Option`. An iterator without its options
+    /// is the bug in issue #660, so the type does not let one be built.
+    readopts: IterReadOptions,
 
     db: PhantomData<&'a D>,
 }
@@ -106,7 +142,10 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
         Self::from_inner(inner, readopts)
     }
 
-    pub(crate) fn from_inner(inner: *mut ffi::rocksdb_iterator_t, readopts: ReadOptions) -> Self {
+    pub(crate) fn from_inner(
+        inner: *mut ffi::rocksdb_iterator_t,
+        readopts: impl Into<IterReadOptions>,
+    ) -> Self {
         // This unwrap will never fail since rocksdb_create_iterator and
         // rocksdb_create_iterator_cf functions always return non-null. They
         // use new and deference the result so any nulls would end up with SIGSEGV
@@ -114,27 +153,27 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
         let inner = std::ptr::NonNull::new(inner).unwrap();
         Self {
             inner,
-            readopts: Some(readopts),
+            readopts: readopts.into(),
             db: PhantomData,
         }
     }
 
-    pub(crate) fn from_inner_without_readopts(inner: *mut ffi::rocksdb_iterator_t) -> Self {
-        let inner = std::ptr::NonNull::new(inner).expect("RocksDB returned a null iterator");
-        Self {
-            inner,
-            readopts: None,
-            db: PhantomData,
-        }
-    }
-
-    pub(crate) fn into_inner(self) -> (std::ptr::NonNull<ffi::rocksdb_iterator_t>, ReadOptions) {
+    pub(crate) fn into_inner(
+        self,
+    ) -> (std::ptr::NonNull<ffi::rocksdb_iterator_t>, IterReadOptions) {
         let value = ManuallyDrop::new(self);
         // SAFETY: value won't be used beyond this point
         let inner = unsafe { std::ptr::read(&raw const value.inner) };
-        let readopts = unsafe { std::ptr::read(&raw const value.readopts) }.unwrap_or_default();
+        let readopts = unsafe { std::ptr::read(&raw const value.readopts) };
 
         (inner, readopts)
+    }
+
+    /// The options object this iterator was created from, for tests that need
+    /// to assert which iterators share one owner.
+    #[cfg(test)]
+    pub(crate) fn readopts_ptr(&self) -> *mut ffi::rocksdb_readoptions_t {
+        self.readopts.as_ptr()
     }
 
     /// Returns `true` if the iterator is valid. An iterator is invalidated when

--- a/src/db_pinnable_batch.rs
+++ b/src/db_pinnable_batch.rs
@@ -81,7 +81,14 @@ impl<'db> DBPinnableBatch<'db> {
                 };
                 Err(Error::new(message))
             }
-            unexpected => unreachable!("unexpected pinned batch result state {unexpected}"),
+            // `index` is bounds-checked above, so neither the out-of-range
+            // state nor an unknown one is reachable against a matching
+            // `librocksdb-sys`. Report them rather than panicking: a System
+            // backend built against a skewed extension should not be able to
+            // abort the process from a safe method.
+            unexpected => Err(Error::new(format!(
+                "unexpected pinned batch result state {unexpected} at index {index}"
+            ))),
         })
     }
 

--- a/src/transactions/transaction_db.rs
+++ b/src/transactions/transaction_db.rs
@@ -1073,9 +1073,12 @@ impl<T: ThreadMode> TransactionDB<T> {
     ///
     /// Deliberately does not take ownership of the handle. Callers must take
     /// the handle out of their map first, so that only one caller can ever
-    /// reach a given handle, and must put it back if this fails: destroying it
-    /// on failure would leave the column family still present in the DB with no
-    /// reachable handle.
+    /// *destroy* a given handle, and must put it back if this fails: destroying
+    /// it on failure would leave the column family still present in the DB with
+    /// no reachable handle.
+    ///
+    /// Other threads can still be holding a live `BoundColumnFamily` clone for
+    /// this handle; the `Arc` refcount keeps it alive until the last one drops.
     fn mark_column_family_dropped(
         &self,
         cf_inner: *mut ffi::rocksdb_column_family_handle_t,
@@ -1111,8 +1114,10 @@ impl TransactionDB<SingleThreaded> {
             return Err(Error::new(format!("Invalid column family: {name}")));
         };
         match self.mark_column_family_dropped(cf.inner) {
-            // `cf` is dropped here, which destroys the handle and reclaims the
-            // memory and files behind it.
+            // `cf` is dropped here. In single-threaded mode that destroys the
+            // handle; in `MultiThreaded` mode it drops one `Arc` reference and
+            // the handle is destroyed once the last `BoundColumnFamily` clone
+            // handed out by `cf_handle` is gone.
             Ok(()) => Ok(()),
             Err(e) => {
                 // The column family is still there, so put the handle back
@@ -1160,8 +1165,10 @@ impl TransactionDB<MultiThreaded> {
             return Err(Error::new(format!("Invalid column family: {name}")));
         };
         match self.mark_column_family_dropped(cf.inner) {
-            // `cf` is dropped here, which destroys the handle and reclaims the
-            // memory and files behind it.
+            // `cf` is dropped here. In single-threaded mode that destroys the
+            // handle; in `MultiThreaded` mode it drops one `Arc` reference and
+            // the handle is destroyed once the last `BoundColumnFamily` clone
+            // handed out by `cf_handle` is gone.
             Ok(()) => Ok(()),
             Err(e) => {
                 // The column family is still there, so put the handle back

--- a/src/write_batch.rs
+++ b/src/write_batch.rs
@@ -661,7 +661,11 @@ impl WriteBatchWithTransaction<false> {
 
     /// Removes entries in a range whose bounds are assembled from byte slices.
     ///
-    /// The range includes `from` and excludes `to`. The two bounds must have
+    /// The range includes `from` and excludes `to`. Both bounds must be split
+    /// into the same number of parts: the System backend forwards them to
+    /// `rocksdb_writebatch_delete_rangev`, which takes one part count for the
+    /// pair. Split them differently and this returns an error.
+    ///
     /// RocksDB copies both bounds into the write batch during this call, so the
     /// slices do not need to outlive the method.
     pub fn delete_range_vectored(
@@ -712,7 +716,10 @@ impl WriteBatchWithTransaction<false> {
 
     /// Removes entries in a column family range whose bounds are assembled from byte slices.
     ///
-    /// The range includes `from` and excludes `to`. The two bounds must have
+    /// The range includes `from` and excludes `to`, and both bounds must be
+    /// split into the same number of parts. See
+    /// [`delete_range_vectored`](Self::delete_range_vectored).
+    ///
     /// RocksDB copies both bounds into the write batch during this call, so the
     /// slices do not need to outlive the method.
     pub fn delete_range_cf_vectored(

--- a/src/write_batch_with_index.rs
+++ b/src/write_batch_with_index.rs
@@ -419,10 +419,13 @@ impl WriteBatchWithIndex {
             ffi::rocksdb_writebatch_wi_create_iterator_with_base_readopts(
                 self.inner,
                 base_iterator_inner.as_ptr(),
-                readopts.inner,
+                readopts.as_ptr(),
             )
         };
 
+        // The delta iterator keeps its own raw pointers to the iterate bounds
+        // in these options, so it has to hold the same object the base
+        // iterator was built from, not an equivalent copy.
         DBRawIteratorWithThreadMode::from_inner(iterator, readopts)
     }
 
@@ -443,7 +446,7 @@ impl WriteBatchWithIndex {
                 self.inner,
                 base_iterator_inner.as_ptr(),
                 cf.inner(),
-                readopts.inner,
+                readopts.as_ptr(),
             )
         };
 


### PR DESCRIPTION
Follow-up review of everything landed since 0.51.0 (`db45d898..a91863d9`). Six real problems, one of which breaks the build.

## Snappy fails to compile on tuned x86_64

#253 started defining `SNAPPY_HAVE_SSSE3` from the rust target feature, but the snappy build has its own `cc::Build` and never goes through `apply_x86`, so nothing passed `-mssse3`. `snappy-internal.h` calls `_mm_shuffle_epi8` from a plain inline function, so the define alone is a hard compile error rather than a slow path:

```
snappy-internal.h:89: error: always_inline function '_mm_shuffle_epi8' requires target feature 'ssse3'
```

CI never saw it because stock `x86_64-unknown-linux-gnu` reports only `fxsr,sse,sse2`, and `x86_64-apple-darwin` has SSSE3 in the compiler baseline. `x86_64` Linux with `-Ctarget-cpu=native` (or `haswell`, or `x86-64-v2` and up) does not. `snappy` is a default feature, so this is the default build for anyone tuning their target.

The flag now travels with the define, gated on the compiler accepting it. Same wiring for `-msse4.2` and `-mbmi2`, which snappy derives `SNAPPY_HAVE_X86_CRC32` and `SNAPPY_HAVE_BMI2` from and which nothing was passing, so the CRC32 hash and `_bzhi_u32` were off on every x86 build. `SNAPPY_HAVE_NEON` is now gated on the target actually having neon instead of on the arch.

The comment claiming BMI2 and CRC32 were already handled was wrong and is gone.

## raw_iterators_cf dropped the ReadOptions its iterators point into

`create_iterators_cf` built one `ReadOptions`, handed all N iterators to `from_inner_without_readopts`, and let it drop at end of scope. RocksDB retains that memory: `rocksdb_create_iterators` stores the bounds as inline `Slice`s in the options object, `DBIter` keeps `const Slice*` to them, and `ArenaWrappedDBIter::Refresh` re-reads them.

Not reachable today, because the only caller passes default options and those pointers are null. The first caller to set an iterate bound would have read freed memory.

The iterators from one call now share the options through an `Arc`, `readopts` stops being an `Option`, and `from_inner_without_readopts` is deleted, so an iterator without its options can no longer be constructed. That also removes `into_inner`'s `unwrap_or_default()`, which was handing the write-batch delta iterator a freshly allocated options object rather than the one its base iterator was built from.

## pinnable_batch_get asserted instead of bounds-checking

`build.rs` defines `NDEBUG` for the vendored build, so the two `assert()`s guarding the index compiled away, leaving an unchecked `std::vector` index feeding a pointer and length into `slice::from_raw_parts`. Now returns a new `rust_rocksdb_pinnable_batch_out_of_range` state.

The System backend never defined `NDEBUG`, so the same source file had two different assert semantics and two different sets of dev-build optimizations depending on backend. It now gets both.

## C extension reported failure as success on allocation failure

`RustSaveError`/`RustSaveMessage` left `errptr` null if `strdup` returned null, and Rust reads a null `errptr` as success, so a failed operation looked like it succeeded. Now falls back to a short static message.

Also: the System-backend batched MultiGet leaked every remaining per-key error string if draining them threw partway through (now RAII), and `create_pinnable_batch` null-checks instead of unwrapping.

## The AddressSanitizer job tested almost nothing

It ran `--lib --bins`, which skips `tests/` where nearly all the FFI coverage lives, and never instrumented the C++, so an overflow performed inside RocksDB or the extension had no instrumented load to trip on. Now runs the integration tests and passes `-fsanitize=address` through to the `cc` build.

LeakSanitizer stays off. It is the tool that would catch a leak in this crate's FFI layer, but RocksDB holds process-lifetime singletons and background threads that it reports at exit, so enabling it needs a suppression list built from an actual CI run. **This is the one hunk I could not verify locally** (no Linux/nightly ASan here), happy to split it out.

## multi_get_pinned allocated before deciding it would not batch

Keys were collected into a `Vec` before the `n == 1` check that falls back to a plain point lookup. Now short-circuits `n == 0` and `n == 1` first, and sizes the vector from `size_hint()`.

## Docs, comments, CHANGELOG

- `delete_range_vectored` and `delete_range_cf_vectored` docs were cut mid-sentence and never said why the bounds need equal part counts.
- The `drop_cf` / `mark_column_family_dropped` comments said the handle is destroyed there, which is only true in single-threaded mode; in `MultiThreaded` it drops an `Arc` refcount.
- The new batched and iterator entry points in the C header had no ownership or nullability contracts.
- CHANGELOG was missing the FreeBSD change, did not flag the `Snapshot` `Send`/`Sync` tightening to `D: DBAccess + Sync` as source-breaking, and undersold the `PerfStatsLevel` fix.

## Verification

`cargo fmt --check` and `cargo clippy --all-targets` clean. 42 test binaries pass with 0 failures; 99 doctests pass. `cargo build --release` and `--no-default-features --features snappy` both build. `cargo doc --no-deps` clean, `cargo bench --no-run` builds.

Snappy fix confirmed by direct probe: `-DSNAPPY_HAVE_SSSE3=1 -march=x86-64` fails to compile, adding `-mssse3` succeeds. Both `#ifdef` branches of `c_api_extensions.cc` pass `-fsyntax-only -Wall -Wextra`. One new unit test asserts the `raw_iterators_cf` iterators share a single live options object.

## Deliberately not here

aarch64 snappy could take `-march=armv8-a+crc` the way #253 did for RocksDB, but snappy's aarch64 CRC path is behind a runtime check and raising the floor on the whole translation unit risks a baseline downgrade. Wants aarch64 Linux benchmarking, not a guess.
