### PR TITLE
Stop caching CPU-tuned artifacts, and start honouring cache-save-if

### DIFF
--- a/.github/workflows/coroutines.yml
+++ b/.github/workflows/coroutines.yml
@@ -95,8 +95,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-coroutines"
-          # The correct input name on this action is `cache-save-if`. We only
-          # want to populate the cache from master runs, not from PR runs.
+          # Populate the cache from master runs only, not from PR runs.
           cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # The folly build's correctness depends on three independent inputs:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -43,6 +43,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rust-docs
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run cargo rustdoc
         run: cargo rustdoc -- -D warnings
@@ -58,6 +59,8 @@ jobs:
 
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Run doctests
         run: cargo test --doc
@@ -75,6 +78,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y liburing-dev pkg-config
@@ -131,7 +135,7 @@ jobs:
         with:
           toolchain: ${{ steps.msrv.outputs.version }}
           cache-key: "v1-rust-msrv"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Check on the declared MSRV
         run: cargo +${{ steps.msrv.outputs.version }} check --all-targets
@@ -164,8 +168,20 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-key: "v1-rust-tuned-cpu"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          # Nothing this job caches may contain machine code. `native` bakes
+          # whatever the saving runner supported into every host artifact,
+          # including the dependency rlibs that get linked into `build.rs`, and
+          # the hosted fleet spans CPU generations, so restoring those onto a
+          # narrower machine kills the build script with SIGILL. That rules out
+          # `target` and `~/.cargo/bin`, leaving the registry and git checkouts,
+          # which are only sources. Costs about two minutes, 8m09s cold against
+          # 6m05s warm, because the cache never covered the RocksDB build in the
+          # first place: `librocksdb-sys` is a workspace member, and it was 5m17s
+          # of that warm run.
+          cache-key: "v2-rust-tuned-cpu"
+          cache-targets: false
+          cache-bin: false
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
           rustflags: ""
 
       - uses: taiki-e/install-action@nextest
@@ -210,7 +226,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-features"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # `--no-default-features` drops `bindgen-runtime`, and with neither
       # bindgen feature `clang-sys` stops loading libclang at runtime and
@@ -240,7 +256,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-package"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       # No `--no-verify`: the point of this job is that cargo unpacks the
       # tarball into `target/package` and compiles RocksDB from it, which is
@@ -320,7 +336,7 @@ jobs:
       - name: Install rust
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - uses: taiki-e/install-action@nextest
 
@@ -373,7 +389,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-multi-threaded-cf"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - uses: taiki-e/install-action@nextest
 
@@ -424,7 +440,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-jemalloc"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - uses: taiki-e/install-action@nextest
 
@@ -459,7 +475,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-release"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - uses: taiki-e/install-action@nextest
 
@@ -481,7 +497,7 @@ jobs:
           toolchain: nightly
           components: rust-src
           cache-key: "v1-rust-asan"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
           rustflags: ""
 
       - name: Install dependencies

--- a/.github/workflows/sanitizers.yml
+++ b/.github/workflows/sanitizers.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-ubsan"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
           rustflags: ""
 
       - name: Install dependencies
@@ -88,7 +88,7 @@ jobs:
           toolchain: nightly
           components: rust-src
           cache-key: "v1-rust-tsan"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
           rustflags: ""
 
       - name: Install dependencies
@@ -132,7 +132,7 @@ jobs:
         uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           cache-key: "v1-rust-valgrind"
-          save-if: ${{ github.ref == 'refs/heads/master' }}
+          cache-save-if: ${{ github.ref == 'refs/heads/master' }}
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y valgrind


### PR DESCRIPTION
`Tuned CPU build - Linux` failed on master with SIGILL in librocksdb-sys's build script:

```
process didn't exit successfully: .../build/rust-librocksdb-sys-c6f55d323ccd750e/build-script-build
  (signal: 4, SIGILL: illegal instruction)
```

## What happened

The job runs the suite under `-Ctarget-cpu=native` and was sharing a `target/` cache across the hosted runner fleet. Cache entry `...-c13e131c-640ca623` was restored by three separate runs of it:

| job | outcome |
| --- | --- |
| [92740073510](https://github.com/zaidoon1/rust-rocksdb/actions/runs/31137502521/job/92740073510) | passed |
| [92744295298](https://github.com/zaidoon1/rust-rocksdb/actions/runs/31138874571/job/92744295298) | SIGILL |
| [92744346560](https://github.com/zaidoon1/rust-rocksdb/actions/runs/31122129829/job/92744346560) | SIGILL |

Same cache, different outcome, so the variable is the machine. In the passing run the only `Compiling` lines were the two workspace members, meaning every dependency rlib linked into that build script came from the cache, compiled on some earlier runner under `native`. Land on a CPU without those instructions and the build script dies before it prints anything past the `cc` probe.

rust-cache does not put the host CPU in its key, and `ubuntu-latest` spans CPU generations, so there was nothing stopping this.

## The fix

The tuned job no longer caches anything holding machine code. `target/` and `~/.cargo/bin` are out; the registry and git checkouts stay, since those are only sources.

Keying the cache on the detected feature set instead would fragment it across the fleet to protect a job that barely benefits from it. Cost of dropping it is about two minutes (8m09s cold against 6m05s warm), because the RocksDB C++ build dominates the run and was never cached anyway: `librocksdb-sys` is a workspace member, so rust-cache strips its artifacts before saving. 5m17s of that 6m05s warm run was RocksDB.

`cache-key` goes to `v2` so the poisoned entry is unreachable by name as well as by path set.

## Also in here

`save-if` is not an input on `setup-rust-toolchain`; the correct name is `cache-save-if`. Every run has been printing `Unexpected input(s) 'save-if'` and saving caches from PR runs, which is how a tuned-cpu entry from an arbitrary runner got written in the first place. Renamed at all 12 sites, and added to `doc-check`, `doctest` and `clippy`, which had no save gating at all.

Nothing else needs the same treatment. `-Zsanitizer=address`, `-Zsanitizer=thread` and the UBSan linker flags change instrumentation, not the ISA baseline, and `build.rs` only emits `-march`/`-mcpu` when `-Ctarget-cpu` is set, which no other job does.

## Worth a separate look

`build.rs` forwards `-Ctarget-cpu` straight into the C++ build as `-march=native`, so a `librocksdb.a` built that way is only valid on the CPU that produced it. That is intentional and arguably what someone asking for `native` signed up for, but the caching section of the README recommends a shared sccache `build-dir` without mentioning it. Not touching that here.
