### PR TITLE
Stop publishing files nothing compiles

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -222,6 +222,79 @@ jobs:
       - name: Check ${{ matrix.name }}
         run: cargo check --all-targets ${{ matrix.features }}
 
+  # What we publish is not what we test. Every other job builds from the git
+  # checkout; users build from a tarball assembled by the `exclude` list in
+  # `librocksdb-sys/Cargo.toml`. Trimming one glob too far breaks every
+  # downstream build and cannot be fixed without publishing a new version, so
+  # verify the tarball itself.
+  package:
+    name: Package verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: "v1-rust-package"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # No `--no-verify`: the point of this job is that cargo unpacks the
+      # tarball into `target/package` and compiles RocksDB from it, which is
+      # what proves the exclude list did not drop a header.
+      - name: Package and build from the tarball
+        run: cargo package -p rust-librocksdb-sys
+
+      # An exclude list silently admits whatever upstream adds next, so assert
+      # the result instead of trusting the patterns. RocksDB keeps tests in
+      # `*_test.cc` beside the sources, which is how 222 test files, the Java
+      # bindings and db_stress_tool were being published in the first place.
+      #
+      # This job runs with `submodules: recursive`, which is the point: snappy's
+      # googletest and benchmark submodules are absent from a shallow clone, so
+      # a local `cargo package` will not show them.
+      - name: Assert the tarball stays trimmed
+        run: |
+          set -euo pipefail
+          cargo package --list -p rust-librocksdb-sys > /tmp/pkg.txt
+          total=$(wc -l < /tmp/pkg.txt)
+          echo "packaged files: $total"
+
+          fail=0
+          for pat in '_test\.cc$' '^rocksdb/java/' '^rocksdb/db_stress_tool/' \
+                     '^rocksdb/microbench/' '^rocksdb/fuzz/' '^rocksdb/buckifier/' \
+                     '^snappy/third_party/'; do
+            n=$(grep -cE "$pat" /tmp/pkg.txt || true)
+            if [ "$n" -ne 0 ]; then
+              echo "::error::$n packaged files match $pat, which nothing compiles"
+              fail=1
+            fi
+          done
+
+          # Ceiling with room for ordinary upstream growth. A jump past this
+          # means a new directory started riding along; extend the exclude list
+          # rather than raising the number.
+          if [ "$total" -gt 1200 ]; then
+            echo "::error::$total packaged files exceeds the 1200 ceiling"
+            fail=1
+          fi
+
+          # The other direction: these are load-bearing and easy to strip by
+          # accident. gtest is on the include path and three test_util files
+          # are compiled.
+          for pat in '^rocksdb/third-party/gtest-1.8.1/fused-src/' '^rocksdb/test_util/' \
+                     '^rocksdb/tools/dump/db_dump_tool\.cc$'; do
+            if ! grep -qE "$pat" /tmp/pkg.txt; then
+              echo "::error::nothing matches $pat, but the build needs it"
+              fail=1
+            fi
+          done
+
+          exit $fail
+
   test:
     name: ${{ matrix.build }}
     runs-on: ${{ matrix.os }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -203,12 +203,33 @@ a minor version bump.
   so gated items carry "available on crate feature" badges. Not
   `all-features`, which would pull in `coroutines` and need a folly install.
 
+### Packaging
+
+- fix: stop publishing files that nothing compiles. The `exclude` list in
+  `rust-librocksdb-sys` relied on `*/tests`, but RocksDB keeps its tests in
+  `*_test.cc` next to the sources, so that pattern matched none of them.
+  0.47.0 shipped 1879 files against the 336 the build actually compiles:
+  222 test files, the 444-file Java binding tree, db_stress_tool,
+  buckifier, microbench, fuzz, build_tools, cmake, and all of `tools` bar
+  the one file that is built. Also dropped snappy's googletest and
+  benchmark submodules, which only appear in a recursive clone and would
+  have added another 398. Now 1039 files and 3.4 MiB compressed, down from
+  6.1 MiB, which every downstream build unpacks and hashes.
+
 ### Continuous integration
 
 - fix: restore the `Security audit` check name. Folding the two audit jobs
   together in the previous release renamed the check that branch protection
   requires, and a required check that never reports never passes, so every
   pull request needed an admin override to merge.
+- ci: verify the published tarball. `cargo package` now runs in CI and
+  compiles RocksDB from the unpacked archive, because no other job builds
+  what users actually download. It also asserts the tarball stays trimmed
+  and that the pieces the build needs, gtest's fused source and
+  `test_util`, are still in it. Trimming one glob too far breaks every
+  downstream build and cannot be undone without publishing a new version.
+  The job checks out submodules recursively, which is how it caught snappy's
+  nested test dependencies that a shallow clone hides.
 - ci: track stable in `rust-toolchain.toml` instead of pinning it to the
   MSRV, and add an `MSRV` job that reads `rust-version` from Cargo.toml so
   the two cannot drift. Pinning meant no job ever built on current stable,

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -19,15 +19,49 @@ exclude = [
     ".gitignore",
     "*.yml",
     "snappy/testdata",
+    # googletest and google benchmark, snappy's own test dependencies. They are
+    # nested submodules, so they are only present once someone clones with
+    # `--recursive`, which is why this is easy to miss locally and not in CI.
+    # `build.rs` compiles three files out of snappy and never looks here.
+    "snappy/third_party",
     "*/doc",
     "*/docs",
     "*/examples",
     "*/tests",
     "tests",
-    # Strip the (large) vendored RocksDB documentation but KEEP
-    # `librocksdb-sys/patches/README.md`, which is referenced from the
-    # build-script panic that fires when a patch fails to apply.
+    # Strip the large vendored RocksDB documentation.
     "rocksdb/**/*.md",
+
+    # Everything below is vendored RocksDB that `build.rs` never compiles.
+    # `rocksdb_lib_sources.txt` plus `c-api-extensions/` is the whole build,
+    # and none of these paths appear in it. `*/tests` above does not catch any
+    # of it, because RocksDB keeps its tests in `*_test.cc` next to the
+    # sources rather than in a tests directory, so before this the published
+    # crate carried roughly four files for every one it built.
+    #
+    # Do not add `rocksdb/third-party` here: `build.rs` puts
+    # `rocksdb/third-party/gtest-1.8.1/fused-src/` on the include path.
+    #
+    # `rocksdb/test_util` also has to stay. Three of its files are compiled.
+    "rocksdb/**/*_test.cc",
+    "rocksdb/java",
+    "rocksdb/db_stress_tool",
+    "rocksdb/microbench",
+    "rocksdb/fuzz",
+    "rocksdb/buckifier",
+    "rocksdb/build_tools",
+    "rocksdb/cmake",
+    "rocksdb/unreleased_history",
+
+    # `tools/dump/db_dump_tool.cc` is the one compiled file under `tools`, and
+    # it includes nothing else from there, so keep that directory and drop the
+    # rest.
+    "rocksdb/tools/advisor",
+    "rocksdb/tools/block_cache_analyzer",
+    "rocksdb/tools/*.cc",
+    "rocksdb/tools/*.h",
+    "rocksdb/tools/*.py",
+    "rocksdb/tools/*.sh",
 ]
 
 [features]


### PR DESCRIPTION
The `exclude` list in `rust-librocksdb-sys` relied on `*/tests`, but RocksDB keeps its tests in `*_test.cc` next to the sources, so that pattern never matched any of them. `cargo package --list` gave 1879 files against the 336 in `rocksdb_lib_sources.txt`.

Dropped, after checking that no kept source includes a header from any of them:

| path | files |
| --- | --- |
| `rocksdb/**/*_test.cc` | 222 |
| `rocksdb/java` | 444 |
| `rocksdb/tools` minus `tools/dump` | 94 |
| `rocksdb/db_stress_tool` | 35 |
| `rocksdb/build_tools` | 25 |
| `rocksdb/cmake` | 11 |
| `rocksdb/buckifier` | 8 |
| `rocksdb/unreleased_history` | 8 |
| `rocksdb/fuzz` | 6 |
| `rocksdb/microbench` | 3 |

1879 files and 6.1 MiB compressed becomes 1039 files and 3.4 MiB. Every downstream `cargo build` unpacks and hashes that.

`rocksdb/third-party` stays, because `build.rs` puts `rocksdb/third-party/gtest-1.8.1/fused-src/` on the include path. `rocksdb/test_util` stays, because three of its files are compiled. `tools/dump/db_dump_tool.cc` is the one compiled file under `tools` and it includes nothing else from there.

## Why the CI job

Nothing verified the tarball. Every other job builds from the git checkout, users build from the archive, and a bad trim is only discoverable after publishing, when it needs a new version to fix. The new `Package verify` job runs `cargo package` without `--no-verify`, so cargo unpacks the archive and compiles RocksDB from it.

It also asserts the result rather than trusting the patterns, in both directions: no test, Java, db_stress_tool, microbench, fuzz or buckifier files present, total under a 1200 ceiling so a new upstream directory trips it, and gtest's fused source, `test_util` and `db_dump_tool.cc` still present.

## Verification

`cargo package -p rust-librocksdb-sys` locally: packaged 1039 files, 3.4 MiB compressed, then compiled RocksDB from the unpacked tarball successfully. All 336 entries in `rocksdb_lib_sources.txt` are still packaged except `util/build_version.cc`, which `build.rs:952` deliberately filters out in favour of the copy this crate ships.