### PR TITLE
feat: expose `DB::GetSortedWalFiles` as `DBCommon::get_sorted_wal_files`

### DIFF
--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -95,8 +95,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-coroutines"
-          # The correct input name on this action is `cache-save-if`. We only
-          # want to populate the cache from master runs, not from PR runs.
+          # Populate the cache from master runs only, not from PR runs.
           cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # The folly build's correctness depends on three independent inputs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -222,6 +222,79 @@ jobs:
       - name: Check ${{ matrix.name }}
         run: cargo check --all-targets ${{ matrix.features }}
 
+  # What we publish is not what we test. Every other job builds from the git
+  # checkout; users build from a tarball assembled by the `exclude` list in
+  # `librocksdb-sys/Cargo.toml`. Trimming one glob too far breaks every
+  # downstream build and cannot be fixed without publishing a new version, so
+  # verify the tarball itself.
+  package:
+    name: Package verify
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Install rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-key: "v1-rust-package"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # No `--no-verify`: the point of this job is that cargo unpacks the
+      # tarball into `target/package` and compiles RocksDB from it, which is
+      # what proves the exclude list did not drop a header.
+      - name: Package and build from the tarball
+        run: cargo package -p rust-librocksdb-sys
+
+      # An exclude list silently admits whatever upstream adds next, so assert
+      # the result instead of trusting the patterns. RocksDB keeps tests in
+      # `*_test.cc` beside the sources, which is how 222 test files, the Java
+      # bindings and db_stress_tool were being published in the first place.
+      #
+      # This job runs with `submodules: recursive`, which is the point: snappy's
+      # googletest and benchmark submodules are absent from a shallow clone, so
+      # a local `cargo package` will not show them.
+      - name: Assert the tarball stays trimmed
+        run: |
+          set -euo pipefail
+          cargo package --list -p rust-librocksdb-sys > /tmp/pkg.txt
+          total=$(wc -l < /tmp/pkg.txt)
+          echo "packaged files: $total"
+
+          fail=0
+          for pat in '_test\.cc$' '^rocksdb/java/' '^rocksdb/db_stress_tool/' \
+                     '^rocksdb/microbench/' '^rocksdb/fuzz/' '^rocksdb/buckifier/' \
+                     '^snappy/third_party/'; do
+            n=$(grep -cE "$pat" /tmp/pkg.txt || true)
+            if [ "$n" -ne 0 ]; then
+              echo "::error::$n packaged files match $pat, which nothing compiles"
+              fail=1
+            fi
+          done
+
+          # Ceiling with room for ordinary upstream growth. A jump past this
+          # means a new directory started riding along; extend the exclude list
+          # rather than raising the number.
+          if [ "$total" -gt 1200 ]; then
+            echo "::error::$total packaged files exceeds the 1200 ceiling"
+            fail=1
+          fi
+
+          # The other direction: these are load-bearing and easy to strip by
+          # accident. gtest is on the include path and three test_util files
+          # are compiled.
+          for pat in '^rocksdb/third-party/gtest-1.8.1/fused-src/' '^rocksdb/test_util/' \
+                     '^rocksdb/tools/dump/db_dump_tool\.cc$'; do
+            if ! grep -qE "$pat" /tmp/pkg.txt; then
+              echo "::error::nothing matches $pat, but the build needs it"
+              fail=1
+            fi
+          done
+
+          exit $fail
+
   test:
     name: ${{ matrix.build }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rust-docs
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run cargo rustdoc
         run: cargo rustdoc -- -D warnings
@@ -58,6 +59,8 @@ jobs:
 
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run doctests
         run: cargo test --doc
@@ -75,6 +78,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y liburing-dev pkg-config
@@ -131,7 +135,7 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
           cache-key: "v1-rust-msrv"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Check on the declared MSRV
         run: cargo +${{ steps.msrv.outputs.version }} check --all-targets
@@ -164,8 +168,20 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-key: "v1-rust-tuned-cpu"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          # Nothing this job caches may contain machine code. `native` bakes
+          # whatever the saving runner supported into every host artifact,
+          # including the dependency rlibs that get linked into `build.rs`, and
+          # the hosted fleet spans CPU generations, so restoring those onto a
+          # narrower machine kills the build script with SIGILL. That rules out
+          # `target` and `~/.cargo/bin`, leaving the registry and git checkouts,
+          # which are only sources. Costs about two minutes, 8m09s cold against
+          # 6m05s warm, because the cache never covered the RocksDB build in the
+          # first place: `librocksdb-sys` is a workspace member, and it was 5m17s
+          # of that warm run.
+          cache-key: "v2-rust-tuned-cpu"
+          cache-targets: false
+          cache-bin: false
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
           rustflags: ""
 
       - uses: taiki-e/install-action@nextest
@@ -210,7 +226,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-features"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # `--no-default-features` drops `bindgen-runtime`, and with neither
       # bindgen feature `clang-sys` stops loading libclang at runtime and
@@ -240,7 +256,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-package"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # No `--no-verify`: the point of this job is that cargo unpacks the
       # tarball into `target/package` and compiles RocksDB from it, which is
@@ -320,7 +336,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - uses: taiki-e/install-action@nextest
 
@@ -373,7 +389,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-multi-threaded-cf"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - uses: taiki-e/install-action@nextest
 
@@ -424,7 +440,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-jemalloc"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - uses: taiki-e/install-action@nextest
 
@@ -459,7 +475,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-release"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - uses: taiki-e/install-action@nextest
 
@@ -481,7 +497,7 @@ jobs:
           toolchain: nightly
           components: rust-src
           cache-key: "v1-rust-asan"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
           rustflags: ""
 
       - name: Install dependencies

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-ubsan"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
           rustflags: ""
 
       - name: Install dependencies
@@ -88,7 +88,7 @@ jobs:
           toolchain: nightly
           components: rust-src
           cache-key: "v1-rust-tsan"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
           rustflags: ""
 
       - name: Install dependencies
@@ -132,7 +132,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-valgrind"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y valgrind

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -190,6 +190,7 @@ a minor version bump.
   only imported privately, so callers had to add `rust-librocksdb-sys` as a
   direct dependency and keep its version in lockstep by hand. Nothing in
   `ffi_raw` is covered by semver.
+- feat: expose `DB::GetSortedWalFiles` as `DBCommon::get_sorted_wal_files`.
 
 ### Documentation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,12 +204,33 @@ a minor version bump.
   so gated items carry "available on crate feature" badges. Not
   `all-features`, which would pull in `coroutines` and need a folly install.
 
+### Packaging
+
+- fix: stop publishing files that nothing compiles. The `exclude` list in
+  `rust-librocksdb-sys` relied on `*/tests`, but RocksDB keeps its tests in
+  `*_test.cc` next to the sources, so that pattern matched none of them.
+  0.47.0 shipped 1879 files against the 336 the build actually compiles:
+  222 test files, the 444-file Java binding tree, db_stress_tool,
+  buckifier, microbench, fuzz, build_tools, cmake, and all of `tools` bar
+  the one file that is built. Also dropped snappy's googletest and
+  benchmark submodules, which only appear in a recursive clone and would
+  have added another 398. Now 1039 files and 3.4 MiB compressed, down from
+  6.1 MiB, which every downstream build unpacks and hashes.
+
 ### Continuous integration
 
 - fix: restore the `Security audit` check name. Folding the two audit jobs
   together in the previous release renamed the check that branch protection
   requires, and a required check that never reports never passes, so every
   pull request needed an admin override to merge.
+- ci: verify the published tarball. `cargo package` now runs in CI and
+  compiles RocksDB from the unpacked archive, because no other job builds
+  what users actually download. It also asserts the tarball stays trimmed
+  and that the pieces the build needs, gtest's fused source and
+  `test_util`, are still in it. Trimming one glob too far breaks every
+  downstream build and cannot be undone without publishing a new version.
+  The job checks out submodules recursively, which is how it caught snappy's
+  nested test dependencies that a shallow clone hides.
 - ci: track stable in `rust-toolchain.toml` instead of pinning it to the
   MSRV, and add an `MSRV` job that reads `rust-version` from Cargo.toml so
   the two cannot drift. Pinning meant no job ever built on current stable,

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -19,15 +19,49 @@ exclude = [
     ".gitignore",
     "*.yml",
     "snappy/testdata",
+    # googletest and google benchmark, snappy's own test dependencies. They are
+    # nested submodules, so they are only present once someone clones with
+    # `--recursive`, which is why this is easy to miss locally and not in CI.
+    # `build.rs` compiles three files out of snappy and never looks here.
+    "snappy/third_party",
     "*/doc",
     "*/docs",
     "*/examples",
     "*/tests",
     "tests",
-    # Strip the (large) vendored RocksDB documentation but KEEP
-    # `librocksdb-sys/patches/README.md`, which is referenced from the
-    # build-script panic that fires when a patch fails to apply.
+    # Strip the large vendored RocksDB documentation.
     "rocksdb/**/*.md",
+
+    # Everything below is vendored RocksDB that `build.rs` never compiles.
+    # `rocksdb_lib_sources.txt` plus `c-api-extensions/` is the whole build,
+    # and none of these paths appear in it. `*/tests` above does not catch any
+    # of it, because RocksDB keeps its tests in `*_test.cc` next to the
+    # sources rather than in a tests directory, so before this the published
+    # crate carried roughly four files for every one it built.
+    #
+    # Do not add `rocksdb/third-party` here: `build.rs` puts
+    # `rocksdb/third-party/gtest-1.8.1/fused-src/` on the include path.
+    #
+    # `rocksdb/test_util` also has to stay. Three of its files are compiled.
+    "rocksdb/**/*_test.cc",
+    "rocksdb/java",
+    "rocksdb/db_stress_tool",
+    "rocksdb/microbench",
+    "rocksdb/fuzz",
+    "rocksdb/buckifier",
+    "rocksdb/build_tools",
+    "rocksdb/cmake",
+    "rocksdb/unreleased_history",
+
+    # `tools/dump/db_dump_tool.cc` is the one compiled file under `tools`, and
+    # it includes nothing else from there, so keep that directory and drop the
+    # rest.
+    "rocksdb/tools/advisor",
+    "rocksdb/tools/block_cache_analyzer",
+    "rocksdb/tools/*.cc",
+    "rocksdb/tools/*.h",
+    "rocksdb/tools/*.py",
+    "rocksdb/tools/*.sh",
 ]
 
 [features]

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.cc
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.cc
@@ -22,6 +22,7 @@
 #include "rocksdb/options.h"
 #include "rocksdb/slice.h"
 #include "rocksdb/table.h"
+#include "rocksdb/transaction_log.h"
 #include "rocksdb/version.h"
 #include "rocksdb/write_batch.h"
 
@@ -45,6 +46,8 @@ using ROCKSDB_NAMESPACE::SubcompactionJobInfo;
 using ROCKSDB_NAMESPACE::WriteStallInfo;
 using ROCKSDB_NAMESPACE::WriteBatch;
 using ROCKSDB_NAMESPACE::MemTableInfo;
+using ROCKSDB_NAMESPACE::WalFile;
+using ROCKSDB_NAMESPACE::VectorWalPtr;
 
 struct rust_rocksdb_status_t {
   Status* rep;
@@ -965,4 +968,83 @@ extern "C" unsigned char rust_rocksdb_snapshot_try_get_sequence_number(
   }
   *seqno = rep->GetSequenceNumber();
   return 1;
+}
+
+// -----------------------------------------------------------------------------
+// DB::GetSortedWalFiles
+//
+// `rocksdb_t` is `struct { DB* rep; }` (db/c.cc), so a pointer to the opaque
+// handle is also a pointer to its `rep` field. See the layout note above for
+// why this file uses a reinterpret_cast rather than re-declaring the struct.
+//
+// WalFile::PathName() returns a std::string by value, so the handle eagerly
+// copies each file's fields (including the owned path string) at creation
+// time; the accessors then hand out borrows that stay valid until destroy.
+// -----------------------------------------------------------------------------
+
+struct rust_rocksdb_wal_file_t {
+  std::string path_name;
+  uint64_t log_number;
+  int type;  // WalFileType: 0 = archived, 1 = alive.
+  uint64_t start_sequence;
+  uint64_t size_file_bytes;
+};
+
+struct rust_rocksdb_wal_files_t {
+  std::vector<rust_rocksdb_wal_file_t> rep;
+};
+
+extern "C" rust_rocksdb_wal_files_t* rust_rocksdb_get_sorted_wal_files(
+    rocksdb_t* db, char** errptr) {
+  try {
+    DB* db_rep = *reinterpret_cast<DB**>(db);
+    VectorWalPtr files;
+    Status s = db_rep->GetSortedWalFiles(files);
+    if (RustSaveError(errptr, s)) {
+      return nullptr;
+    }
+
+    auto result = std::make_unique<rust_rocksdb_wal_files_t>();
+    result->rep.reserve(files.size());
+    for (const auto& file : files) {
+      result->rep.push_back(rust_rocksdb_wal_file_t{
+          file->PathName(), file->LogNumber(), static_cast<int>(file->Type()),
+          file->StartSequence(), file->SizeFileBytes()});
+    }
+    return result.release();
+  } catch (const std::exception& error) {
+    RustSaveMessage(errptr, error.what());
+    return nullptr;
+  } catch (...) {
+    RustSaveMessage(errptr, "unknown C++ exception in GetSortedWalFiles");
+    return nullptr;
+  }
+}
+
+extern "C" size_t rust_rocksdb_wal_files_count(
+    const rust_rocksdb_wal_files_t* files) {
+  return files->rep.size();
+}
+
+extern "C" unsigned char rust_rocksdb_wal_files_get(
+    const rust_rocksdb_wal_files_t* files, size_t index, const char** path_name,
+    uint64_t* log_number, int* type, uint64_t* start_sequence,
+    uint64_t* size_file_bytes) {
+  // Same reasoning as rust_rocksdb_pinnable_batch_get (an assert would compile
+  // away in the vendored build).
+  if (index >= files->rep.size()) {
+    return 0;
+  }
+  const rust_rocksdb_wal_file_t& file = files->rep[index];
+  *path_name = file.path_name.c_str();
+  *log_number = file.log_number;
+  *type = file.type;
+  *start_sequence = file.start_sequence;
+  *size_file_bytes = file.size_file_bytes;
+  return 1;
+}
+
+extern "C" void rust_rocksdb_wal_files_destroy(
+    rust_rocksdb_wal_files_t* files) {
+  delete files;
 }

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.h
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.h
@@ -274,6 +274,48 @@ extern ROCKSDB_LIBRARY_API unsigned char
 rust_rocksdb_snapshot_try_get_sequence_number(const rocksdb_snapshot_t*,
                                              uint64_t* seqno);
 
+/* -------------------------------------------------------------------------
+ * DB::GetSortedWalFiles
+ *
+ * Retrieves the sorted list of WAL files (earliest first).
+ *
+ * The returned handle owns an eagerly-materialized copy of each WAL file's
+ * metadata (including its path string), so the accessors below stay valid
+ * until `rust_rocksdb_wal_files_destroy`. On error the getter sets `*errptr`
+ * and returns NULL.
+ * ------------------------------------------------------------------------- */
+typedef struct rust_rocksdb_wal_files_t rust_rocksdb_wal_files_t;
+
+/* WalFileType values, mirroring rocksdb/transaction_log.h. */
+enum {
+  rust_rocksdb_wal_file_type_archived = 0,
+  rust_rocksdb_wal_file_type_alive = 1,
+};
+
+extern ROCKSDB_LIBRARY_API rust_rocksdb_wal_files_t*
+rust_rocksdb_get_sorted_wal_files(rocksdb_t* db, char** errptr);
+
+extern ROCKSDB_LIBRARY_API size_t
+rust_rocksdb_wal_files_count(const rust_rocksdb_wal_files_t*);
+
+/* Reads the WAL file at `index` into the out-params and returns 1. If `index`
+ * is out of range (>= rust_rocksdb_wal_files_count) it returns 0 and leaves
+ * every out-param untouched.
+ * All out-params must be non-NULL.
+ *
+ * `*path_name` receives the WAL file's NUL-terminated path name, relative to
+ * the main db dir (e.g. "/000003.log"). The pointer is owned by the handle and
+ * valid until rust_rocksdb_wal_files_destroy. `*type` is one of the
+ * rust_rocksdb_wal_file_type_* values. */
+extern ROCKSDB_LIBRARY_API unsigned char
+rust_rocksdb_wal_files_get(const rust_rocksdb_wal_files_t* files, size_t index,
+                           const char** path_name, uint64_t* log_number,
+                           int* type, uint64_t* start_sequence,
+                           uint64_t* size_file_bytes);
+
+extern ROCKSDB_LIBRARY_API void
+rust_rocksdb_wal_files_destroy(rust_rocksdb_wal_files_t*);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/db.rs
+++ b/src/db.rs
@@ -3736,6 +3736,61 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
         }
     }
 
+    /// Retrieve the sorted list of all (archived and live) WAL files, with the
+    /// earliest file first.
+    ///
+    /// Empty WALs are filtered out. That is, the returned vector may be empty
+    /// (e.g. if called on a newly created database).
+    ///
+    /// This method blocks until scheduled or ongoging WAL purges complete.
+    ///
+    /// Furthermore, on databases with many SST files writes may be delayed
+    /// slightly while the WALs are being scanned (but not if called with file
+    /// deletions disabled, see [`DBCommon::disable_file_deletions`]).
+    pub fn get_sorted_wal_files(&self) -> Result<Vec<WalFile>, Error> {
+        unsafe {
+            let ptr = ffi_try!(ffi::rust_rocksdb_get_sorted_wal_files(self.inner.inner()));
+            if ptr.is_null() {
+                return Err(Error::new("Could not get sorted WAL files".to_owned()));
+            }
+            let count = ffi::rust_rocksdb_wal_files_count(ptr);
+            let mut out = Vec::with_capacity(count);
+            for i in 0..count {
+                let mut path_ptr: *const c_char = ptr::null();
+                let mut log_number: u64 = 0;
+                let mut file_type: c_int = 0;
+                let mut start_sequence: u64 = 0;
+                let mut size_file_bytes: u64 = 0;
+                let ok = ffi::rust_rocksdb_wal_files_get(
+                    ptr,
+                    i,
+                    &raw mut path_ptr,
+                    &raw mut log_number,
+                    &raw mut file_type,
+                    &raw mut start_sequence,
+                    &raw mut size_file_bytes,
+                );
+                if ok == 0 {
+                    // This should never happen... But when it does:
+                    ffi::rust_rocksdb_wal_files_destroy(ptr);
+                    return Err(Error::new(format!(
+                        "WAL file index out of range: {i} >= {count}"
+                    )));
+                }
+                out.push(WalFile {
+                    // `path_ptr` is owned by `ptr`, freed by the destroy below.
+                    path_name: from_cstr_without_free(path_ptr),
+                    log_number,
+                    file_type: WalFileType::from(file_type),
+                    start_sequence,
+                    size_file_bytes,
+                });
+            }
+            ffi::rust_rocksdb_wal_files_destroy(ptr);
+            Ok(out)
+        }
+    }
+
     /// Delete sst files whose keys are entirely in the given range.
     ///
     /// Could leave some keys in the range which are in files which are not
@@ -4054,6 +4109,43 @@ pub struct ColumnFamilyMetaData {
     pub name: String,
     // The number of files in this column family.
     pub file_count: usize,
+}
+
+/// Type of a WAL (write-ahead log) file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WalFileType {
+    Unknown,
+    /// Archived: moved out of the main db dir, retained per WAL ttl/size limits.
+    Archived,
+    /// Alive: resides in the main db directory.
+    Alive,
+}
+
+impl From<c_int> for WalFileType {
+    fn from(value: c_int) -> Self {
+        match value {
+            0 => WalFileType::Archived,
+            1 => WalFileType::Alive,
+            _ => WalFileType::Unknown,
+        }
+    }
+}
+
+/// Metadata describing a single WAL file, as returned by
+/// [`DBCommon::get_sorted_wal_files`].
+#[derive(Debug, Clone)]
+pub struct WalFile {
+    /// Path name relative to wal_dir (e.g. `/000003.log`, `/archived/000005.log`).
+    pub path_name: String,
+    /// Primary identifier for the log file; proportional to creation time.
+    pub log_number: u64,
+    /// Whether the file is alive or archived.
+    pub file_type: WalFileType,
+    /// Starting sequence number of the first write batch in this log file.
+    pub start_sequence: u64,
+    /// Position of the last flushed write (may be less than the full file size
+    /// for recycled WAL files).
+    pub size_file_bytes: u64,
 }
 
 /// The metadata that describes a SST file

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -128,7 +128,7 @@ pub use crate::{
     db::{
         ColumnFamilyMetaData, DB, DBAccess, DBCommon, DBWithThreadMode, ExportImportFilesMetaData,
         GetIntoBufferResult, LiveFile, MultiThreaded, PrefixProber, Range, SingleThreaded,
-        ThreadMode,
+        ThreadMode, WalFile, WalFileType,
     },
     db_iterator::{
         DBIterator, DBIteratorWithThreadMode, DBRawIterator, DBRawIteratorWithThreadMode,

--- a/tests/test_db.rs
+++ b/tests/test_db.rs
@@ -27,8 +27,8 @@ use rust_rocksdb::{
     DBCompactionStyle, DBWithThreadMode, DEFAULT_COLUMN_FAMILY_NAME, Env, Error, ErrorKind,
     FifoCompactOptions, IteratorMode, MultiThreaded, Options, PerfContext, PerfMetric,
     RateLimiterMode, ReadOptions, SingleThreaded, SliceTransform, Snapshot,
-    UniversalCompactOptions, UniversalCompactionStopStyle, WaitForCompactOptions, WriteBatch,
-    perf::get_memory_usage_stats,
+    UniversalCompactOptions, UniversalCompactionStopStyle, WaitForCompactOptions, WalFileType,
+    WriteBatch, perf::get_memory_usage_stats,
 };
 use util::{DBPath, U64Comparator, U64Timestamp, assert_iter, pair};
 
@@ -952,6 +952,54 @@ fn fifo_compaction_test() {
             assert_eq!(f.num_entries, 5);
             assert_eq!(f.num_deletions, 0);
         });
+    }
+}
+
+#[test]
+fn test_get_sorted_wal_files() {
+    let path = DBPath::new("_rust_rocksdb_get_sorted_wal_files");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        // Retain archived WALs for the duration of the test.
+        opts.set_wal_ttl_seconds(3600);
+        let db: DB = DB::open(&opts, &path).unwrap();
+
+        // Make some archived WALs.
+        for round in 0..3 {
+            for i in 0..10 {
+                let n = round * 10 + i;
+                db.put(format!("key{n}").as_bytes(), format!("value{n}").as_bytes())
+                    .unwrap();
+            }
+            db.flush().unwrap();
+        }
+
+        // Make a live WAL.
+        for i in 30..40 {
+            db.put(format!("key{i}").as_bytes(), format!("value{i}").as_bytes())
+                .unwrap();
+        }
+
+        let wal_files = db.get_sorted_wal_files().unwrap();
+        // Assert multiple files, otherwise ordering behaviour is not tested.
+        assert!(wal_files.len() > 1);
+
+        let mut prev = 0;
+        let n = wal_files.len();
+        for f in &wal_files[0..n - 1] {
+            assert_eq!(f.file_type, WalFileType::Archived);
+            assert!(f.size_file_bytes > 0);
+            assert!(f.path_name.starts_with("/"));
+            assert!(prev < f.log_number);
+            prev = f.log_number;
+        }
+
+        let f = wal_files.last().unwrap();
+        assert_eq!(f.file_type, WalFileType::Alive);
+        assert!(f.size_file_bytes > 0);
+        assert!(f.path_name.starts_with("/"));
+        assert!(f.log_number > prev);
     }
 }
 

--- a/tests/test_optimistic_transaction_db.rs
+++ b/tests/test_optimistic_transaction_db.rs
@@ -18,7 +18,7 @@ mod util;
 use rust_rocksdb::{
     CuckooTableOptions, DB, DBAccess, Direction, Error, ErrorKind, IteratorMode,
     OptimisticTransactionDB, OptimisticTransactionOptions, Options, ReadOptions, SingleThreaded,
-    SliceTransform, SnapshotWithThreadMode, WriteBatchWithTransaction, WriteOptions,
+    SliceTransform, SnapshotWithThreadMode, WalFileType, WriteBatchWithTransaction, WriteOptions,
 };
 use util::DBPath;
 
@@ -659,5 +659,34 @@ fn test_enable_and_disable_file_deletions() {
         db.compact_range(None::<&[u8]>, None::<&[u8]>);
 
         assert_eq!(get_sst_files().len(), 1);
+    }
+}
+
+#[test]
+fn test_get_sorted_wal_files() {
+    let path = DBPath::new("_rust_rocksdb_otxn_get_sorted_wal_files");
+    {
+        let mut opts = Options::default();
+        opts.create_if_missing(true);
+        let db: OptimisticTransactionDB<SingleThreaded> =
+            OptimisticTransactionDB::open(&opts, &path).unwrap();
+
+        for i in 0..100 {
+            db.put(format!("key{i}").as_bytes(), format!("value{i}").as_bytes())
+                .unwrap();
+        }
+        db.flush_wal(false).unwrap();
+
+        let wal_files = db.get_sorted_wal_files().unwrap();
+        assert!(!wal_files.is_empty());
+
+        let mut prev = 0u64;
+        for f in &wal_files {
+            assert!(f.log_number >= prev);
+            prev = f.log_number;
+            assert!(f.path_name.ends_with(".log"));
+            assert!(f.size_file_bytes > 0);
+            assert_eq!(f.file_type, WalFileType::Alive);
+        }
     }
 }


### PR DESCRIPTION
Backed by a new C-API extension (`rust_rocksdb_get_sorted_wal_files` plus count/get/destroy accessors), since upstream `rocksdb/c.h` has no wrapper.

The extension eagerly materializes each WAL file's metadata into `rust_rocksdb_wal_file_t` so accessors stay valid until destroy. Returns files sorted by log number.

Add `LiveWalFile` and `WalFileType`  to the public API, and tests covering both `DB` and `OptimisticTransactionDB`.

Co-authored-by: Claude Opus 4.8