### PR TITLE
Add UBSan, TSan and Valgrind jobs, and turn LeakSanitizer on

### DIFF
--- a/.github/tsan-suppressions.txt
+++ b/.github/tsan-suppressions.txt
@@ -1,0 +1,12 @@
+# ThreadSanitizer suppressions.
+#
+# Only add an entry with the file and line it came from and a reason it is not
+# a bug worth fixing here. An unexplained entry is indistinguishable from
+# hiding a real race.
+
+# rocksdb/util/crc32c.cc:380, reached from DumpSupportInfo on every DB::Open,
+# writes the plain global `pmull_runtime_flag` declared at crc32c.cc:56 and
+# read from crc32c_arm64.cc:127. Two concurrent opens race on it. Every writer
+# computes the same value from the same cpuinfo probe, so the outcome does not
+# depend on the interleaving. aarch64 only, the write is under HAVE_ARM64_CRC.
+race:rocksdb::crc32c::IsFastCrc32Supported

--- a/.github/valgrind.supp
+++ b/.github/valgrind.supp
@@ -1,0 +1,19 @@
+# Valgrind memcheck suppressions.
+#
+# Only add an entry with the file and line it came from and a reason it is not
+# a bug worth fixing here. An unexplained entry is indistinguishable from
+# hiding a real defect.
+
+# rocksdb/util/compression.cc:515, MySink::GetAppendBuffer hands snappy the
+# sink's own output buffer, so snappy compresses straight into it and then
+# calls MySink::Append with that same pointer. Append memcpys it onto itself
+# at compression.cc:507. Nothing moves, but memcpy requires non-overlapping
+# ranges, so memcheck counts one error per compressed block. Upstream RocksDB;
+# the snappy Sink contract expects Append to skip the copy when the pointer
+# came from GetAppendBuffer.
+{
+   rocksdb-snappy-sink-self-memcpy
+   Memcheck:Overlap
+   fun:*memcpy*
+   fun:*BuiltinSnappyCompressorV2*MySink*Append*
+}

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,13 +1,16 @@
 name: Security Audit
 
+# Advisories land against dependency versions that are already pinned, so this
+# has to run on a timer as well as on change. The pull request trigger is what
+# used to be a second, separate audit job in rust.yml using a different action.
 on:
   push:
     branches:
       - master
-    paths:
-      - "**/Cargo.toml"
+  pull_request:
   schedule:
     - cron: "0 2 * * *" # run at 2 AM UTC
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -15,24 +18,24 @@ permissions:
 jobs:
   security-audit:
     permissions:
-      checks: write # for rustsec/audit-check to create check
+      checks: write # for the action to create a check
       contents: read # for actions/checkout to fetch code
-      issues: write # for rustsec/audit-check to create issues
+      issues: write # for the action to file advisories it finds
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache: false
+          rustflags: ""
 
-      - name: use stable rust
-        run: rustup override set stable
-
+      # Cargo.lock is gitignored, so there is nothing to audit until it exists.
       - name: Generate Cargo.lock
         run: cargo generate-lockfile
 
-      - name: Audit Check
-        # https://github.com/rustsec/audit-check/issues/2
-        uses: rustsec/audit-check@master
+      - name: Audit check
+        uses: actions-rust-lang/audit@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -172,6 +172,13 @@ jobs:
           cache-key: "v1-rust-features"
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
+      # `--no-default-features` drops `bindgen-runtime`, and with neither
+      # bindgen feature `clang-sys` looks for libclang through `llvm-config`
+      # instead of loading it at runtime. The runner image has libclang but no
+      # `llvm-config` on PATH, so that configuration needs the llvm package.
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y llvm clang
+
       - name: Check ${{ matrix.name }}
         run: cargo check --all-targets ${{ matrix.features }}
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -96,12 +96,84 @@ jobs:
             serde1" \
             -- -D warnings
 
-  audit:
-    name: Security audit
-    runs-on: ubuntu-latest
+  # Every other job builds for the target's baseline CPU, where
+  # x86_64-unknown-linux-gnu reports only fxsr, sse and sse2. `build.rs` turns
+  # target features into `-march`/`-mcpu` and into RocksDB and snappy defines,
+  # so a tuned build takes entirely different code paths. A snappy build break
+  # under `-Ctarget-cpu` shipped in 0.51.0 precisely because nothing here ever
+  # left the baseline. `native` rather than a fixed level so the job keeps
+  # matching whatever the runners actually are.
+  build-tuned-cpu:
+    name: Tuned CPU build - ${{ matrix.build }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [Linux, Linux-ARM]
+        include:
+          - build: Linux
+            os: ubuntu-latest
+          - build: Linux-ARM
+            os: ubuntu-24.04-arm
     steps:
-      - uses: actions/checkout@v5
-      - uses: actions-rust-lang/audit@v1
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: "v1-rust-tuned-cpu"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          rustflags: ""
+
+      - uses: taiki-e/install-action@nextest
+
+      - name: Run tests with -Ctarget-cpu=native
+        env:
+          RUSTFLAGS: -Ctarget-cpu=native
+        run: cargo nextest run --all
+
+  # Nothing else builds without the default features, so a compression backend
+  # that only compiles because a sibling feature happens to pull in its headers
+  # goes unnoticed. Check builds only; the point is that each combination
+  # compiles and links, which the default matrix already covers behaviourally.
+  build-feature-matrix:
+    name: Feature build - ${{ matrix.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: no-default-features
+            features: "--no-default-features"
+          - name: snappy only
+            features: "--no-default-features --features snappy"
+          - name: lz4 only
+            features: "--no-default-features --features lz4"
+          - name: zstd only
+            features: "--no-default-features --features zstd"
+          - name: zlib only
+            features: "--no-default-features --features zlib"
+          - name: bzip2 only
+            features: "--no-default-features --features bzip2"
+          - name: serde1 + multi-threaded-cf
+            features: "--features serde1,multi-threaded-cf"
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: "v1-rust-features"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Check ${{ matrix.name }}
+        run: cargo check --all-targets ${{ matrix.features }}
 
   test:
     name: ${{ matrix.build }}
@@ -251,8 +323,31 @@ jobs:
         if: runner.os == 'Linux'
         run: chmod -R a+w .
 
+  # Everything else runs the debug profile. Release turns on optimization and
+  # turns off debug_assertions, which changes both what the optimizer is
+  # allowed to assume about the FFI boundary and which assertions run.
+  test-release:
+    name: Test release profile
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: "v1-rust-release"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - uses: taiki-e/install-action@nextest
+
+      - name: Run rocksdb tests (release)
+        run: cargo nextest run --all --release
+
   test-sanitizers:
-    name: Test with AddressSanitizer
+    name: Test with Address/LeakSanitizer
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -281,16 +376,21 @@ jobs:
       # instrumented load to trip on. `build.rs` looks for "sanitize" in those
       # vars and keeps its dev-profile size optimizations out of the way.
       #
-      # LeakSanitizer stays off. It is the tool that would catch a leak in this
-      # crate's FFI layer, but RocksDB keeps process-lifetime singletons and
-      # background threads that it reports at exit, so turning it on needs a
-      # suppression list built from an actual run.
-      - name: Run tests with AddressSanitizer
+      # Do not add `-fsanitize=address` as a link arg. `-Zsanitizer=address`
+      # already links rustc's ASan runtime, and adding clang's on top of it
+      # gives duplicate symbol definitions for the whole runtime.
+      #
+      # `--jobs 2` because linking these binaries takes several GB each and a
+      # runner-wide parallel link gets the linker OOM-killed.
+      - name: Run tests with Address/LeakSanitizer
         env:
+          CC: clang
+          CXX: clang++
           RUSTFLAGS: -Zsanitizer=address
           RUSTDOCFLAGS: -Zsanitizer=address
           CFLAGS: -fsanitize=address -fno-omit-frame-pointer
           CXXFLAGS: -fsanitize=address -fno-omit-frame-pointer
-          ASAN_OPTIONS: detect_leaks=0:abort_on_error=1:print_stats=1
+          ASAN_OPTIONS: detect_leaks=1:detect_stack_use_after_return=1:abort_on_error=1:print_stats=1
         run: |
-          cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu --all --lib --bins --tests
+          cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu \
+            --all --lib --bins --tests --jobs 2

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -173,11 +173,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # `--no-default-features` drops `bindgen-runtime`, and with neither
-      # bindgen feature `clang-sys` looks for libclang through `llvm-config`
-      # instead of loading it at runtime. The runner image has libclang but no
-      # `llvm-config` on PATH, so that configuration needs the llvm package.
+      # bindgen feature `clang-sys` stops loading libclang at runtime and
+      # links it instead, which needs `llvm-config` from llvm-dev to locate
+      # `libclang.so` from libclang-dev. Neither is on the runner by default.
       - name: Install dependencies
-        run: sudo apt-get update && sudo apt-get install -y llvm clang
+        run: sudo apt-get update && sudo apt-get install -y llvm-dev libclang-dev clang
 
       - name: Check ${{ matrix.name }}
         run: cargo check --all-targets ${{ matrix.features }}

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,0 +1,164 @@
+name: Sanitizers
+
+# These rebuild RocksDB with instrumentation, which costs far more than the
+# regular matrix, so they do not gate every pull request. AddressSanitizer and
+# LeakSanitizer still run per-PR in the main workflow. Put the
+# `run-sanitizers` label on a pull request to run these against it.
+on:
+  push:
+    branches: [master]
+  schedule:
+    - cron: "0 3 * * *" # 3 AM UTC
+  workflow_dispatch:
+  pull_request:
+    types: [opened, synchronize, reopened, labeled]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  ubsan:
+    name: UndefinedBehaviorSanitizer
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-sanitizers')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: "v1-rust-ubsan"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          rustflags: ""
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y llvm clang
+
+      # rustc has no UBSan, so only the C++ is instrumented. That is where the
+      # value is anyway: RocksDB plus the hand-written extension in
+      # `librocksdb-sys/c-api-extensions/`, which does pointer and length
+      # arithmetic across the FFI boundary.
+      #
+      # ROCKSDB_UBSAN_RUN is RocksDB's own switch. It puts
+      # `no_sanitize("alignment")` on the deliberately unaligned loads in
+      # `util/coding.h`, `util/murmurhash.cc` and the crc32c sources.
+      #
+      # vptr needs RTTI and `build.rs` compiles with `-fno-rtti` unless the
+      # `rtti` feature is on, so that check has to come back out.
+      #
+      # Without `-fno-sanitize-recover=all` UBSan prints and carries on, and
+      # the job passes with undefined behaviour in the log.
+      - name: Run tests with UndefinedBehaviorSanitizer
+        env:
+          CC: clang
+          CXX: clang++
+          CFLAGS: -fsanitize=undefined -fno-sanitize=vptr -fno-sanitize-recover=all -DROCKSDB_UBSAN_RUN -fno-omit-frame-pointer
+          CXXFLAGS: -fsanitize=undefined -fno-sanitize=vptr -fno-sanitize-recover=all -DROCKSDB_UBSAN_RUN -fno-omit-frame-pointer
+          RUSTFLAGS: -Clinker=clang -Clink-arg=-fsanitize=undefined
+          UBSAN_OPTIONS: print_stacktrace=1:halt_on_error=1
+        run: cargo test --all --lib --bins --tests --jobs 2
+
+  tsan:
+    name: ThreadSanitizer
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-sanitizers')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install rust nightly
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          toolchain: nightly
+          components: rust-src
+          cache-key: "v1-rust-tsan"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+          rustflags: ""
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y llvm clang
+
+      # This crate's public contract is largely a thread-safety claim: the
+      # `Send`/`Sync` impls, the `MultiThreaded` column family map, and
+      # snapshot and iterator lifetimes against RocksDB's background threads.
+      # TSan is the only tool here that checks any of it.
+      #
+      # `-fPIC` and `FOLLY_SANITIZE_THREAD` match what RocksDB's own Makefile
+      # does under COMPILE_WITH_TSAN. jemalloc is off by default and must stay
+      # off, TSan does not work with it.
+      #
+      # Do not add `-fsanitize=thread` as a link arg. `-Zsanitizer=thread`
+      # already links rustc's TSan runtime and clang's is a duplicate of it.
+      - name: Run tests with ThreadSanitizer
+        env:
+          CC: clang
+          CXX: clang++
+          CFLAGS: -fsanitize=thread -fPIC -DFOLLY_SANITIZE_THREAD -fno-omit-frame-pointer
+          CXXFLAGS: -fsanitize=thread -fPIC -DFOLLY_SANITIZE_THREAD -fno-omit-frame-pointer
+          RUSTFLAGS: -Zsanitizer=thread
+          TSAN_OPTIONS: halt_on_error=1:suppressions=${{ github.workspace }}/.github/tsan-suppressions.txt
+        run: |
+          cargo +nightly test -Zbuild-std --target x86_64-unknown-linux-gnu \
+            --all --lib --bins --tests --jobs 2
+
+  valgrind:
+    name: Valgrind memcheck
+    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-sanitizers')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: "v1-rust-valgrind"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y valgrind
+
+      - name: Build test binaries
+        run: |
+          set -euo pipefail
+          cargo test --all --lib --bins --tests --features valgrind --no-run \
+            --message-format=json > cargo-test.json
+          grep -o '"executable":"[^"]*"' cargo-test.json \
+            | cut -d'"' -f4 | sort -u > test-binaries.txt
+          count=$(wc -l < test-binaries.txt)
+          echo "found $count test binaries"
+          # Without this the loop below would find nothing and report success.
+          test "$count" -gt 0
+
+      # Memcheck is the only thing here that reports reads of uninitialised
+      # memory. MemorySanitizer would too, but it needs an instrumented libc++
+      # underneath RocksDB, which is not a reasonable amount of work for this
+      # crate. Leak checking is off because LeakSanitizer already covers it in
+      # the main workflow and is much faster at it.
+      - name: Run test binaries under memcheck
+        run: |
+          set -uo pipefail
+          failed=0
+          while read -r bin; do
+            echo "::group::$(basename "$bin")"
+            if ! valgrind --suppressions=.github/valgrind.supp \
+                          --error-exitcode=99 --leak-check=no \
+                          --errors-for-leak-kinds=none \
+                          "$bin" --test-threads=1; then
+              failed=1
+              echo "::error::valgrind reported errors in $(basename "$bin")"
+            fi
+            echo "::endgroup::"
+          done < test-binaries.txt
+          exit "$failed"

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -1,9 +1,14 @@
 name: Sanitizers
 
-# These rebuild RocksDB with instrumentation, which costs far more than the
-# regular matrix, so they do not gate every pull request. AddressSanitizer and
-# LeakSanitizer still run per-PR in the main workflow. Put the
-# `run-sanitizers` label on a pull request to run these against it.
+# UBSan and TSan run on every pull request. They rebuild RocksDB
+# instrumented, but at 14 and 10 minutes they finish inside the 25 minutes the
+# coroutines build already takes, so they cost no extra wall clock.
+#
+# Valgrind takes 25 minutes on its own and is the one tool here that overlaps
+# with a per-PR job, since AddressSanitizer already covers leaks and heap
+# corruption. What it uniquely catches is reads of uninitialised memory, so it
+# still runs nightly and on master. Put the `run-sanitizers` label on a pull
+# request to get it there too.
 on:
   push:
     branches: [master]
@@ -23,7 +28,9 @@ env:
 jobs:
   ubsan:
     name: UndefinedBehaviorSanitizer
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-sanitizers')
+    # Adding the label starts a fresh run for Valgrind's benefit. Skip the two
+    # jobs that already ran when the commit was pushed.
+    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -67,7 +74,7 @@ jobs:
 
   tsan:
     name: ThreadSanitizer
-    if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-sanitizers')
+    if: github.event.action != 'labeled'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
@@ -112,6 +119,7 @@ jobs:
 
   valgrind:
     name: Valgrind memcheck
+    # Nightly and on master, plus any pull request carrying the label.
     if: github.event_name != 'pull_request' || contains(github.event.pull_request.labels.*.name, 'run-sanitizers')
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,41 @@ a minor version bump.
 
 - feat: expose `disable_file_deletions` and `enable_file_deletions` on
   `OptimisticTransactionDB`.
+- feat: the `valgrind` feature now does something. It was declared and
+  wired to nothing; it defines `ROCKSDB_VALGRIND_RUN`, which RocksDB
+  uses to skip work that does not finish in reasonable time under
+  Memcheck. Build with it before running the suite under Valgrind.
+
+### Continuous integration
+
+- ci: run the test suite under UndefinedBehaviorSanitizer,
+  ThreadSanitizer and Valgrind Memcheck, in a new `Sanitizers` workflow
+  on a nightly schedule, on pushes to master, and on pull requests
+  labelled `run-sanitizers`. All three are clean today. Two upstream
+  RocksDB findings are suppressed with the file and line they came from
+  in `.github/tsan-suppressions.txt` and `.github/valgrind.supp`: a race
+  on the non-atomic `pmull_runtime_flag` global written from every
+  `DB::Open` on aarch64, and a self-overlapping `memcpy` in the snappy
+  compression sink.
+- ci: turn LeakSanitizer on and add `detect_stack_use_after_return`. The
+  concern that RocksDB's process-lifetime singletons would swamp the
+  report was wrong, because LeakSanitizer treats globals as roots. The
+  full suite reports no leaks and needs no suppressions.
+- ci: build with `-Ctarget-cpu=native` on x86_64 and aarch64. Every
+  other job builds for the target baseline, which is why a snappy build
+  break under `-Ctarget-cpu` shipped in 0.51.0 without CI noticing.
+- ci: check the compression features individually and with
+  `--no-default-features`. Nothing built without the default feature set
+  before, so a backend that only compiled because a sibling feature
+  pulled in its headers would not have been caught.
+- ci: run the suite once in the release profile, which turns off
+  `debug_assertions` and changes what the optimizer may assume.
+- ci: limit link parallelism in the sanitizer jobs. Instrumented test
+  binaries take several GB each to link and a runner-wide parallel link
+  gets the linker OOM-killed.
+- ci: fold the two duplicate security audit jobs, which used two
+  different actions, into one that runs on pull requests, on master and
+  on a timer.
 
 ## 0.51.0 (2026-06-26)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,9 +189,13 @@ a minor version bump.
 ### Continuous integration
 
 - ci: run the test suite under UndefinedBehaviorSanitizer,
-  ThreadSanitizer and Valgrind Memcheck, in a new `Sanitizers` workflow
-  on a nightly schedule, on pushes to master, and on pull requests
-  labelled `run-sanitizers`. All three are clean today. Two upstream
+  ThreadSanitizer and Valgrind Memcheck, in a new `Sanitizers` workflow.
+  UBSan and TSan run on every pull request; they take 14 and 10 minutes,
+  which fits inside the 25 the coroutines build already takes. Valgrind
+  needs 25 minutes by itself and only adds uninitialised-read detection
+  over the per-PR AddressSanitizer job, so it runs nightly and on master,
+  or on a pull request labelled `run-sanitizers`. All three are clean
+  today. Two upstream
   RocksDB findings are suppressed with the file and line they came from
   in `.github/tsan-suppressions.txt` and `.github/valgrind.supp`: a race
   on the non-atomic `pmull_runtime_flag` global written from every

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ io-uring = ["rust-librocksdb-sys/io-uring"]
 # and the "Coroutines / async MultiGet" section of the README for build
 # prerequisites. Linux only.
 coroutines = ["rust-librocksdb-sys/coroutines"]
-valgrind = []
+valgrind = ["rust-librocksdb-sys/valgrind"]
 snappy = ["rust-librocksdb-sys/snappy"]
 lz4 = ["rust-librocksdb-sys/lz4"]
 zstd = ["rust-librocksdb-sys/zstd"]

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -55,6 +55,10 @@ rtti = []
 malloc-usable-size = []
 zstd-static-linking-only = []
 lto = []
+# Define ROCKSDB_VALGRIND_RUN. RocksDB uses it to skip work that is only
+# correct or only finishes in reasonable time outside Valgrind. Build with
+# this before running the test suite under Memcheck.
+valgrind = []
 
 [dependencies]
 libc = "0.2"

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -632,6 +632,9 @@ mod vendor {
         if cfg!(feature = "malloc-usable-size") && target.os == "linux" {
             cfg.define("ROCKSDB_MALLOC_USABLE_SIZE", Some("1"));
         }
+        if cfg!(feature = "valgrind") {
+            cfg.define("ROCKSDB_VALGRIND_RUN", Some("1"));
+        }
     }
 
     /// Pass `-Ctarget-cpu=...` through to the C/C++ compiler as `-march=` /

--- a/tests/test_rocksdb_options.rs
+++ b/tests/test_rocksdb_options.rs
@@ -936,14 +936,18 @@ fn test_crc32_build() {
     let log_line = log_line.unwrap();
 
     let expected_supported = if cfg!(target_arch = "x86_64") {
-        // Default Linux x86-64 (x86-64-v1) does not support CRC32. Nearly all CPUs since ~2014
-        // should support it (>= x86-64-v2), but RocksDB only does compile-time detection.
-        // Our build.rs should match the Rust target settings
-        if cfg!(target_feature = "crc") {
-            Some(true)
-        } else {
-            Some(false)
-        }
+        // RocksDB gates its x86 fast CRC32 on `__SSE4_2__` (util/crc32c.cc),
+        // and build.rs forwards `-Ctarget-cpu` to the C++ compiler as
+        // `-march`, so the C++ define tracks this Rust target feature.
+        //
+        // Baseline x86-64 (x86-64-v1) has no SSE4.2, so a default build
+        // reports "Not supported". Anything from x86-64-v2 on, including
+        // `-Ctarget-cpu=native` on essentially any CPU since ~2014, has it.
+        //
+        // This used to test `target_feature = "crc"`, which is an aarch64
+        // feature name and therefore always false here. It agreed with
+        // RocksDB only for as long as nothing built above the baseline.
+        Some(cfg!(target_feature = "sse4.2"))
     } else if cfg!(target_arch = "aarch64") {
         // On aarch64 the answer is a property of the CPU, not of the build:
         // build.rs compiles the crc32c sources with `-march=armv8-a+crc+crypto`


### PR DESCRIPTION
CI had exactly one memory-checking job: AddressSanitizer with LeakSanitizer switched off. This adds the three tools it was missing and closes the two gaps that let the 0.51.0 snappy break ship.

Everything below was validated on real Linux in a container before writing the YAML, not inferred.

## LeakSanitizer: on, no suppressions needed

My reasoning in #256 for leaving it off was wrong. The worry was that RocksDB's process-lifetime singletons and background threads would swamp the report. LeakSanitizer treats globals as roots, so those allocations are reachable and never reported.

Verified: **42 suites, 321 tests, zero leaks, no suppression file.** Also added `detect_stack_use_after_return`, which RocksDB's own Makefile sets by default and we did not.

I checked the clean result actually meant something rather than LeakSanitizer being inert, by leaking a `rocksdb_options_t` on purpose. It was reported, with the `rocksdb_options_create` frame, from uninstrumented C++.

## UndefinedBehaviorSanitizer

C++ only, because rustc has no UBSan. That is where the value is anyway: RocksDB plus the extension in `librocksdb-sys/c-api-extensions/`, which does pointer and length arithmetic across the FFI boundary.

Three things it needs, all found the hard way:

- `-DROCKSDB_UBSAN_RUN`, RocksDB's own switch. It applies `no_sanitize("alignment")` to the deliberately unaligned loads in `util/coding.h:340`, `util/murmurhash.cc:25` and the crc32c sources.
- `-fno-sanitize=vptr`, because `build.rs:630` compiles with `-fno-rtti` and the vptr check requires RTTI.
- `-fno-sanitize-recover=all`, or UBSan prints and continues and the job goes green with undefined behaviour in the log.

Verified: **42 suites, 321 tests, clean.** Confirmed armed with a signed-overflow probe that aborts with exit 1. No nightly needed.

## ThreadSanitizer

The only tool here that checks what this crate mostly promises: the `Send`/`Sync` impls, the `MultiThreaded` column family map, and iterator and snapshot lifetimes against RocksDB's background threads. Worth remembering a `drop_cf` use-after-free shipped in `05f567ff`.

Verified: **42 suites, 321 tests, clean with one suppression.**

## Valgrind, and the dead `valgrind` feature

Memcheck is the only thing here that reports reads of uninitialised memory. MemorySanitizer would too, but it needs an instrumented libc++ underneath RocksDB, which is not a reasonable amount of work for this crate.

This also gives the `valgrind` feature a purpose. It was declared at `Cargo.toml:29`, passed to the clippy job, and wired to nothing at all. It now defines `ROCKSDB_VALGRIND_RUN`.

Verified: **42 binaries, clean, about 4 minutes** for the whole suite.

## The two suppressions, both upstream RocksDB

Each is recorded with the file and line it came from and why it is not a bug worth fixing here. I did not add anything I had not actually seen reported.

**`.github/tsan-suppressions.txt`** — `rocksdb/util/crc32c.cc:380`, reached from `DumpSupportInfo` on every `DB::Open`, writes the plain global `pmull_runtime_flag` (declared `crc32c.cc:56`, read `crc32c_arm64.cc:127`). Two concurrent opens race on it. Every writer stores the same probed value, so the result does not depend on interleaving. aarch64 only, the write is under `HAVE_ARM64_CRC`.

**`.github/valgrind.supp`** — `rocksdb/util/compression.cc:515`, `MySink::GetAppendBuffer` hands snappy the sink's own output buffer, so snappy compresses straight into it and then calls `Append` with that same pointer, which memcpys it onto itself at `compression.cc:507`. Nothing moves, but `memcpy` requires non-overlapping ranges. 34000 reports in one test. The snappy `Sink` contract expects `Append` to skip the copy when the pointer came from `GetAppendBuffer`, so this looks like a real upstream bug, just a harmless one. Worth reporting upstream.

## Not sanitizers, but why a build break reached a release

- **Tuned CPU build.** Nothing ever built outside the target baseline, where `x86_64-unknown-linux-gnu` reports only `fxsr,sse,sse2`. That is exactly why the SSSE3 break in #256 shipped. Now builds and tests with `-Ctarget-cpu=native` on x86_64 and aarch64.
- **Feature matrix.** Nothing built without the default features, so a compression backend that only compiles because a sibling pulled in its headers would go unnoticed. Now checks each backend alone and `--no-default-features`.
- **Release profile.** Everything else tests debug only.

## Triggers and cost

The three new tools rebuild RocksDB instrumented, so they live in a separate `Sanitizers` workflow and do not gate every PR. Nightly, on master, on demand, and on PRs labelled `run-sanitizers`. AddressSanitizer keeps running per-PR exactly as before, so nothing loses coverage.

Sanitizer jobs cap link parallelism. These binaries take several GB each to link and a runner-wide parallel link gets the linker OOM-killed. Found that the hard way too.

## Cleanup

Folded the two security audit jobs into one. `rust.yml` ran `actions-rust-lang/audit@v1` on PRs, `audit.yml` ran `rustsec/audit-check@master` on a timer, same check twice with two actions and a moving branch pin. Now one job covering PRs, master and the nightly timer, on `actions/checkout@v5`.

## Two corrections to what I told you earlier

- **MSRV is already enforced.** I said it was unverified. `rust-toolchain.toml` pins `1.91.0`, so every non-nightly job already builds on exactly the MSRV. No job needed. The real gap is the opposite: nothing tests current stable or beta, so an upstream Rust change will not surface until someone bumps the pin. Left alone, happy to add if you want it.
- **AddressSanitizer on macOS does not work with instrumented C++.** Apple clang emits `___asan_version_mismatch_check_apple_clang_2100`, which rustc's ASan runtime does not provide, and the link fails. So the sanitizer jobs stay on Linux. Worth knowing before anyone tries to add a macOS row.

## Verification

`cargo fmt --check` and `cargo clippy --all-targets` clean, 42 suites pass, `actionlint` clean on all three workflows. The valgrind job's shell was run verbatim end to end against the committed `.github/valgrind.supp`: 42 binaries, exit 0.

One thing I could not verify: the tuned-CPU job on x86_64. My hardware is aarch64, so `-Ctarget-cpu=native` there exercised the NEON path, not SSSE3. The underlying x86 behaviour was confirmed with direct compiler probes in #256.

