### PR TITLE
Keep snappy's NEON path off 32-bit ARM, and fix seven wrong option defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -236,6 +236,17 @@ a minor version bump.
 - docs: declare the docs.rs feature set explicitly and pass `--cfg docsrs`,
   so gated items carry "available on crate feature" badges. Not
   `all-features`, which would pull in `coroutines` and need a folly install.
+- docs: correct seven documented option defaults that disagreed with the
+  bundled RocksDB. `set_compression_type` is LZ4, not Snappy, as of RocksDB
+  11.5.0. `set_paranoid_checks` and `set_level_compaction_dynamic_level_bytes`
+  are on, not off. `set_level_zero_stop_writes_trigger` is 36, not 24.
+  `set_format_version` is 7, not 6, and the linked version list pointed at
+  RocksDB 8.6.7, which predates format 7. `set_max_manifest_file_size` is a
+  1 GiB floor under an auto-tuned limit, not a hard MAX_INT that disables
+  rollover. The deprecated `set_max_background_compactions` and
+  `set_max_background_flushes` are -1, derived from `max_background_jobs`,
+  not 1. `Options::default()` is RocksDB's own defaults, so these were wrong
+  about shipped behaviour rather than about a crate-level override.
 
 ### Packaging
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,9 +106,11 @@ a minor version bump.
   x86_64 builds with `-Ctarget-cpu=native` (or `haswell`, or
   `x86-64-v2` and newer) failed. The snappy build has its own
   `cc::Build` and never went through `apply_x86`, so nothing else
-  supplied the flag. `SNAPPY_HAVE_NEON` is now gated on the `neon`
-  target feature rather than on the architecture, for the few aarch64
-  targets that build without SIMD.
+  supplied the flag. `SNAPPY_HAVE_NEON` now also requires the `neon`
+  target feature on top of the aarch64 check, for the few aarch64
+  targets that build without SIMD. It stays gated on the architecture
+  too, because snappy's NEON path uses AArch64-only intrinsics and
+  `neon` is a target feature on 32-bit ARM as well.
 - perf: pass `-msse4.2` and `-mbmi2` to the vendored snappy build when
   the target has them. snappy derives `SNAPPY_HAVE_X86_CRC32` and
   `SNAPPY_HAVE_BMI2` from `__SSE4_2__`/`__BMI2__`, and nothing was

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -1256,10 +1256,16 @@ mod snappy {
         // the translation unit fails to compile. NEON is the exception: it is
         // mandatory in AArch64, so the baseline already provides it.
         //
+        // The arch check is load-bearing. snappy's NEON path calls
+        // `vqtbl1q_u8`, `vminvq_u8` and `vmaxvq_u8`, which only exist in
+        // AArch64, but `neon` is also a target feature on 32-bit ARM, and the
+        // `thumbv7neon-*` targets enable it by default. The feature check
+        // narrows within AArch64 for the targets that build without SIMD.
+        //
         // This build has its own `cc::Build` and never runs through
         // `apply_x86`/`apply_target_cpu`, so nothing else here will supply the
         // flag.
-        if target.has_feature("neon") {
+        if target.arch == "aarch64" && target.has_feature("neon") {
             cfg.define("SNAPPY_HAVE_NEON", Some("1"));
         }
         if target.has_feature("ssse3") {

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -690,10 +690,11 @@ impl BlockBasedOptions {
 
     /// Format version, reserved for backward compatibility.
     ///
-    /// See full [list](https://github.com/facebook/rocksdb/blob/v8.6.7/include/rocksdb/table.h#L493-L521)
+    /// See full [list](https://github.com/facebook/rocksdb/blob/v11.8.1/include/rocksdb/table.h#L702-L731)
     /// of the supported versions.
     ///
-    /// Default: 6.
+    /// Default: 7, which needs RocksDB 10.4.0 or newer to read. Lower it if
+    /// older readers have to open the files.
     pub fn set_format_version(&mut self, version: i32) {
         unsafe {
             ffi::rocksdb_block_based_options_set_format_version(self.inner, version);
@@ -1251,7 +1252,7 @@ impl Options {
     /// the database will switch to read-only mode and fail all other
     /// Write operations.
     ///
-    /// Default: false
+    /// Default: true
     pub fn set_paranoid_checks(&mut self, enabled: bool) {
         unsafe {
             ffi::rocksdb_options_set_paranoid_checks(self.inner, c_uchar::from(enabled));
@@ -1306,8 +1307,12 @@ impl Options {
 
     /// Sets the compression algorithm that will be used for compressing blocks.
     ///
-    /// Default: `DBCompressionType::Snappy` (`DBCompressionType::None` if
-    /// snappy feature is not enabled).
+    /// Default: `DBCompressionType::Lz4`, falling back to
+    /// `DBCompressionType::Snappy` and then `DBCompressionType::None` when the
+    /// preceding one is not compiled in. RocksDB 11.5.0 changed this from
+    /// Snappy; it affects only column families that never set `compression`,
+    /// and only newly written SST files. Existing data stays readable, since
+    /// the decompressor is selected per block.
     ///
     /// # Examples
     ///
@@ -1553,7 +1558,7 @@ impl Options {
     /// With this feature turned on, RocksDB will automatically adjust max bytes for each level.
     /// The goal of this feature is to have lower bound on size amplification.
     ///
-    /// Default: false.
+    /// Default: true.
     pub fn set_level_compaction_dynamic_level_bytes(&mut self, v: bool) {
         unsafe {
             ffi::rocksdb_options_set_level_compaction_dynamic_level_bytes(
@@ -2414,9 +2419,14 @@ impl Options {
         }
     }
 
-    /// The manifest file is rolled over on reaching this limit.
-    /// The older manifest file be deleted.
-    /// The default value is MAX_INT so that roll-over does not take place.
+    /// Sets a lower bound on the auto-tuned MANIFEST size limit. The MANIFEST
+    /// is rolled over on reaching the limit and the older one is deleted.
+    ///
+    /// This used to be a hard limit. RocksDB now auto-tunes the real limit and
+    /// treats this as a minimum, so setting it small does not keep the MANIFEST
+    /// small. Batches written in the foreground get a 25% higher limit.
+    ///
+    /// Default: 1 GiB.
     ///
     /// # Examples
     ///
@@ -2528,7 +2538,7 @@ impl Options {
 
     /// Sets the maximum number of level-0 files.  We stop writes at this point.
     ///
-    /// Default: `24`
+    /// Default: `36`
     ///
     /// Dynamically changeable through SetOptions() API
     ///
@@ -2642,7 +2652,9 @@ impl Options {
     /// LOW priority thread pool. For more information, see
     /// Env::SetBackgroundThreads
     ///
-    /// Default: `1`
+    /// Default: `-1`, meaning RocksDB derives it from `max_background_jobs`.
+    /// Setting either this or `max_background_flushes` opts into the old
+    /// behaviour, where the unset one of the pair counts as `1`.
     ///
     /// # Examples
     ///
@@ -2678,7 +2690,9 @@ impl Options {
     /// HIGH priority thread pool. For more information, see
     /// Env::SetBackgroundThreads
     ///
-    /// Default: `1`
+    /// Default: `-1`, meaning RocksDB derives it from `max_background_jobs`.
+    /// Setting either this or `max_background_compactions` opts into the old
+    /// behaviour, where the unset one of the pair counts as `1`.
     ///
     /// # Examples
     ///


### PR DESCRIPTION
Two fixes found while auditing the changelog for the 0.52.0 release.

## snappy NEON on 32-bit ARM

`SNAPPY_HAVE_NEON` moved from an aarch64 arch check to a `neon` target feature check in #256, to skip the few aarch64 targets that build without SIMD. `neon` is a target feature on 32-bit ARM too, and the `thumbv7neon-*` targets enable it by default, so those builds started defining the macro.

That does not compile. Under `SNAPPY_HAVE_NEON`, `snappy-internal.h` implements `V128_Shuffle` with `vqtbl1q_u8`, `vminvq_u8` and `vmaxvq_u8`, all AArch64-only. snappy is a default feature, so any `thumbv7neon-*` build fails. Same failure class as the `SNAPPY_HAVE_SSSE3`-without-`-mssse3` break that #256 was fixing.

Requiring both the arch and the feature keeps the intended narrowing without widening to 32-bit ARM.

```
thumbv7neon-unknown-linux-gnueabihf   arch "arm"       features "+v7,+thumb-mode,+thumb2,+vfp3,+neon"
aarch64-apple-darwin                  arch "aarch64"   target_feature="neon"
aarch64-unknown-linux-gnu             arch "aarch64"   target_feature="neon"
```

So the accelerated path is unchanged on both aarch64 targets and off on 32-bit ARM. I could not compile-test `thumbv7neon-*` without a cross toolchain, so the break is established from the intrinsics snappy calls rather than from a failing build.

The bad gate is unreleased, so nothing shipped with it. The changelog sentence describing it was wrong in the same way and is corrected here.

## Seven wrong option defaults

`Options::default()` is just `rocksdb_options_create()`, so these doc comments describe RocksDB's own defaults. Seven disagreed with the bundled library. Each value was checked against the headers in the submodule, not against upstream docs.

| option | doc said | actually |
| --- | --- | --- |
| `set_compression_type` | Snappy | LZ4, since RocksDB 11.5.0 |
| `set_paranoid_checks` | false | true |
| `set_level_compaction_dynamic_level_bytes` | false | true |
| `set_level_zero_stop_writes_trigger` | 24 | 36 |
| `set_format_version` | 6 | 7 |
| `set_max_manifest_file_size` | MAX_INT, no rollover | 1 GiB floor under an auto-tuned limit |
| `set_max_background_compactions` / `_flushes` | 1 | -1, derived from `max_background_jobs` |

Only the compression one is caused by this release. The rest were already wrong.

Worth calling out individually:

- `paranoid_checks` spent four lines describing the consequences of turning it on and then told you it was off.
- `level0_stop_writes_trigger` sat next to a slowdown trigger doc that says 20 and is correct, so anyone computing stall headroom from the pair got the wrong gap.
- `set_format_version` linked to the version list in RocksDB 8.6.7, which predates format 7. Following the link confirmed the wrong answer. Now points at v11.8.1 and notes that 7 needs a reader >= 10.4.0, which is what matters for downgrades.
- `max_manifest_file_size` stopped being a hard limit upstream. Setting it small no longer keeps the MANIFEST small.

## Verification

Build, tests, doctests, `cargo doc`, fmt and clippy pass locally on aarch64-apple-darwin, which still takes the NEON path. No test asserted any of the old default values.