### PR TITLE
Audit the committed lockfile instead of regenerating it

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -35,10 +35,10 @@ jobs:
           cache: false
           rustflags: ""
 
-      # Cargo.lock is gitignored, so there is nothing to audit until it exists.
-      - name: Generate Cargo.lock
-        run: cargo generate-lockfile
-
+      # No `cargo generate-lockfile` here. Cargo.lock is committed, and
+      # regenerating it re-resolves every dependency to the newest compatible
+      # version, so the audit would cover versions nobody builds and would miss
+      # a vulnerable pin that is actually in the lockfile.
       - name: Audit check
         uses: actions-rust-lang/audit@v1
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -282,9 +282,11 @@ a minor version bump.
   and then arrived together. Moving to 1.97.1 surfaced three clippy
   findings, now fixed: `libc::strlen` on a `CStr`, a reference cast to a raw
   pointer, and a redundant reference in an `assert!`.
-- ci: commit `Cargo.lock`. It was ignored, so the audit job had to run
-  `cargo generate-lockfile` first and was auditing whatever resolved that
-  day rather than anything anyone builds.
+- ci: audit the committed `Cargo.lock`. It used to be gitignored, so the
+  audit job ran `cargo generate-lockfile` first and checked whatever
+  resolved that day rather than anything anyone builds. The lockfile is
+  committed now and that step is gone, so a vulnerable pin in it gets
+  reported instead of quietly resolved away.
 - ci: run the test suite under UndefinedBehaviorSanitizer,
   ThreadSanitizer and Valgrind Memcheck, in a new `Sanitizers` workflow.
   UBSan and TSan run on every pull request; they take 14 and 10 minutes,


### PR DESCRIPTION
## Problem

`Cargo.lock` was committed earlier in this cycle, but `.github/workflows/audit.yml` was never updated to match. It still runs `cargo generate-lockfile` before the audit, under a comment claiming the lockfile is gitignored.

`cargo generate-lockfile` ignores the existing lockfile and re-resolves every dependency to the newest compatible version. So the job audits a dependency graph nobody builds, and a vulnerable version pinned in the committed lockfile gets resolved away before `cargo audit` sees it. That is the specific case the audit is there to catch.

## Fix

Remove the step. The lockfile is committed and current, so `actions-rust-lang/audit` reads it directly.

## Verifications run

- `cargo metadata --no-deps --format-version 1 --locked` succeeds, so the committed lockfile is in sync with the manifests and needs no generation step.
- `.github/workflows/audit.yml` parses as YAML.
- No other references to `generate-lockfile` or to the lockfile being gitignored remain in the repo.