### PR TITLE
Expose missing RocksDB C API options

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -16,7 +16,7 @@
 use crate::env::Env;
 use crate::{DBCommon, Error, ThreadMode, db::DBInner, ffi, ffi_util::to_cpath};
 
-use libc::c_uchar;
+use libc::{c_int, c_uchar};
 use std::ffi::CString;
 use std::path::Path;
 
@@ -279,6 +279,83 @@ impl BackupEngineOptions {
         let val_u8 = unsafe { ffi::rocksdb_backup_engine_options_get_sync(self.inner) };
         val_u8 != 0
     }
+
+    /// (Experimental - subject to change or removal) When taking a backup and saving file
+    /// temperature info (minimum schema_version is 2), there are two potential sources of
+    /// truth for the placement of files into temperature tiers: (a) the current file
+    /// temperature reported by the FileSystem or (b) the expected file temperature recorded
+    /// in DB manifest. When this option is false (default), (b) overrides (a) if both are not
+    /// UNKNOWN. When true, (a) overrides (b) if both are not UNKNOWN. Regardless of this
+    /// setting, a known temperature overrides UNKNOWN.
+    pub fn set_current_temperatures_override_manifest(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_current_temperatures_override_manifest(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `current_temperatures_override_manifest` option.
+    pub fn get_current_temperatures_override_manifest(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_get_current_temperatures_override_manifest(
+                self.inner,
+            ) != 0
+        }
+    }
+
+    /// Sets the `io_buffer_size` option.
+    pub fn set_io_buffer_size(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_io_buffer_size(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `io_buffer_size` option.
+    pub fn get_io_buffer_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_backup_engine_options_get_io_buffer_size(self.inner) }
+    }
+
+    /// Major schema version to use when writing backup meta files 1 (default) - compatible
+    /// with very old versions of RocksDB. 2 - can be read by RocksDB versions >= 6.19.0.
+    /// Minimum schema version for
+    /// - (Experimental) saving and restoring file temperature metadata
+    pub fn set_schema_version(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_schema_version(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `schema_version` option.
+    pub fn get_schema_version(&self) -> c_int {
+        unsafe { ffi::rocksdb_backup_engine_options_get_schema_version(self.inner) }
+    }
+
+    /// share_files_with_checksum supports table and blob files.
+    ///
+    /// Only used if share_table_files is set to true. Setting to false is DEPRECATED and
+    /// potentially dangerous because in that case BackupEngine can lose data if backing up
+    /// databases with distinct or divergent history, for example if restoring from a backup
+    /// other than the latest, writing to the DB, and creating another backup. Setting to true
+    /// (default) prevents these issues by ensuring that different table files (SSTs) and blob
+    /// files with the same number are treated as distinct. See
+    /// share_files_with_checksum_naming and ShareFilesNaming.
+    ///
+    /// Default: true
+    pub fn set_share_files_with_checksum(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_share_files_with_checksum(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `share_files_with_checksum` option.
+    pub fn get_share_files_with_checksum(&self) -> bool {
+        unsafe { ffi::rocksdb_backup_engine_options_get_share_files_with_checksum(self.inner) != 0 }
+    }
 }
 
 impl RestoreOptions {
@@ -292,6 +369,14 @@ impl RestoreOptions {
         unsafe {
             ffi::rocksdb_restore_options_set_keep_log_files(self.inner, i32::from(keep_log_files));
         }
+    }
+
+    /// If true, restore won't overwrite the existing log files in wal_dir. It will also move
+    /// all log files from archive directory to wal_dir. Use this option in combination with
+    /// BackupEngineOptions::backup_log_files = false for persisting in-memory databases.
+    /// Default: false
+    pub fn get_keep_log_files(&self) -> bool {
+        unsafe { ffi::rocksdb_restore_options_get_keep_log_files(self.inner) != 0 }
     }
 }
 

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -894,6 +894,625 @@ impl BlockBasedOptions {
             );
         }
     }
+
+    /// Align data blocks on lesser of page size and block size
+    pub fn get_block_align(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_block_align(self.inner) != 0 }
+    }
+
+    /// Number of keys between restart points for delta encoding of keys. This parameter can
+    /// be changed dynamically.  Most clients should leave this parameter alone.  The minimum
+    /// value allowed is 1.  Any smaller value will be silently overwritten with 1.
+    pub fn get_block_restart_interval(&self) -> c_int {
+        unsafe { ffi::rocksdb_block_based_options_get_block_restart_interval(self.inner) }
+    }
+
+    /// Approximate size of user data packed per block.  Note that the block size specified
+    /// here corresponds to uncompressed data.  The actual size of the unit read from disk may
+    /// be smaller if compression is enabled.  This parameter can be changed dynamically.
+    pub fn get_block_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_block_based_options_get_block_size(self.inner) }
+    }
+
+    /// This is used to close a block before it reaches the configured 'block_size'. If the
+    /// percentage of free space in the current block is less than this specified number and
+    /// adding a new record to the block will exceed the configured block size, then this
+    /// block will be closed and the new record will be written to the next block.
+    pub fn get_block_size_deviation(&self) -> c_int {
+        unsafe { ffi::rocksdb_block_based_options_get_block_size_deviation(self.inner) }
+    }
+
+    /// TODO(kailiu) Temporarily disable this feature by making the default value to be false.
+    ///
+    /// TODO(ajkr) we need to update names of variables controlling meta-block caching as they
+    /// should now apply to range tombstone and compression dictionary meta-blocks, in
+    /// addition to index and filter meta-blocks.
+    ///
+    /// Whether to put index/filter blocks in the block cache. When false, each "table reader"
+    /// object will pre-load index/filter blocks during table initialization. Index and filter
+    /// partition blocks always use block cache regardless of this option.
+    pub fn get_cache_index_and_filter_blocks(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_block_based_options_get_cache_index_and_filter_blocks(self.inner) != 0
+        }
+    }
+
+    /// If cache_index_and_filter_blocks is enabled, cache index and filter blocks with high
+    /// priority. If set to true, depending on implementation of block cache, index, filter,
+    /// and other metadata blocks may be less likely to be evicted than data blocks.
+    pub fn get_cache_index_and_filter_blocks_with_high_priority(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_block_based_options_get_cache_index_and_filter_blocks_with_high_priority(
+                self.inner,
+            ) != 0
+        }
+    }
+
+    /// Use the specified checksum type. Newly created table files will be protected with this
+    /// checksum type. Old table files will still be readable, even though they have different
+    /// checksum type.
+    pub fn get_checksum(&self) -> c_int {
+        unsafe { ffi::rocksdb_block_based_options_get_checksum(self.inner) }
+    }
+
+    /// #entries/#buckets. It is valid only when data_block_hash_index_type is
+    /// kDataBlockBinaryAndHash.
+    pub fn set_data_block_hash_table_util_ratio(&mut self, val: f64) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_data_block_hash_table_util_ratio(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `data_block_hash_table_util_ratio` option.
+    pub fn get_data_block_hash_table_util_ratio(&self) -> f64 {
+        unsafe { ffi::rocksdb_block_based_options_get_data_block_hash_table_util_ratio(self.inner) }
+    }
+
+    /// Returns the value of the `data_block_index_type` option.
+    pub fn get_data_block_index_type(&self) -> c_int {
+        unsafe { ffi::rocksdb_block_based_options_get_data_block_index_type(self.inner) }
+    }
+
+    /// When both partitioned indexes and partitioned filters are enabled, this enables
+    /// independent partitioning boundaries between the two. Most notably, this enables these
+    /// metadata blocks to hit their target size much more accurately, as there is often a
+    /// disparity between index sizes and filter sizes. This should reduce fragmentation and
+    /// metadata overheads in the block cache, as well as treat blocks more fairly for cache
+    /// eviction purposes.
+    ///
+    /// There are no SST format compatibility issues with this option. (All versions of
+    /// RocksDB able to read partitioned filters are able to read decoupled partitioned
+    /// filters.)
+    ///
+    /// decouple_partitioned_filters = true is the new default. This option is now DEPRECATED
+    /// and might be ignored and/or removed in a future release.
+    ///
+    /// NOTE: decouple_partitioned_filters = false with partition_filters = true disables
+    /// parallel compression (CompressionOptions::parallel_threads sanitized to 1).
+    pub fn set_decouple_partitioned_filters(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_decouple_partitioned_filters(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `decouple_partitioned_filters` option.
+    pub fn get_decouple_partitioned_filters(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_block_based_options_get_decouple_partitioned_filters(self.inner) != 0
+        }
+    }
+
+    /// If true, detect corruption during Bloom Filter (format_version >= 5) and Ribbon Filter
+    /// construction.
+    ///
+    /// This is an extra check that is only useful in detecting software bugs or CPU+memory
+    /// malfunction. Turning on this feature increases filter construction time by 30%.
+    ///
+    /// TODO: optimize this performance
+    pub fn set_detect_filter_construct_corruption(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_detect_filter_construct_corruption(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `detect_filter_construct_corruption` option.
+    pub fn get_detect_filter_construct_corruption(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_block_based_options_get_detect_filter_construct_corruption(self.inner) != 0
+        }
+    }
+
+    /// Store index blocks on disk in compressed format. Changing this option to false  will
+    /// avoid the overhead of decompression if index blocks are evicted and read back
+    pub fn set_enable_index_compression(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_enable_index_compression(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `enable_index_compression` option.
+    pub fn get_enable_index_compression(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_enable_index_compression(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL
+    ///
+    /// Return an error Status if a user_defined_index_factory is configured, but there's no
+    /// corresponding UDI block in the SST file being opened. When use_udi_as_primary_index is
+    /// true, this check is automatically enforced (a missing UDI block is always an error in
+    /// primary mode).
+    pub fn set_fail_if_no_udi_on_open(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_fail_if_no_udi_on_open(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `fail_if_no_udi_on_open` option.
+    pub fn get_fail_if_no_udi_on_open(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_fail_if_no_udi_on_open(self.inner) != 0 }
+    }
+
+    /// We currently have these format versions: 0 - 1 -- No longer supported. Attempting to
+    /// read files with these format versions will return an error. To upgrade, load the data
+    /// with RocksDB >= 4.6.0 and < 11.0.0, then run a full compaction.
+    /// - Can be read by RocksDB's versions since 3.10. Changes the way we encode compressed
+    ///   blocks with LZ4, BZip2 and Zlib compression. If you don't plan to run RocksDB
+    ///   before version 3.10, you should probably use this.
+    /// - Can be read by RocksDB's versions since 5.15. Changes the way we encode the keys
+    ///   in index blocks. If you don't plan to run RocksDB before version 5.15, you should
+    ///   probably use this. This option only affects newly written tables. When reading
+    ///   existing tables, the information about version is read from the footer.
+    /// - Can be read by RocksDB's versions since 5.16. Changes the way we encode the values
+    ///   in index blocks. If you don't plan to run RocksDB before version 5.16 and you are
+    ///   using index_block_restart_interval > 1, you should probably use this as it would
+    ///   reduce the index size. This option only affects newly written tables. When reading
+    ///   existing tables, the information about version is read from the footer.
+    /// - Can be read by RocksDB's versions since 6.6.0. Full and partitioned filters use a
+    ///   generally faster and more accurate Bloom filter implementation, with a different
+    ///   schema.
+    /// - Modified the file footer and checksum matching so that SST data misplaced within
+    ///   or between files is as likely to fail checksum verification as random corruption.
+    ///   Also checksum-protects SST footer. Can be read by RocksDB versions >= 8.6.0.
+    /// - Support for custom compression algorithms with a CompressionManager using a
+    ///   non-built-in CompatibilityName(). See `compression_manager` in
+    ///   ColumnFamilyOptions. Also changes the format of TableProperties field
+    ///   `compression_name`. Can be read by RocksDB versions >= 10.4.0.
+    ///
+    /// Using the default setting of format_version is strongly recommended, so that available
+    /// enhancements are adopted eventually and automatically. The default setting will only
+    /// update to the latest after thorough production validation and sufficient time and
+    /// number of releases have elapsed (6 months recommended) to ensure a clean
+    /// downgrade/revert path for users who might only upgrade a few times per year.
+    pub fn get_format_version(&self) -> u32 {
+        unsafe { ffi::rocksdb_block_based_options_get_format_version(self.inner) }
+    }
+
+    /// Same as block_restart_interval but used for the index block.
+    pub fn get_index_block_restart_interval(&self) -> c_int {
+        unsafe { ffi::rocksdb_block_based_options_get_index_block_restart_interval(self.inner) }
+    }
+
+    /// Returns the value of the `index_block_search_type` option.
+    pub fn get_index_block_search_type(&self) -> c_int {
+        unsafe { ffi::rocksdb_block_based_options_get_index_block_search_type(self.inner) }
+    }
+
+    /// Sets the `index_shortening` option.
+    pub fn set_index_shortening(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_index_shortening(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `index_shortening` option.
+    pub fn get_index_shortening(&self) -> c_int {
+        unsafe { ffi::rocksdb_block_based_options_get_index_shortening(self.inner) }
+    }
+
+    /// Returns the value of the `index_type` option.
+    pub fn get_index_type(&self) -> c_int {
+        unsafe { ffi::rocksdb_block_based_options_get_index_type(self.inner) }
+    }
+
+    /// RocksDB does auto-readahead for iterators on noticing more than two reads for a table
+    /// file if user doesn't provide readahead_size. The readahead size starts at
+    /// initial_auto_readahead_size and doubles on every additional read upto
+    /// BlockBasedTableOptions.max_auto_readahead_size. max_auto_readahead_size can also be
+    /// configured.
+    ///
+    /// Scenarios:
+    /// - If initial_auto_readahead_size is set 0 then it will disabled the implicit auto
+    ///   prefetching irrespective of max_auto_readahead_size.
+    /// - If max_auto_readahead_size is set 0, it will disable the internal prefetching
+    ///   irrespective of initial_auto_readahead_size.
+    /// - If initial_auto_readahead_size > max_auto_readahead_size, then RocksDB will
+    ///   sanitize the value of initial_auto_readahead_size to max_auto_readahead_size and
+    ///   readahead_size will be max_auto_readahead_size.
+    ///
+    /// Value should be provided along with KB i.e. 8 * 1024 as it will prefetch the blocks.
+    ///
+    /// Default: 8 KB (8 * 1024).
+    pub fn set_initial_auto_readahead_size(&mut self, val: usize) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_initial_auto_readahead_size(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `initial_auto_readahead_size` option.
+    pub fn get_initial_auto_readahead_size(&self) -> usize {
+        unsafe { ffi::rocksdb_block_based_options_get_initial_auto_readahead_size(self.inner) }
+    }
+
+    /// RocksDB does auto-readahead for iterators on noticing more than two reads for a table
+    /// file if user doesn't provide readahead_size. The readahead starts at
+    /// BlockBasedTableOptions.initial_auto_readahead_size (default: 8KB) and doubles on every
+    /// additional read upto max_auto_readahead_size and max_auto_readahead_size can be
+    /// configured.
+    ///
+    /// Special Value: 0 - If max_auto_readahead_size is set 0 then it will disable the
+    /// implicit auto prefetching. If max_auto_readahead_size provided is less than
+    /// initial_auto_readahead_size, then RocksDB will sanitize the
+    /// initial_auto_readahead_size and set it to max_auto_readahead_size.
+    ///
+    /// Value should be provided along with KB i.e. 256 * 1024 as it will prefetch the blocks.
+    ///
+    /// Found that 256 KB readahead size provides the best performance, based on experiments,
+    /// for auto readahead. Experiment data is in PR #3282.
+    ///
+    /// Default: 256 KB (256 * 1024).
+    pub fn set_max_auto_readahead_size(&mut self, val: usize) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_max_auto_readahead_size(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `max_auto_readahead_size` option.
+    pub fn get_max_auto_readahead_size(&self) -> usize {
+        unsafe { ffi::rocksdb_block_based_options_get_max_auto_readahead_size(self.inner) }
+    }
+
+    /// Target block size for partitioned metadata. Currently applied to indexes when
+    /// kTwoLevelIndexSearch is used and to filters when partition_filters is used. When
+    /// decouple_partitioned_filters=false (original behavior), there is much more deviation
+    /// from this target size. See the comment on decouple_partitioned_filters.
+    pub fn get_metadata_block_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_block_based_options_get_metadata_block_size(self.inner) }
+    }
+
+    /// Disable block cache. If this is set to true, then no block cache will be configured
+    /// (block_cache reset to nullptr).
+    ///
+    /// This option should not be used with SetOptions.
+    pub fn get_no_block_cache(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_no_block_cache(self.inner) != 0 }
+    }
+
+    /// RocksDB does auto-readahead for iterators on noticing more than two reads for a table
+    /// file if user doesn't provide readahead_size and reads are sequential.
+    /// num_file_reads_for_auto_readahead indicates after how many sequential reads internal
+    /// auto prefetching should be start.
+    ///
+    /// For example, if value is 2 then after reading 2 sequential data blocks on third data
+    /// block prefetching will start. If set 0, it will start prefetching from the first read.
+    ///
+    /// This parameter can be changed dynamically by
+    /// DB::SetOptions({{"block_based_table_factory",
+    /// "{num_file_reads_for_auto_readahead=0;}"}}));
+    ///
+    /// Changing the value dynamically will only affect files opened after the change.
+    ///
+    /// Default: 2
+    pub fn set_num_file_reads_for_auto_readahead(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_num_file_reads_for_auto_readahead(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `num_file_reads_for_auto_readahead` option.
+    pub fn get_num_file_reads_for_auto_readahead(&self) -> u64 {
+        unsafe {
+            ffi::rocksdb_block_based_options_get_num_file_reads_for_auto_readahead(self.inner)
+        }
+    }
+
+    /// Option to generate Bloom/Ribbon filters that minimize memory internal fragmentation.
+    ///
+    /// When false, malloc_usable_size is not available, or format_version < 5, filters are
+    /// generated without regard to internal fragmentation when loaded into memory (historical
+    /// behavior). When true (and malloc_usable_size is available and format_version >= 5),
+    /// then filters are generated to "round up" and "round down" their sizes to minimize
+    /// internal fragmentation when loaded into memory, assuming the reading DB has the same
+    /// memory allocation characteristics as the generating DB. This option does not break
+    /// forward or backward compatibility.
+    ///
+    /// While individual filters will vary in bits/key and false positive rate when setting is
+    /// true, the implementation attempts to maintain a weighted average FP rate for filters
+    /// consistent with this option set to false.
+    ///
+    /// With Jemalloc for example, this setting is expected to save about 10% of the memory
+    /// footprint and block cache charge of filters, while increasing disk usage of filters by
+    /// about 1-2% due to encoding efficiency losses with variance in bits/key.
+    ///
+    /// NOTE: Because some memory counted by block cache might be unmapped pages within
+    /// internal fragmentation, this option can increase observed RSS memory usage. With
+    /// cache_index_and_filter_blocks=true, this option makes the block cache better at using
+    /// space it is allowed. (These issues should not arise with partitioned filters.)
+    ///
+    /// NOTE: Set to false if you do not trust malloc_usable_size. When set to true, RocksDB
+    /// might access an allocated memory object beyond its original size if malloc_usable_size
+    /// says it is safe to do so. While this can be considered bad practice, it should not
+    /// produce undefined behavior unless malloc_usable_size is buggy or broken.
+    pub fn get_optimize_filters_for_memory(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_optimize_filters_for_memory(self.inner) != 0 }
+    }
+
+    /// Note: currently this option requires kTwoLevelIndexSearch to be set as well.
+    /// TODO(myabandeh): remove the note above once the limitation is lifted Use partitioned
+    /// full filters for each SST file. This option is incompatible with block-based filters.
+    /// Filter partition blocks use block cache even when cache_index_and_filter_blocks=false.
+    pub fn get_partition_filters(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_partition_filters(self.inner) != 0 }
+    }
+
+    /// DEPRECATED: This option will be removed in a future version. For now, this option
+    /// still takes effect by updating each of the following variables that has the default
+    /// value, `PinningTier::kFallback`:
+    ///
+    /// - `MetadataCacheOptions::partition_pinning`
+    /// - `MetadataCacheOptions::unpartitioned_pinning`
+    ///
+    /// The updated value is chosen as follows:
+    ///
+    /// - `pin_l0_filter_and_index_blocks_in_cache == false` -> `PinningTier::kNone`
+    /// - `pin_l0_filter_and_index_blocks_in_cache == true` ->
+    ///   `PinningTier::kFlushedAndSimilar`
+    ///
+    /// To migrate away from this flag, explicitly configure `MetadataCacheOptions` as
+    /// described above.
+    ///
+    /// if cache_index_and_filter_blocks is true and the below is true, then filter and index
+    /// blocks are stored in the cache, but a reference is held in the "table reader" object
+    /// so the blocks are pinned and only evicted from cache when the table reader is freed.
+    pub fn get_pin_l0_filter_and_index_blocks_in_cache(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_block_based_options_get_pin_l0_filter_and_index_blocks_in_cache(self.inner)
+                != 0
+        }
+    }
+
+    /// DEPRECATED: This option will be removed in a future version. For now, this option
+    /// still takes effect by updating `MetadataCacheOptions::top_level_index_pinning` when it
+    /// has the default value, `PinningTier::kFallback`.
+    ///
+    /// The updated value is chosen as follows:
+    ///
+    /// - `pin_top_level_index_and_filter == false` -> `PinningTier::kNone`
+    /// - `pin_top_level_index_and_filter == true` -> `PinningTier::kAll`
+    ///
+    /// To migrate away from this flag, explicitly configure `MetadataCacheOptions` as
+    /// described above.
+    ///
+    /// If cache_index_and_filter_blocks is true and the below is true, then the top-level
+    /// index of partitioned filter and index blocks are stored in the cache, but a reference
+    /// is held in the "table reader" object so the blocks are pinned and only evicted from
+    /// cache when the table reader is freed. This is not limited to l0 in LSM tree.
+    pub fn get_pin_top_level_index_and_filter(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_block_based_options_get_pin_top_level_index_and_filter(self.inner) != 0
+        }
+    }
+
+    /// Sets the `prepopulate_block_cache` option.
+    pub fn set_prepopulate_block_cache(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_prepopulate_block_cache(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `prepopulate_block_cache` option.
+    pub fn get_prepopulate_block_cache(&self) -> c_int {
+        unsafe { ffi::rocksdb_block_based_options_get_prepopulate_block_cache(self.inner) }
+    }
+
+    /// If used, For every data block we load into memory, we will create a bitmap of size
+    /// ((block_size / `read_amp_bytes_per_bit`) / 8) bytes. This bitmap will be used to
+    /// figure out the percentage we actually read of the blocks.
+    ///
+    /// When this feature is used Tickers::READ_AMP_ESTIMATE_USEFUL_BYTES and
+    /// Tickers::READ_AMP_TOTAL_READ_BYTES can be used to calculate the read amplification
+    /// using this formula (READ_AMP_TOTAL_READ_BYTES / READ_AMP_ESTIMATE_USEFUL_BYTES)
+    ///
+    /// value  =>  memory usage (percentage of loaded blocks memory) 1      =>  12.50 % 2
+    /// =>  06.25 % 4      =>  03.12 % 8      =>  01.56 % 16     =>  00.78 %
+    ///
+    /// Note: This number must be a power of 2, if not it will be sanitized to be the next
+    /// lowest power of 2, for example a value of 7 will be treated as 4, a value of 19 will
+    /// be treated as 16.
+    ///
+    /// Default: 0 (disabled)
+    pub fn set_read_amp_bytes_per_bit(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_read_amp_bytes_per_bit(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `read_amp_bytes_per_bit` option.
+    pub fn get_read_amp_bytes_per_bit(&self) -> u32 {
+        unsafe { ffi::rocksdb_block_based_options_get_read_amp_bytes_per_bit(self.inner) }
+    }
+
+    /// When true, data blocks store keys and values separately. Keys are stored at the
+    /// beginning of the block, followed by values at the end. This can improve read
+    /// performance at a cost of a varint per restart interval (~1 bit per key by default), in
+    /// addition to improving compression. Small values or low block_restart_interval may
+    /// prefer to set this as false.
+    ///
+    /// Default: false
+    pub fn get_separate_key_value_in_data_block(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_block_based_options_get_separate_key_value_in_data_block(self.inner) != 0
+        }
+    }
+
+    /// Align data blocks on super block alignment. Avoid a data block split across super
+    /// block boundaries. Works with/without compression.
+    ///
+    /// Here a "super block" refers to an aligned unit of underlying Filesystem storage for
+    /// which there is an extra cost when a random read involves two such super blocks instead
+    /// of just one. Configuring that size here suggests inserting padding in the SST file to
+    /// avoid a single SST block splitting across two super blocks. Only power-of-two sizes
+    /// are supported. See also super_block_alignment_space_overhead_ratio. Default to 0,
+    /// which means super block alignment is disabled.
+    ///
+    /// Super block alignment size. Default to 0, which means super block alignment is
+    /// disabled. If it is enabled, it needs to be a power of 2 and higher than block size.
+    pub fn set_super_block_alignment_size(&mut self, val: usize) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_super_block_alignment_size(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `super_block_alignment_size` option.
+    pub fn get_super_block_alignment_size(&self) -> usize {
+        unsafe { ffi::rocksdb_block_based_options_get_super_block_alignment_size(self.inner) }
+    }
+
+    /// This option constrols the storage space overhead of super block alignment. It is used
+    /// to calculate the max padding size allowed for super block alignment. It is calculated
+    /// in this way. If super_block_alignment_size is 2MB, and
+    /// super_block_alignment_overhead_ratio is 128, then the max padding size allowed for
+    /// super block alignment is 2MB / 128 = 16KB. Note that, when it is set to 0, super block
+    /// alignment is disabled.
+    pub fn set_super_block_alignment_space_overhead_ratio(&mut self, val: usize) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_super_block_alignment_space_overhead_ratio(
+                self.inner, val,
+            );
+        }
+    }
+
+    /// Returns the value of the `super_block_alignment_space_overhead_ratio` option.
+    pub fn get_super_block_alignment_space_overhead_ratio(&self) -> usize {
+        unsafe {
+            ffi::rocksdb_block_based_options_get_super_block_alignment_space_overhead_ratio(
+                self.inner,
+            )
+        }
+    }
+
+    /// Coefficient of variation (CV) threshold used to determine if keys in an index block
+    /// are uniformly distributed. Lower CV means more "uniform", and the more likely
+    /// interpolation search will outperform binary search.
+    ///
+    /// On the write path, if the CV of key gaps in an index block is less than this
+    /// threshold, the "is_uniform" hint is set in that block's footer. To disable (i.e.
+    /// always have "is_uniform=false"), set value to -1.
+    ///
+    /// On the read path, if `BlockSearchType::kAuto` is set, then it will use the is_uniform
+    /// hint to select an appropriate search algorithm for the block.
+    ///
+    /// NOTE: Currently only supports index blocks. May update to include data blocks in the
+    /// future.
+    pub fn get_uniform_cv_threshold(&self) -> f64 {
+        unsafe { ffi::rocksdb_block_based_options_get_uniform_cv_threshold(self.inner) }
+    }
+
+    /// Use delta encoding to compress keys in blocks. ReadOptions::pin_data requires this
+    /// option to be disabled.
+    ///
+    /// Default: true
+    pub fn get_use_delta_encoding(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_use_delta_encoding(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL
+    ///
+    /// When true and user_defined_index_factory is set, the UDI becomes the primary index for
+    /// reads. All reads (including internal operations like compaction and VerifyChecksum)
+    /// automatically route through the UDI without needing ReadOptions::table_index_factory.
+    ///
+    /// Both the standard binary search index and the UDI are always fully built. The standard
+    /// index serves as a safety fallback (e.g., for backup/restore or rollback to a non-UDI
+    /// configuration). A future refactor will extract the index abstraction to allow skipping
+    /// the standard index build when the UDI is primary.
+    ///
+    /// When the UDI is primary:
+    /// - All reads automatically use the UDI (ReadOptions::table_index_factory does not
+    ///   need to be set)
+    /// - Partitioned index (kTwoLevelIndexSearch) and partitioned filters are incompatible
+    ///   with this option
+    /// - fail_if_no_udi_on_open is automatically enforced to prevent silent data loss if
+    ///   these SSTs are opened without UDI support
+    ///
+    /// Recommended migration path:
+    ///
+    /// - Deploy with user_defined_index_factory set but use_udi_as_primary_index=false
+    ///   (secondary mode). New SSTs are written with both indexes. Reads use the standard
+    ///   index by default.
+    ///
+    /// - Validate reads through the UDI by setting ReadOptions::table_index_factory on a
+    ///   subset of reads.
+    ///
+    /// - Compact the entire DB to rewrite all pre-existing SSTs with both indexes. All SSTs
+    ///   must have a UDI block before proceeding.
+    ///
+    /// - Enable use_udi_as_primary_index=true. All reads use the UDI.
+    ///
+    /// Rollback: set use_udi_as_primary_index=false. Since the standard index is always fully
+    /// populated, SSTs are immediately readable through the standard index. No compaction is
+    /// required. All reads immediately revert to the standard index path.
+    ///
+    /// Backup/restore: the user_defined_index_factory is a shared_ptr that cannot survive
+    /// Options serialization (e.g., GetStringFromDBOptions). Since the standard index is
+    /// always fully populated, a restored DB can be opened and read without the factory
+    /// (reads fall back to the standard index). Set the factory when opening the restored DB
+    /// to resume using the UDI.
+    ///
+    /// Default: false (UDI is built alongside the standard index as a secondary)
+    pub fn set_use_udi_as_primary_index(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_use_udi_as_primary_index(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `use_udi_as_primary_index` option.
+    pub fn get_use_udi_as_primary_index(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_use_udi_as_primary_index(self.inner) != 0 }
+    }
+
+    /// Verify that decompressing the compressed block gives back the input. This is a
+    /// verification mode that we use to detect bugs in compression algorithms.
+    pub fn set_verify_compression(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_verify_compression(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `verify_compression` option.
+    pub fn get_verify_compression(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_verify_compression(self.inner) != 0 }
+    }
+
+    /// If true, place whole keys in the filter (not just prefixes). This must generally be
+    /// true for gets to be efficient.
+    pub fn get_whole_key_filtering(&self) -> bool {
+        unsafe { ffi::rocksdb_block_based_options_get_whole_key_filtering(self.inner) != 0 }
+    }
 }
 
 impl Default for BlockBasedOptions {
@@ -965,6 +1584,49 @@ impl CuckooTableOptions {
         unsafe {
             ffi::rocksdb_cuckoo_options_set_use_module_hash(self.inner, c_uchar::from(flag));
         }
+    }
+
+    /// In case of collision while inserting, the builder attempts to insert in the next
+    /// cuckoo_block_size locations before skipping over to the next Cuckoo hash function.
+    /// This makes lookups more cache friendly in case of collisions.
+    pub fn get_cuckoo_block_size(&self) -> u32 {
+        unsafe { ffi::rocksdb_cuckoo_options_get_cuckoo_block_size(self.inner) }
+    }
+
+    /// @hash_table_ratio: the desired utilization of the hash table used for prefix hashing.
+    /// hash_table_ratio = number of prefixes / #buckets in the hash table
+    pub fn set_hash_table_ratio(&mut self, val: f64) {
+        unsafe {
+            ffi::rocksdb_cuckoo_options_set_hash_table_ratio(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `hash_table_ratio` option.
+    pub fn get_hash_table_ratio(&self) -> f64 {
+        unsafe { ffi::rocksdb_cuckoo_options_get_hash_table_ratio(self.inner) }
+    }
+
+    /// If this option is enabled, user key is treated as uint64_t and its value is used as
+    /// hash value directly. This option changes builder's behavior. Reader ignore this option
+    /// and behave according to what specified in table property.
+    pub fn get_identity_as_first_hash(&self) -> bool {
+        unsafe { ffi::rocksdb_cuckoo_options_get_identity_as_first_hash(self.inner) != 0 }
+    }
+
+    /// A property used by builder to determine the depth to go to to search for a path to
+    /// displace elements in case of collision. See Builder.MakeSpaceForKey method. Higher
+    /// values result in more efficient hash tables with fewer lookups but take more time to
+    /// build.
+    pub fn get_max_search_depth(&self) -> u32 {
+        unsafe { ffi::rocksdb_cuckoo_options_get_max_search_depth(self.inner) }
+    }
+
+    /// If this option is set to true, module is used during hash calculation. This often
+    /// yields better space efficiency at the cost of performance. If this option is set to
+    /// false, # of entries in table is constrained to be power of two, and bit and is used to
+    /// calculate hash, which is faster in general.
+    pub fn get_use_module_hash(&self) -> bool {
+        unsafe { ffi::rocksdb_cuckoo_options_get_use_module_hash(self.inner) != 0 }
     }
 }
 
@@ -4092,6 +4754,1532 @@ impl Options {
             callback: self.outlive.logger_callback.clone(),
         }
     }
+
+    /// Sets the `add` option.
+    pub fn set_add(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_calculate_sst_write_lifetime_hint_set_add(self.inner, val);
+        }
+    }
+
+    /// if set to false then recovery will fail when a prepared transaction is encountered in
+    /// the WAL
+    pub fn set_allow_2pc(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_allow_2pc(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `allow_2pc` option.
+    pub fn get_allow_2pc(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_allow_2pc(self.inner) != 0 }
+    }
+
+    /// It allows user to opt-in to get error messages containing corrupted keys/values.
+    /// Corrupt keys, values will be logged in the messages/logs/status that will help users
+    /// with the useful information regarding affected data. By default value is set false to
+    /// prevent users data to be exposed in the logs/messages etc.
+    ///
+    /// Default: false
+    pub fn set_allow_data_in_errors(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_allow_data_in_errors(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `allow_data_in_errors` option.
+    pub fn get_allow_data_in_errors(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_allow_data_in_errors(self.inner) != 0 }
+    }
+
+    /// If false, fallocate() calls are bypassed, which disables file preallocation. The file
+    /// space preallocation is used to increase the file write/append performance. By default,
+    /// RocksDB preallocates space for WAL, SST, Manifest files, the extra space is truncated
+    /// when the file is written. Warning: if you're using btrfs, we would recommend setting
+    /// `allow_fallocate=false` to disable preallocation. As on btrfs, the extra allocated
+    /// space cannot be freed, which could be significant if you have lots of files. More
+    /// details about this limitation:
+    /// <https://github.com/btrfs/btrfs-dev-docs/blob/471c5699336e043114d4bca02adcd57d9dab9c44/data-extent-reference-counts.md>
+    pub fn set_allow_fallocate(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_allow_fallocate(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `allow_fallocate` option.
+    pub fn get_allow_fallocate(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_allow_fallocate(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL: If true, RocksDB asynchronously precreates the next WAL file so
+    /// foreground memtable switching can usually avoid the filesystem latency of creating a
+    /// new WAL. The precreated file is only reserved empty storage; it does not become a
+    /// logical WAL and is not added to WAL tracking until it is consumed by a foreground WAL
+    /// rotation.
+    ///
+    /// The option is sanitized to false when recycle_log_file_num is non-zero.
+    ///
+    /// Default: false
+    pub fn set_async_wal_precreate(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_async_wal_precreate(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `async_wal_precreate` option.
+    pub fn get_async_wal_precreate(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_async_wal_precreate(self.inner) != 0 }
+    }
+
+    /// By default RocksDB replay WAL logs and flush them on DB open, which may create very
+    /// small SST files. If this option is enabled, RocksDB will try to avoid (but not
+    /// guarantee not to) flush during recovery. Also, existing WAL logs will be kept, so that
+    /// if crash happened before flush, we still have logs to recover from.
+    ///
+    /// Note: when `enforce_write_buffer_manager_during_recovery` is also enabled, flushes may
+    /// still occur during recovery to respect the WriteBufferManager's global memory limit,
+    /// even if this option is true. Once any such WBM-triggered flush happens, all remaining
+    /// memtables will also be flushed at the end of recovery (similar to the behavior when
+    /// this option is false).
+    ///
+    /// DEFAULT: false
+    pub fn set_avoid_flush_during_recovery(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_avoid_flush_during_recovery(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `avoid_flush_during_recovery` option.
+    pub fn get_avoid_flush_during_recovery(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_avoid_flush_during_recovery(self.inner) != 0 }
+    }
+
+    /// By default RocksDB will flush all memtables on DB close if there are unpersisted data
+    /// (i.e. with WAL disabled) The flush can be skip to speedup DB close. Unpersisted data
+    /// WILL BE LOST.
+    ///
+    /// DEFAULT: false
+    ///
+    /// Dynamically changeable through SetDBOptions() API.
+    pub fn set_avoid_flush_during_shutdown(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_avoid_flush_during_shutdown(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `avoid_flush_during_shutdown` option.
+    pub fn get_avoid_flush_during_shutdown(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_avoid_flush_during_shutdown(self.inner) != 0 }
+    }
+
+    /// Set to true to re-instate an old behavior of keeping complete, synced WAL files open
+    /// for write until they are collected for deletion by a background thread. This should
+    /// not be needed unless there is a performance issue with file Close(), but setting it to
+    /// true means that Checkpoint might call LinkFile on a WAL still open for write, which
+    /// might be unsupported on some FileSystem implementations. As this is intended as a
+    /// temporary kill switch, it is already DEPRECATED.
+    pub fn set_background_close_inactive_wals(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_background_close_inactive_wals(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `background_close_inactive_wals` option.
+    pub fn get_background_close_inactive_wals(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_background_close_inactive_wals(self.inner) != 0 }
+    }
+
+    /// By default, RocksDB will attempt to detect any data losses or corruptions in DB files
+    /// and return an error to the user, either at DB::Open time or later during DB operation.
+    /// The exception to this policy is the WAL file, whose recovery is controlled by the
+    /// wal_recovery_mode option.
+    ///
+    /// Best-efforts recovery (this option set to true) signals a preference for opening the
+    /// DB to any point-in-time valid state for each column family, including the empty/new
+    /// state, versus the default of returning non-WAL data losses to the user as errors. In
+    /// terms of RocksDB user data, this is like applying
+    /// WALRecoveryMode::kPointInTimeRecovery to each column family rather than just the WAL.
+    ///
+    /// The behavior changes in the presence of "AtomicGroup"s in the MANIFEST, which is
+    /// currently only the case when `atomic_flush == true`. In that case, all pre-existing
+    /// CFs must recover the atomic group in order for that group to be applied in an
+    /// all-or-nothing manner. This means that unused/inactive CF(s) with invalid filesystem
+    /// state can block recovery of all other CFs at an atomic group.
+    ///
+    /// Best-efforts recovery (BER) is specifically designed to recover a DB with files that
+    /// are missing or truncated to some smaller size, such as the result of an incomplete DB
+    /// "physical" (FileSystem) copy. BER can also detect when an SST file has been replaced
+    /// with a different one of the same size (assuming SST unique IDs are tracked in DB
+    /// manifest). BER is not yet designed to produce a usable DB from other corruptions to DB
+    /// files (which should generally be detectable by DB::VerifyChecksum()), and BER does not
+    /// yet attempt to recover any WAL files.
+    ///
+    /// For example, if an SST or blob file referenced by the MANIFEST is missing, BER might
+    /// be able to find a set of files corresponding to an old "point in time" version of the
+    /// column family, possibly from an older MANIFEST file. Besides complete "point in time"
+    /// version, an incomplete version with only a suffix of L0 files missing can also be
+    /// recovered to if the versioning history doesn't include an atomic flush.  From the
+    /// users' perspective, missing a suffix of L0 files means missing the user's most
+    /// recently written data. So the remaining available files still presents a valid point
+    /// in time view, although for some previous time. It's not done for atomic flush because
+    /// that guarantees a consistent view across column families. We cannot guarantee that if
+    /// recovering an incomplete version. Some other kinds of DB files (e.g. CURRENT, LOCK,
+    /// IDENTITY) are either ignored or replaced with BER, or quietly fixed regardless of BER
+    /// setting. BER does require at least one valid MANIFEST to recover to a non-trivial DB
+    /// state, unlike `ldb repair`.
+    ///
+    /// Default: false
+    pub fn set_best_efforts_recovery(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_best_efforts_recovery(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `best_efforts_recovery` option.
+    pub fn get_best_efforts_recovery(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_best_efforts_recovery(self.inner) != 0 }
+    }
+
+    /// If max_bgerror_resume_count is >= 2, db resume is called multiple times. This option
+    /// decides how long to wait to retry the next resume if the previous resume fails and
+    /// satisfy redo resume conditions.
+    ///
+    /// Default: 1000000 (microseconds).
+    pub fn set_bgerror_resume_retry_interval(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_bgerror_resume_retry_interval(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `bgerror_resume_retry_interval` option.
+    pub fn get_bgerror_resume_retry_interval(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_bgerror_resume_retry_interval(self.inner) }
+    }
+
+    /// Number of direct-write blob partitions for this column family. Requires
+    /// enable_blob_direct_write = true.
+    ///
+    /// If blob_direct_write_partition_strategy is null, partition selection uses the default
+    /// round-robin strategy.
+    ///
+    /// Default: 1
+    ///
+    /// Not dynamically changeable through the SetOptions() API.
+    pub fn set_blob_direct_write_partitions(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_options_set_blob_direct_write_partitions(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `blob_direct_write_partitions` option.
+    pub fn get_blob_direct_write_partitions(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_blob_direct_write_partitions(self.inner) }
+    }
+
+    /// Enable/disable per key-value checksum protection for in memory blocks.
+    ///
+    /// Checksum is constructed when a block is loaded into memory and verification is done
+    /// for each key read from the block. This is useful for detecting in-memory data
+    /// corruption. Note that this feature has a non-trivial negative impact on read
+    /// performance. Different values of the option have similar performance impact, but
+    /// different memory cost and corruption detection probability (e.g. 1 byte gives 255/256
+    /// chance for detecting a corruption).
+    ///
+    /// Default: 0 (no protection) Supported values: 0, 1, 2, 4, 8. Dynamically changeable
+    /// through the SetOptions() API.
+    pub fn set_block_protection_bytes_per_key(&mut self, val: u8) {
+        unsafe {
+            ffi::rocksdb_options_set_block_protection_bytes_per_key(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `block_protection_bytes_per_key` option.
+    pub fn get_block_protection_bytes_per_key(&self) -> u8 {
+        unsafe { ffi::rocksdb_options_get_block_protection_bytes_per_key(self.inner) }
+    }
+
+    /// For leveled compaction, RocksDB may compact a file at the bottommost level if it can
+    /// compact away data that were protected by some snapshot. The compaction reason in LOG
+    /// for this kind of compactions is "BottommostFiles". Usually such compaction can happen
+    /// as soon as a relevant snapshot is released. This option allows user to delay such
+    /// compactions. A file is qualified for "BottommostFiles" compaction if it is at least
+    /// "bottommost_file_compaction_delay" seconds old.
+    ///
+    /// Default: 0 (no delay) Dynamically changeable through the SetOptions() API.
+    pub fn set_bottommost_file_compaction_delay(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_options_set_bottommost_file_compaction_delay(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `bottommost_file_compaction_delay` option.
+    pub fn get_bottommost_file_compaction_delay(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_bottommost_file_compaction_delay(self.inner) }
+    }
+
+    /// If either DBOptions::allow_ingest_behind or this option is set to true, this column
+    /// family will prepare for ingesting files to the last level (IngestExternalFiles() with
+    /// ingest_behind=true). Users should set only this option since
+    /// DBOptions::allow_ingest_behind is deprecated.
+    ///
+    /// Specifically, preparing a column family for ingesting files to the last level has the
+    /// following effects:
+    /// - Disables some internal optimizations around SST file compression.
+    /// - Reserves the last level for ingested files only.
+    /// - Compaction will not include any file from the last level.
+    /// - Compaction will preserve necessary tombstones that can apply on top of ingested
+    ///   files.
+    ///
+    /// Note that only Universal Compaction supports cf_allow_ingest_behind. `num_levels`
+    /// should be >= 3 if this option is turned on.
+    ///
+    /// Note that this option needs to be set to true before any write to the CF. It's
+    /// recommended to set the option to true since CF creation. Otherwise, ingestion with
+    /// ingest_behind = true might fail. Once file ingestions are done, the option should be
+    /// flipped to false. Flipping this option to false allows the CF to disable the behavior
+    /// changes detailed above and resume more efficient operation.
+    ///
+    /// Default: false Immutable.
+    pub fn set_cf_allow_ingest_behind(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_cf_allow_ingest_behind(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `cf_allow_ingest_behind` option.
+    pub fn get_cf_allow_ingest_behind(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_cf_allow_ingest_behind(self.inner) != 0 }
+    }
+
+    /// DEPRECATED: This option might be removed in a future release.
+    ///
+    /// If true, during compaction, RocksDB will count the number of entries read and compare
+    /// it against the number of entries in the compaction input files. This is intended to
+    /// add protection against corruption during compaction. Note that
+    /// - this verification is not done for compactions during which a compaction filter
+    ///   returns kRemoveAndSkipUntil, and
+    /// - the number of range deletions is not verified.
+    ///
+    /// The option is here to turn the feature off in case this new validation feature has a
+    /// bug. The option may be removed in the future once the feature is stable.
+    ///
+    /// Default: true
+    pub fn set_compaction_verify_record_count(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_compaction_verify_record_count(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `compaction_verify_record_count` option.
+    pub fn get_compaction_verify_record_count(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_compaction_verify_record_count(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL When this field is set, all SST files without an explicitly set
+    /// temperature will be treated as if they have this temperature for file reading
+    /// accounting purpose, such as io statistics, io perf context.
+    ///
+    /// Not dynamically changeable; change requires DB restart.
+    pub fn set_default_temperature(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_default_temperature(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `default_temperature` option.
+    pub fn get_default_temperature(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_default_temperature(self.inner) }
+    }
+
+    /// EXPERIMENTAL When no other option such as last_level_temperature determines the
+    /// temperature of a new SST file, it will be written with this temperature, which can be
+    /// set differently for each column family.
+    ///
+    /// Dynamically changeable through the SetOptions() API
+    pub fn set_default_write_temperature(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_default_write_temperature(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `default_write_temperature` option.
+    pub fn get_default_write_temperature(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_default_write_temperature(self.inner) }
+    }
+
+    /// The limited write rate to DB if soft_pending_compaction_bytes_limit or
+    /// level0_slowdown_writes_trigger is triggered, or we are writing to the last mem table
+    /// allowed and we allow more than 3 mem tables. It is calculated using size of user write
+    /// requests before compression. RocksDB may decide to slow down more if the compaction
+    /// still gets behind further. If the value is 0, we will infer a value from
+    /// `rater_limiter` value if it is not empty, or 16MB if `rater_limiter` is empty. Note
+    /// that if users change the rate in `rate_limiter` after DB is opened,
+    /// `delayed_write_rate` won't be adjusted.
+    ///
+    /// Unit: byte per second.
+    ///
+    /// Default: 0
+    ///
+    /// Dynamically changeable through SetDBOptions() API.
+    pub fn set_delayed_write_rate(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_delayed_write_rate(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `delayed_write_rate` option.
+    pub fn get_delayed_write_rate(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_delayed_write_rate(self.inner) }
+    }
+
+    /// Setting this option to true disallows ordinary writes to the column family and it can
+    /// only be populated through import and ingestion. It is intended to protect "ingestion
+    /// only" column families. This option is not currently supported on the default column
+    /// family because of error handling challenges analogous to
+    /// <https://github.com/facebook/rocksdb/issues/13429>
+    ///
+    /// This option is not mutable with SetOptions(). It can be changed between DB::Open()
+    /// calls, but open will fail if recovering WAL writes to a CF with this option set.
+    pub fn set_disallow_memtable_writes(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_disallow_memtable_writes(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `disallow_memtable_writes` option.
+    pub fn get_disallow_memtable_writes(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_disallow_memtable_writes(self.inner) != 0 }
+    }
+
+    /// If true, then print malloc stats together with rocksdb.stats when printing to LOG.
+    /// DEFAULT: false
+    pub fn get_dump_malloc_stats(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_dump_malloc_stats(self.inner) != 0 }
+    }
+
+    /// When enabled, values >= min_blob_size are written directly to blob files during the
+    /// write path and replaced in WAL and memtable with BlobIndex references.
+    ///
+    /// Requires enable_blob_files = true. Experimental reduced-scope v1 restrictions. These
+    /// limitations keep the v1 implementation intentionally small; follow-up PRs are expected
+    /// to improve feature compatibility over time:
+    /// - only supports the ordered single-memtable-writer path; unordered, pipelined,
+    ///   two_write_queues, and allow_concurrent_memtable_write are not supported.
+    /// - crash recovery only supports blob files that were already made manifest-visible by
+    ///   flush/SST creation; WAL replay of active direct-write blob files is not currently
+    ///   supported.
+    /// - checkpoint/backup/live-files enumeration must flush pending direct-write state
+    ///   first; APIs that intentionally skip the flush, or run while WAL is locked, can
+    ///   return NotSupported.
+    /// - not compatible with MemPurge or user-defined timestamps.
+    /// - DB::IngestWriteBatchWithIndex() is not supported while any live column family
+    ///   enables this option.
+    /// - read-only and secondary opens can read flushed/manifest-visible blob files, but do
+    ///   not resolve still-active direct-write blob files.
+    ///
+    /// Default: false
+    ///
+    /// Not dynamically changeable through the SetOptions() API.
+    pub fn set_enable_blob_direct_write(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_enable_blob_direct_write(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `enable_blob_direct_write` option.
+    pub fn get_enable_blob_direct_write(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_enable_blob_direct_write(self.inner) != 0 }
+    }
+
+    /// If true, then the status of the threads involved in this DB will be tracked and
+    /// available via GetThreadList() API.
+    ///
+    /// Default: false
+    pub fn set_enable_thread_tracking(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_enable_thread_tracking(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `enable_thread_tracking` option.
+    pub fn get_enable_thread_tracking(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_enable_thread_tracking(self.inner) != 0 }
+    }
+
+    /// DEPRECATED: This option might be removed in a future release.
+    ///
+    /// If set to false, when compaction or flush sees a SingleDelete followed by a Delete for
+    /// the same user key, compaction job will not fail. Otherwise, compaction job will fail.
+    /// This is a temporary option to help existing use cases migrate, and will be removed in
+    /// a future release. Warning: do not set to false unless you are trying to migrate
+    /// existing data in which the contract of single delete
+    /// (<https://github.com/facebook/rocksdb/wiki/Single-Delete>) is not enforced, thus has
+    /// Delete mixed with SingleDelete for the same user key. Violation of the contract leads
+    /// to undefined behaviors with high possibility of data inconsistency, e.g. deleted old
+    /// data become visible again, etc.
+    pub fn set_enforce_single_del_contracts(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_enforce_single_del_contracts(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `enforce_single_del_contracts` option.
+    pub fn get_enforce_single_del_contracts(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_enforce_single_del_contracts(self.inner) != 0 }
+    }
+
+    /// If true and a WriteBufferManager is configured, RocksDB will check
+    /// WriteBufferManager::ShouldFlush() during WAL recovery and schedule flushes when
+    /// needed. This prevents OOM when multiple RocksDB instances share a WriteBufferManager
+    /// and one instance is recovering from WAL.
+    ///
+    /// When triggered, all column families with non-empty memtables are scheduled for flush,
+    /// which may produce smaller L0 files in some column families. This also overrides
+    /// `avoid_flush_during_recovery`: once a WBM-triggered flush occurs mid-recovery, all
+    /// remaining non-empty memtables will be flushed at the end of recovery as well.
+    ///
+    /// DEFAULT: true
+    pub fn set_enforce_write_buffer_manager_during_recovery(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_enforce_write_buffer_manager_during_recovery(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `enforce_write_buffer_manager_during_recovery` option.
+    pub fn get_enforce_write_buffer_manager_during_recovery(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_options_get_enforce_write_buffer_manager_during_recovery(self.inner) != 0
+        }
+    }
+
+    /// EXPERIMENTAL When this is true, save file system metadata (if supported by the FS) for
+    /// SST files added to the DB in the MANIFEST, and use it to accelerate re-opening of
+    /// those files on DB open. This will help cut down DB open latency on remote storage
+    /// systems.
+    pub fn set_fast_sst_open(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_fast_sst_open(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `fast_sst_open` option.
+    pub fn get_fast_sst_open(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_fast_sst_open(self.inner) != 0 }
+    }
+
+    /// DEPRECATED: This option might be removed in a future release.
+    ///
+    /// If true, during memtable flush, RocksDB will validate total entries read in flush,
+    /// total entries written in the SST and compare them with counter of keys added.
+    ///
+    /// The option is here to turn the feature off in case this new validation feature has a
+    /// bug. The option may be removed in the future once the feature is stable.
+    ///
+    /// Default: true
+    pub fn set_flush_verify_memtable_count(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_flush_verify_memtable_count(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `flush_verify_memtable_count` option.
+    pub fn get_flush_verify_memtable_count(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_flush_verify_memtable_count(self.inner) != 0 }
+    }
+
+    /// For a given catch up attempt, this option specifies the number of times to tail the
+    /// MANIFEST and try to install a new, consistent  version before giving up. Though it
+    /// should be extremely rare, the catch up may fail if the leader is mutating the LSM at a
+    /// very high rate and the follower is unable to get a consistent view. Default to 10
+    /// attempts
+    pub fn set_follower_catchup_retry_count(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_follower_catchup_retry_count(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `follower_catchup_retry_count` option.
+    pub fn get_follower_catchup_retry_count(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_follower_catchup_retry_count(self.inner) }
+    }
+
+    /// Time to wait between consecutive catch up attempts Default 100ms
+    pub fn set_follower_catchup_retry_wait_ms(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_follower_catchup_retry_wait_ms(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `follower_catchup_retry_wait_ms` option.
+    pub fn get_follower_catchup_retry_wait_ms(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_follower_catchup_retry_wait_ms(self.inner) }
+    }
+
+    /// When a RocksDB database is opened in follower mode, this option is set by the user to
+    /// request the frequency of the follower attempting to refresh its view of the leader.
+    /// RocksDB may choose to trigger catch ups more frequently if it detects any changes in
+    /// the database state. Default every 10s.
+    pub fn set_follower_refresh_catchup_period_ms(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_follower_refresh_catchup_period_ms(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `follower_refresh_catchup_period_ms` option.
+    pub fn get_follower_refresh_catchup_period_ms(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_follower_refresh_catchup_period_ms(self.inner) }
+    }
+
+    /// In debug mode, RocksDB runs consistency checks on the LSM every time the LSM changes
+    /// (Flush, Compaction, AddFile). When this option is true, these checks are also enabled
+    /// in release mode. These checks were historically disabled in release mode, but are now
+    /// enabled by default for proactive corruption detection. The CPU overhead is negligible
+    /// for normal mixed operations but can slow down saturated writing. See
+    /// Options::DisableExtraChecks(). Default: true
+    pub fn set_force_consistency_checks(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_force_consistency_checks(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `force_consistency_checks` option.
+    pub fn get_force_consistency_checks(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_force_consistency_checks(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL If this option is set, when creating the last level files, pass this
+    /// temperature to FileSystem used. Should be no-op for default FileSystem and users need
+    /// to plug in their own FileSystem to take advantage of it. Currently only compatible
+    /// with universal compaction.
+    ///
+    /// Dynamically changeable through the SetOptions() API
+    pub fn set_last_level_temperature(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_last_level_temperature(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `last_level_temperature` option.
+    pub fn get_last_level_temperature(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_last_level_temperature(self.inner) }
+    }
+
+    /// The number of bytes to prefetch when reading the DB manifest and WAL files during
+    /// DB::Open (and variants). This is mostly useful for reading a remotely located log, as
+    /// it can save the number of round-trips. If 0, then the prefetching is disabled.
+    ///
+    /// Default: 0
+    pub fn set_log_readahead_size(&mut self, val: usize) {
+        unsafe {
+            ffi::rocksdb_options_set_log_readahead_size(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `log_readahead_size` option.
+    pub fn get_log_readahead_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_log_readahead_size(self.inner) }
+    }
+
+    /// It indicates, which lowest cache tier we want to use for a certain DB. Currently we
+    /// support volatile_tier and non_volatile_tier. They are layered. By setting it to
+    /// kVolatileTier, only the block cache (current implemented volatile_tier) is used. So
+    /// cache entries will not spill to secondary cache (current implemented
+    /// non_volatile_tier), and block cache lookup misses will not lookup in the secondary
+    /// cache. When kNonVolatileBlockTier is used, we use both block cache and secondary
+    /// cache.
+    ///
+    /// Default: kNonVolatileBlockTier
+    pub fn set_lowest_used_cache_tier(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_lowest_used_cache_tier(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `lowest_used_cache_tier` option.
+    pub fn get_lowest_used_cache_tier(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_lowest_used_cache_tier(self.inner) }
+    }
+
+    /// It defines how many times DB::Resume() is called by a separate thread when background
+    /// retryable IO Error happens. When background retryable IO Error happens, SetBGError is
+    /// called to deal with the error. If the error can be auto-recovered (e.g., retryable IO
+    /// Error during Flush or WAL write), then db resume is called in background to recover
+    /// from the error. If this value is 0 or negative, DB::Resume() will not be called
+    /// automatically.
+    ///
+    /// Default: INT_MAX
+    pub fn set_max_bgerror_resume_count(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_max_bgerror_resume_count(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `max_bgerror_resume_count` option.
+    pub fn get_max_bgerror_resume_count(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_max_bgerror_resume_count(self.inner) }
+    }
+
+    /// Maximum interval in seconds between periodic compaction trigger checks. The periodic
+    /// trigger re-evaluates compaction scores for all column families, which is necessary for
+    /// features like read-triggered compaction and time-based compaction to work on a "quiet"
+    /// DB with no writes.
+    ///
+    /// This is an upper bound: the actual check interval may be reduced to align with
+    /// stats_dump_period_sec, stats_persist_period_sec, or per-CF time-based compaction
+    /// intervals (periodic_compaction_seconds, ttl, etc.).
+    ///
+    /// Note: this option controls how often RocksDB *checks* whether compaction is needed. It
+    /// is different from the CF option `periodic_compaction_seconds` which controls the *age
+    /// threshold* at which SST files become eligible for periodic compaction.
+    ///
+    /// The minimum effective period is 1 second (values below 1 are clamped to 1). Setting
+    /// this to 0 results in the most aggressive 1-second polling.
+    ///
+    /// Default: 43200 (12 hours)
+    ///
+    /// Dynamically changeable through SetDBOptions() API.
+    pub fn set_max_compaction_trigger_wakeup_seconds(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_max_compaction_trigger_wakeup_seconds(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `max_compaction_trigger_wakeup_seconds` option.
+    pub fn get_max_compaction_trigger_wakeup_seconds(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_max_compaction_trigger_wakeup_seconds(self.inner) }
+    }
+
+    /// This option mostly replaces max_manifest_file_size to control an auto-tuned balance of
+    /// manifest write amplification and space amplification. A new manifest file is created
+    /// with the "compacted" contents of the old one when current_manifest_size >
+    /// max(max_manifest_file_size, est_compacted_manifest_size * (1 +
+    /// max_manifest_space_amp_pct/100))
+    ///
+    /// where est_compacted_manifest_size is an estimate of how big a new compacted version of
+    /// the current manifest would be. Currently, the estimate used is the last newly-written
+    /// manifest, in its "compacted" form.
+    ///
+    /// Space amplification in the manifest file might be less of a concern for primary
+    /// storage space and more of a concern for DB recover time and size of backup files that
+    /// aren't incremental between backups. To minimize manifest churn on initial DB
+    /// population, setting max_manifest_file_size to something not too small, like 1MB,
+    /// should suffice. Similarly, write amp on the manifest file is likely not a direct
+    /// concern but completed compactions and flushes cannot (currently) be committed while
+    /// the (relatively small) manifest file is being compacted. Manifest compactions should
+    /// not interfere with user write latency or throughput unless the DB is chronically
+    /// stalling or close to stalling writes already.
+    ///
+    /// For this option to have a meaningful effect, it is recommended to set
+    /// max_manifest_file_size to something modest like 1MB. Then we can interpret values for
+    /// this option as follows, starting with minimum space amp and maximum write amp:
+    /// - 0 - Every manifest write (flush, compaction, etc.) generates a whole new manifest.
+    ///   Only useful for testing.
+    /// - very small - Doesn't take many manifest writes to generate a whole new manifest.
+    /// - 100 - In a DB with pretty consistent number of SST files, etc., achieves about 1.0
+    ///   write amp (writing about 2x the theoretical minimum) and a max of about 1.0 space
+    ///   amp (manifest up to 2x the compacted size).
+    /// - 500 - Recommended and default: 0.2 write amp and up to roughly 5.0 space amp.
+    /// - 10000 - 0.01 write amp and up to 100 space amp on the manifest.
+    ///
+    /// This option is mutable with SetDBOptions(), taking effect on the next manifest write
+    /// (e.g. completed DB compaction or flush).
+    pub fn set_max_manifest_space_amp_pct(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_max_manifest_space_amp_pct(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `max_manifest_space_amp_pct` option.
+    pub fn get_max_manifest_space_amp_pct(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_max_manifest_space_amp_pct(self.inner) }
+    }
+
+    /// The maximum limit of number of bytes that are written in a single batch of WAL or
+    /// memtable write. It is followed when the leader write size is larger than 1/8 of this
+    /// limit.
+    ///
+    /// Default: 1 MB
+    pub fn set_max_write_batch_group_size_bytes(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_max_write_batch_group_size_bytes(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `max_write_batch_group_size_bytes` option.
+    pub fn get_max_write_batch_group_size_bytes(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_max_write_batch_group_size_bytes(self.inner) }
+    }
+
+    /// RocksDB will try to flush the current memtable after the number of range deletions is
+    /// \>= this limit. For workloads with many range deletions, limiting the number of range
+    /// deletions in memtable can help prevent performance degradation and/or OOM caused by
+    /// too many range tombstones in a single memtable.
+    ///
+    /// Default: 0 (disabled)
+    ///
+    /// Dynamically changeable through SetOptions() API
+    pub fn set_memtable_max_range_deletions(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_options_set_memtable_max_range_deletions(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `memtable_max_range_deletions` option.
+    pub fn get_memtable_max_range_deletions(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_memtable_max_range_deletions(self.inner) }
+    }
+
+    /// Enable memtable per key-value checksum protection.
+    ///
+    /// Each entry in memtable will be suffixed by a per key-value checksum. This options
+    /// determines the size of such checksums.
+    ///
+    /// It is suggested to turn on write batch per key-value checksum protection together with
+    /// this option, so that the checksum computation is done outside of writer threads
+    /// (memtable kv checksum can be computed from write batch checksum) See
+    /// WriteOptions::protection_bytes_per_key for more detail.
+    ///
+    /// Default: 0 (no protection) Supported values: 0, 1, 2, 4, 8. Dynamically changeable
+    /// through the SetOptions() API.
+    pub fn set_memtable_protection_bytes_per_key(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_options_set_memtable_protection_bytes_per_key(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `memtable_protection_bytes_per_key` option.
+    pub fn get_memtable_protection_bytes_per_key(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_memtable_protection_bytes_per_key(self.inner) }
+    }
+
+    /// Enables additional integrity checks during seek. Specifically, for skiplist-based
+    /// memtables, key checksum validation could be enabled during seek optionally. This is
+    /// helpful to detect corrupted memtable keys during reads. Enabling this feature incurs a
+    /// performance overhead due to additional key checksum validation during memtable seek
+    /// operation. This option depends on memtable_protection_bytes_per_key to be non zero. If
+    /// memtable_protection_bytes_per_key is zero, no validation is performed.
+    pub fn set_memtable_verify_per_key_checksum_on_seek(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_memtable_verify_per_key_checksum_on_seek(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `memtable_verify_per_key_checksum_on_seek` option.
+    pub fn get_memtable_verify_per_key_checksum_on_seek(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_options_get_memtable_verify_per_key_checksum_on_seek(self.inner) != 0
+        }
+    }
+
+    /// Enable whole key bloom filter in memtable. Note this will only take effect if
+    /// memtable_prefix_bloom_size_ratio is not 0. Enabling whole key filtering can
+    /// potentially reduce CPU usage for point-look-ups.
+    ///
+    /// Default: false (disabled)
+    ///
+    /// Dynamically changeable through SetOptions() API
+    pub fn get_memtable_whole_key_filtering(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_memtable_whole_key_filtering(self.inner) != 0 }
+    }
+
+    /// When DB files other than SST, blob and WAL files are created, use this filesystem
+    /// temperature. (See also `wal_write_temperature` and various `*_temperature` CF
+    /// options.) When not `kUnknown`, this overrides any temperature set by
+    /// OptimizeForManifestWrite functions.
+    pub fn set_metadata_write_temperature(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_metadata_write_temperature(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `metadata_write_temperature` option.
+    pub fn get_metadata_write_temperature(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_metadata_write_temperature(self.inner) }
+    }
+
+    /// EXPERIMENTAL
+    ///
+    /// During forward or reverse iteration, when this many or more strictly contiguous point
+    /// tombstones (kTypeDeletion, kTypeDeletionWithTimestamp, kTypeSingleDeletion) are
+    /// encountered with no live keys between them, a range tombstone [first_tombstone_key,
+    /// next_live_key) is inserted into the current mutable memtable (only if memtable is not
+    /// empty). This is a logically redundant entry that does not change any data, but
+    /// optimizes future iterators by potentially skipping a large number of tombstone scans.
+    ///
+    /// This optimization is best-effort and is currently disabled for iterator configurations
+    /// that may not expose all interior live keys, including:
+    /// - user-defined timestamp reads without full visibility (for example,
+    ///   ReadOptions::iter_start_ts or a non-max ReadOptions::timestamp)
+    /// - prefix extractor reads that are neither total-order (ReadOptions::total_order_seek
+    ///   / ReadOptions::auto_prefix_mode) nor bounded by ReadOptions::prefix_same_as_start
+    ///
+    /// Even if the above restrictions are met, there are still scenarios where a converted
+    /// range tombstone may be discarded:
+    /// - The snapshot's active mutable memtable has already become immutable.
+    /// - The iterator's snapshot seq is below the active memtable's earliest sequence
+    ///   number.
+    /// - A range tombstone covering [first_tombstone_key, next_live_key) is already present
+    ///   in the memtable.
+    /// - A WritePrepared/WriteUnprepared transaction read callback is in use and the
+    ///   snapshot seq is at or above its min uncommitted seq.
+    /// - An IngestExternalFile call is currently in flight on this column family OR the
+    ///   inserted range tombstone seqno would be lower than the ingested file seqno.
+    ///
+    /// Read-write iterators using ReadOptions::table_filter are rejected while this option is
+    /// enabled, see more details in ReadOptions::table_filter comments.
+    ///
+    /// Set to 0 to disable.
+    ///
+    /// Dynamically changeable through SetOptions() API
+    pub fn set_min_tombstones_for_range_conversion(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_options_set_min_tombstones_for_range_conversion(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `min_tombstones_for_range_conversion` option.
+    pub fn get_min_tombstones_for_range_conversion(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_min_tombstones_for_range_conversion(self.inner) }
+    }
+
+    /// EXPERIMENTAL: If true, RocksDB can reduce recovery work after a clean shutdown, which
+    /// may reduce DB::Open latency on warm reopens, especially on storage where metadata
+    /// appends are expensive.
+    ///
+    /// Best-effort optimization: if it is disabled or unavailable, RocksDB falls back to the
+    /// standard recovery path.
+    ///
+    /// Temporary rollout / kill switch for an optimization that is intended to be correct and
+    /// eventually always enabled. Mutable via SetDBOptions().
+    pub fn set_optimize_manifest_for_recovery(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_optimize_manifest_for_recovery(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `optimize_manifest_for_recovery` option.
+    pub fn get_optimize_manifest_for_recovery(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_optimize_manifest_for_recovery(self.inner) != 0 }
+    }
+
+    /// After writing every SST file, reopen it and read all the keys. Checks the hash of all
+    /// of the keys and values written versus the keys in the file and signals a corruption if
+    /// they do not match
+    ///
+    /// Default: false
+    ///
+    /// Dynamically changeable through SetOptions() API
+    pub fn set_paranoid_file_checks(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_paranoid_file_checks(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `paranoid_file_checks` option.
+    pub fn get_paranoid_file_checks(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_paranoid_file_checks(self.inner) != 0 }
+    }
+
+    /// Enables additional integrity checks during reads/scans. Specifically, for
+    /// skiplist-based memtables, key ordering validation could be enabled optionally. This is
+    /// helpful to detect corrupted memtable keys during reads. Enabling this feature incurs a
+    /// performance overhead due to additional comparison during memtable lookup.
+    pub fn set_paranoid_memory_checks(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_paranoid_memory_checks(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `paranoid_memory_checks` option.
+    pub fn get_paranoid_memory_checks(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_paranoid_memory_checks(self.inner) != 0 }
+    }
+
+    /// If true, automatically persist stats to a hidden column family (column family name:
+    /// ___rocksdb_stats_history___) every stats_persist_period_sec seconds; otherwise, write
+    /// to an in-memory struct. User can query through `GetStatsHistory` API. If user attempts
+    /// to create a column family with the same name on a DB which have previously set
+    /// persist_stats_to_disk to true, the column family creation will fail, but the hidden
+    /// column family will survive, as well as the previously persisted statistics. When
+    /// peristing stats to disk, the stat name will be limited at 100 bytes. Default: false
+    pub fn set_persist_stats_to_disk(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_persist_stats_to_disk(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `persist_stats_to_disk` option.
+    pub fn get_persist_stats_to_disk(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_persist_stats_to_disk(self.inner) != 0 }
+    }
+
+    /// UNDER CONSTRUCTION -- DO NOT USE When the user-defined timestamp feature is enabled,
+    /// this flag controls whether the user-defined timestamps will be persisted.
+    ///
+    /// When it's false, the user-defined timestamps will be removed from the user keys when
+    /// data is flushed from memtables to SST files. Other places that user keys can be
+    /// persisted like file boundaries in file metadata and blob files go through a similar
+    /// process. There are two major motivations for this flag:
+    /// - backward compatibility: if the user later decides to disable the user-defined
+    ///   timestamp feature for the column family, these SST files can be handled by a user
+    ///   comparator that is not aware of user-defined timestamps.
+    /// - enable user-defined timestamp feature for an existing column family while set this
+    ///   flag to be `false`: user keys in the newly generated SST files are of the same
+    ///   format as the existing SST files.
+    ///
+    /// Currently only user comparator that formats user-defined timesamps as uint64_t via
+    /// using one of the RocksDB provided comparator `ComparatorWithU64TsImpl` are supported.
+    ///
+    /// When setting this flag to `false`, users should also call
+    /// `DB::IncreaseFullHistoryTsLow` to set a cutoff timestamp for flush. RocksDB refrains
+    /// from flushing a memtable with data still above the cutoff timestamp with best effort.
+    /// One limitation of this best effort is that when `max_write_buffer_number` is equal to
+    /// or smaller than 2, RocksDB will not attempt to retain user-defined timestamps, all
+    /// flush jobs continue normally.
+    ///
+    /// Users can do user-defined multi-versioned read above the cutoff timestamp. When users
+    /// try to read below the cutoff timestamp, an error will be returned.
+    ///
+    /// Note that if WAL is enabled, unlike SST files, user-defined timestamps are persisted
+    /// to WAL even if this flag is set to `false`. The benefit of this is that user-defined
+    /// timestamps can be recovered with the caveat that users should flush all memtables so
+    /// there is no active WAL files before doing a downgrade. In order to use WAL to recover
+    /// user-defined timestamps, users of this feature would want to set both
+    /// `avoid_flush_during_shutdown` and `avoid_flush_during_recovery` to be true.
+    ///
+    /// Note that setting this flag to false is not supported in combination with atomic
+    /// flush, or concurrent memtable write enabled by `allow_concurrent_memtable_write`.
+    ///
+    /// Default: true (user-defined timestamps are persisted) Not dynamically changeable,
+    /// change it requires db restart and only compatible changes are allowed.
+    pub fn set_persist_user_defined_timestamps(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_persist_user_defined_timestamps(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `persist_user_defined_timestamps` option.
+    pub fn get_persist_user_defined_timestamps(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_persist_user_defined_timestamps(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL The feature is still in development and is incomplete. If this option is
+    /// set, when data insert time is within this time range, it will be precluded from the
+    /// last level. 0 means no key will be precluded from the last level.
+    ///
+    /// Note: when enabled, universal size amplification (controlled by option
+    /// `compaction_options_universal.max_size_amplification_percent`) calculation will
+    /// exclude the last level. As the feature is designed for tiered storage and a typical
+    /// setting is the last level is cold tier which is likely not size constrained, the size
+    /// amp is going to be only for non-last levels.
+    ///
+    /// Default: 0 (disable the feature)
+    ///
+    /// Dynamically changeable through the SetOptions() API
+    pub fn set_preclude_last_level_data_seconds(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_preclude_last_level_data_seconds(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `preclude_last_level_data_seconds` option.
+    pub fn get_preclude_last_level_data_seconds(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_preclude_last_level_data_seconds(self.inner) }
+    }
+
+    /// Historically, when prefix_extractor != nullptr, iterators have an unfortunate default
+    /// semantics of *possibly* only returning data within the same prefix. To avoid "spooky
+    /// action at a distance," iterator bounds should come from the instantiation or seeking
+    /// of the iterator, not from a mutable column family option.
+    ///
+    /// When set to true, it is as if every iterator is created with total_order_seek=true and
+    /// only auto_prefix_mode=true and prefix_same_as_start=true can take advantage of prefix
+    /// seek optimizations.
+    pub fn set_prefix_seek_opt_in_only(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_prefix_seek_opt_in_only(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `prefix_seek_opt_in_only` option.
+    pub fn get_prefix_seek_opt_in_only(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_prefix_seek_opt_in_only(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL If this option is set, it will preserve the internal time information
+    /// about the data until it's older than the specified time here. Internally the time
+    /// information is a map between sequence number and time, which is the same as
+    /// `preclude_last_level_data_seconds`. But it won't preclude the data from the last level
+    /// and the data in the last level won't have the sequence number zeroed out. Internally,
+    /// rocksdb would sample the sequence number to time pair and store that in SST property
+    /// "rocksdb.seqno.time.map". The information is currently only used for tiered storage
+    /// compaction (option `preclude_last_level_data_seconds`).
+    ///
+    /// Note: if both `preclude_last_level_data_seconds` and this option is set, it will
+    /// preserve the max time of the 2 options and compaction still preclude the data based on
+    /// `preclude_last_level_data_seconds`. The higher the preserve_time is, the less the
+    /// sampling frequency will be ( which means less accuracy of the time estimation).
+    ///
+    /// Default: 0 (disable the feature)
+    ///
+    /// Dynamically changeable through the SetOptions() API
+    pub fn set_preserve_internal_time_seconds(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_preserve_internal_time_seconds(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `preserve_internal_time_seconds` option.
+    pub fn get_preserve_internal_time_seconds(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_preserve_internal_time_seconds(self.inner) }
+    }
+
+    /// Requested maximum number of threads in the shared read I/O executor. A DB open can
+    /// increase the executor to this size but cannot reduce it. Used exclusively for
+    /// asynchronous read requests (e.g. GetAsync, MultiGetAsync).
+    pub fn set_read_io_executor_threads(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_read_io_executor_threads(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `read_io_executor_threads` option.
+    pub fn get_read_io_executor_threads(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_read_io_executor_threads(self.inner) }
+    }
+
+    /// When set to a positive value, enables read-triggered compaction. An SST file is marked
+    /// for compaction when its estimated read frequency (estimated_reads / file_size) exceeds
+    /// this threshold. This helps reduce read amplification for hot keys by compacting
+    /// frequently-read files.
+    ///
+    /// Only "collapsible" reads are counted -- lookups that return NotFound (bloom filter
+    /// false positive), Delete/SingleDeletion (tombstone), or Merge (partial result). These
+    /// are reads where the file contributed no final value and compaction would eliminate the
+    /// wasted work.
+    ///
+    /// Choosing a value: the threshold balances read IO saved against the write amplification
+    /// (WA) of an extra compaction. This assumes the block-based table format is being used,
+    ///
+    /// Break-even derivation (no block cache): Let r = estimated_reads / file_size  (the
+    /// threshold) S = file_size B = block_size             (typically 4 KB) F = level fanout
+    /// (typically ~10)
+    ///
+    /// Each collapsible read wastes one data-block read = B bytes of IO. Total wasted read IO
+    /// for a file = r * S * B.
+    ///
+    /// Compaction cost: one level-L file overlaps ~F files in level L+1, so we read (1 + F)
+    /// files and write (1 + F) files. Total compaction IO = 2 * (1 + F) * S.
+    ///
+    /// Break-even when wasted read IO equals compaction IO: r * S * B = 2 * (1 + F) * S r = 2
+    /// * (1 + F) / B
+    ///
+    /// With F = 10, B = 4096:  r = 22 / 4096 ~= 0.005.
+    ///
+    /// With a block-cache hit rate h (0 <= h < 1), each collapsible read only costs (1 - h) *
+    /// B bytes of actual disk IO, so: r = 2 * (1 + F) / ((1 - h) * B)
+    ///
+    /// h = 0   -> r ~= 0.005 h = 0.5 -> r ~= 0.01 h = 0.9 -> r ~= 0.05
+    ///
+    /// A recommended starting point is 0.01, which avoids triggering compactions that cost
+    /// more IO than they save for most cache-friendly workloads, while still being responsive
+    /// enough to compact files with significant wasted reads.
+    ///
+    /// For this feature to take effect on a "quiet" DB (no writes), the DB-level option
+    /// `max_compaction_trigger_wakeup_seconds` must also be set to a non-zero value so the
+    /// periodic background job can re-evaluate files.
+    ///
+    /// Valid range: >= 0.0 (must be finite). Use 0.0 to disable.
+    ///
+    /// Dynamically changeable through SetOptions() API
+    pub fn set_read_triggered_compaction_threshold(&mut self, val: f64) {
+        unsafe {
+            ffi::rocksdb_options_set_read_triggered_compaction_threshold(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `read_triggered_compaction_threshold` option.
+    pub fn get_read_triggered_compaction_threshold(&self) -> f64 {
+        unsafe { ffi::rocksdb_options_get_read_triggered_compaction_threshold(self.inner) }
+    }
+
+    /// Sets the `remove` option.
+    pub fn set_remove(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_calculate_sst_write_lifetime_hint_set_remove(self.inner, val);
+        }
+    }
+
+    /// EXPERIMENTAL: If true, DB::Open can try to reuse the existing MANIFEST for the first
+    /// post-open metadata update instead of creating a fresh one. This can reduce warm-open
+    /// latency for DBs whose MANIFEST is expensive to rebuild.
+    ///
+    /// Best-effort optimization: even when enabled, RocksDB may still create a fresh MANIFEST
+    /// if the FileSystem does not support reopening the existing MANIFEST for append, or if
+    /// RocksDB decides reuse is unsafe. That fallback is normal behavior.
+    ///
+    /// With very small `max_manifest_file_size` settings, the reused MANIFEST can still
+    /// rotate earlier than expected after open, because RocksDB may keep a conservative
+    /// auto-tuned rotation threshold until it later refreshes its compacted-size estimate.
+    ///
+    /// Temporary rollout / kill switch while this optimization is being validated.
+    pub fn set_reuse_manifest_on_open(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_reuse_manifest_on_open(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `reuse_manifest_on_open` option.
+    pub fn get_reuse_manifest_on_open(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_reuse_manifest_on_open(self.inner) != 0 }
+    }
+
+    /// If this option is set then 1 in N blocks are compressed using a fast (lz4) and slow
+    /// (zstd) compression algorithm. The compressibility is reported as stats and the stored
+    /// data is left uncompressed (unless compression is also requested).
+    pub fn set_sample_for_compression(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_sample_for_compression(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `sample_for_compression` option.
+    pub fn get_sample_for_compression(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_sample_for_compression(self.inner) }
+    }
+
+    /// if not zero, periodically take stats snapshots and store in memory, the memory size
+    /// for stats snapshots is capped at stats_history_buffer_size Default: 1MB
+    pub fn set_stats_history_buffer_size(&mut self, val: usize) {
+        unsafe {
+            ffi::rocksdb_options_set_stats_history_buffer_size(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `stats_history_buffer_size` option.
+    pub fn get_stats_history_buffer_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_stats_history_buffer_size(self.inner) }
+    }
+
+    /// When true, guarantees WAL files have at most `wal_bytes_per_sync` bytes submitted for
+    /// writeback at any given time, and SST files have at most `bytes_per_sync` bytes pending
+    /// writeback at any given time. This can be used to handle cases where processing speed
+    /// exceeds I/O speed during file generation, which can lead to a huge sync when the file
+    /// is finished, even with `bytes_per_sync` / `wal_bytes_per_sync` properly configured.
+    ///
+    /// - If `sync_file_range` is supported it achieves this by waiting for any prior
+    ///   `sync_file_range`s to finish before proceeding. In this way, processing
+    ///   (compression, etc.) can proceed uninhibited in the gap between `sync_file_range`s,
+    ///   and we block only when I/O falls behind.
+    /// - Otherwise the `WritableFile::Sync` method is used. Note this mechanism always
+    ///   blocks, thus preventing the interleaving of I/O and processing.
+    ///
+    /// Note: Enabling this option does not provide any additional persistence guarantees, as
+    /// it may use `sync_file_range`, which does not write out metadata.
+    ///
+    /// Default: false
+    pub fn set_strict_bytes_per_sync(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_strict_bytes_per_sync(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `strict_bytes_per_sync` option.
+    pub fn get_strict_bytes_per_sync(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_strict_bytes_per_sync(self.inner) != 0 }
+    }
+
+    /// Whether to allow filesystem reads to stay under the `max_successive_merges` limit.
+    /// When true, this can lead to merge writes blocking the write path waiting on filesystem
+    /// reads.
+    ///
+    /// This option is temporary in case the recent change to disallow filesystem reads during
+    /// merge writes has a problem and users need to undo it quickly.
+    ///
+    /// Default: false
+    pub fn set_strict_max_successive_merges(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_strict_max_successive_merges(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `strict_max_successive_merges` option.
+    pub fn get_strict_max_successive_merges(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_strict_max_successive_merges(self.inner) != 0 }
+    }
+
+    /// If true, RocksDB will consider the estimated tail size (filter + index + meta blocks)
+    /// when deciding whether to cut a compaction output file. This helps prevent output files
+    /// from exceeding the target_file_size_base due to large tail blocks. When disabled, only
+    /// the data block size is considered, which may result in SST files exceeding the
+    /// target_file_size_base.
+    ///
+    /// Default: false
+    ///
+    /// Dynamically changeable through SetOptions() API
+    pub fn set_target_file_size_is_upper_bound(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_target_file_size_is_upper_bound(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `target_file_size_is_upper_bound` option.
+    pub fn get_target_file_size_is_upper_bound(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_target_file_size_is_upper_bound(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL
+    ///
+    /// If true, each new WAL will record various information about its predecessor WAL for
+    /// verification on the predecessor WAL during WAL recovery.
+    ///
+    /// It verifies the following:
+    /// - There exists at least some WAL in the DB
+    /// - It's not compatible with `RepairDB()` since this option imposes a stricter
+    ///   requirement on WAL than the DB went through `RepariDB()` can normally meet
+    /// - There exists no WAL hole where new WAL data presents while some old WAL data not
+    ///   yet obsolete is missing. The DB manifest indicates which WALs are obsolete.
+    ///
+    /// This is intended to be a better replacement to `track_and_verify_wals_in_manifest`.
+    ///
+    /// Default: false
+    pub fn set_track_and_verify_wals(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_track_and_verify_wals(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `track_and_verify_wals` option.
+    pub fn get_track_and_verify_wals(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_track_and_verify_wals(self.inner) != 0 }
+    }
+
+    /// If enabled it uses two queues for writes, one for the ones with disable_memtable and
+    /// one for the ones that also write to memtable. This allows the memtable writes not to
+    /// lag behind other writes. It can be used to optimize MySQL 2PC in which only the
+    /// commits, which are serial, write to memtable.
+    pub fn set_two_write_queues(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_two_write_queues(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `two_write_queues` option.
+    pub fn get_two_write_queues(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_two_write_queues(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL When > 0, RocksDB attempts to erase some block cache entries for files
+    /// that have become obsolete, which means they are about to be deleted. To avoid
+    /// excessive tracking, this "uncaching" process is iterative and speculative, meaning it
+    /// could incur extra background CPU effort if the file's blocks are generally not cached.
+    /// A larger number indicates more willingness to spend CPU time to maximize block cache
+    /// hit rates by erasing known-obsolete entries.
+    ///
+    /// When uncache_aggressiveness=1, block cache entries for an obsolete file are only
+    /// erased until any attempted erase operation fails because the block is not cached. Then
+    /// no further attempts are made to erase cached blocks for that file.
+    ///
+    /// For larger values, erasure is attempted until evidence incidates that the chance of
+    /// success is < 0.99^(a-1), where a = uncache_aggressiveness. For example: 2 -> Attempt
+    /// only while expecting >= 99% successful/useful erasure 11 -> 90% 69 -> 50% 110 -> 33%
+    /// 230 -> 10% 460 -> 1% 690 -> 0.1% 1000 -> 1 in 23000 10000 -> Always (for all practical
+    /// purposes) NOTE: UINT32_MAX and nearby values could take additional special meanings in
+    /// the future.
+    ///
+    /// Pinned cache entries (guaranteed present) are always erased if uncache_aggressiveness
+    /// \> 0, but are not used in predicting the chances of successful erasure of non-pinned
+    /// entries.
+    ///
+    /// NOTE: In the case of copied DBs (such as Checkpoints) sharing a block cache, it is
+    /// possible that a file becoming obsolete doesn't mean its block cache entries (shared
+    /// among copies) are obsolete. Such a scenerio is the best case for
+    /// uncache_aggressiveness = 0.
+    ///
+    /// When using allow_mmap_reads=true, this option is ignored (no un-caching).
+    ///
+    /// Once validated in production, the default will likely change to something around 300.
+    pub fn set_uncache_aggressiveness(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_options_set_uncache_aggressiveness(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `uncache_aggressiveness` option.
+    pub fn get_uncache_aggressiveness(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_uncache_aggressiveness(self.inner) }
+    }
+
+    /// Use O_DIRECT for compaction-input SST reads only, leaving user reads buffered. Useful
+    /// when sequential compaction reads would otherwise evict the hot user-read working set
+    /// from the OS page cache. When this is true and use_direct_reads is false, compaction
+    /// opens short-lived O_DIRECT readers for its input files instead of reusing the buffered
+    /// readers cached for user reads. This is the read-side analogue of
+    /// use_direct_io_for_flush_and_compaction, and the two are often paired on write-heavy
+    /// workloads.
+    ///
+    /// Scope and limits:
+    /// - DBOption scope (applies to all column families); no per-CF setting.
+    /// - Covers compaction inputs only. Blob-file reads and compaction-output verification
+    ///   (paranoid_file_checks) still use the buffered path.
+    /// - The ephemeral readers bypass the TableCache and are not counted against
+    ///   max_open_files. Non-L0 levels keep one reader open at a time; L0 opens all of a
+    ///   subcompaction's overlapping inputs at once, so with large L0 fan-in and many
+    ///   subcompactions, watch RLIMIT_NOFILE.
+    /// - Every input file is reopened per compaction, so NO_FILE_OPENS and
+    ///   TABLE_OPEN_IO_MICROS rise while this is enabled.
+    ///
+    /// The same SST can be open through both a buffered handle (user reads) and an O_DIRECT
+    /// handle (the compaction scan) at once; modern Linux handles this fine. The flag is
+    /// neutral or slightly negative for in-memory DBs or uniform random reads, so measure
+    /// before enabling.
+    ///
+    /// Has no effect when use_direct_reads is true (all reads are already O_DIRECT). Rejected
+    /// at DB::Open when allow_mmap_reads is set.
+    ///
+    /// On a filesystem without O_DIRECT support (e.g. tmpfs), DB::Open fails: it probes by
+    /// opening the MANIFEST with O_DIRECT. The probe only checks the filesystem holding the
+    /// DB directory, so if SST files live elsewhere (via db_paths/cf_paths) without O_DIRECT,
+    /// Open succeeds and the first compaction fails instead.
+    ///
+    /// Default: false
+    pub fn set_use_direct_io_for_compaction_reads(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_use_direct_io_for_compaction_reads(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `use_direct_io_for_compaction_reads` option.
+    pub fn get_use_direct_io_for_compaction_reads(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_use_direct_io_for_compaction_reads(self.inner) != 0 }
+    }
+
+    /// If true, on DB close, read back the entire MANIFEST file and validate CRC checksums
+    /// and logical record content. If corruption is detected, a fresh MANIFEST is written
+    /// from in-memory state before closing.
+    ///
+    /// This option is mutable with SetDBOptions().
+    pub fn set_verify_manifest_content_on_close(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_verify_manifest_content_on_close(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `verify_manifest_content_on_close` option.
+    pub fn get_verify_manifest_content_on_close(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_verify_manifest_content_on_close(self.inner) != 0 }
+    }
+
+    /// Bitmask enum for output verification option.
+    ///
+    /// Default: 0 (kVerifyNone)
+    ///
+    /// Dynamically changeable (as a uint32_t) through SetOptions() API.
+    pub fn set_verify_output_flags(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_verify_output_flags(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `verify_output_flags` option.
+    pub fn get_verify_output_flags(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_verify_output_flags(self.inner) }
+    }
+
+    /// If true, verifies the SST unique id between MANIFEST and actual file each time an SST
+    /// file is opened. This check ensures an SST file is not overwritten or misplaced. A
+    /// corruption error will be reported if mismatch detected, but only when MANIFEST tracks
+    /// the unique id, which starts from RocksDB version 7.3. Although the tracked internal
+    /// unique id is related to the one returned by GetUniqueIdFromTableProperties, that is
+    /// subject to change. NOTE: verification is currently only done on SST files using
+    /// block-based table format.
+    ///
+    /// Setting to false should only be needed in case of unexpected problems.
+    ///
+    /// Although an early version of this option opened all SST files for verification on
+    /// DB::Open, that is no longer guaranteed. However, as documented in an above option, if
+    /// max_open_files is -1, DB will open all files on DB::Open().
+    ///
+    /// Default: true
+    pub fn set_verify_sst_unique_id_in_manifest(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_verify_sst_unique_id_in_manifest(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `verify_sst_unique_id_in_manifest` option.
+    pub fn get_verify_sst_unique_id_in_manifest(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_verify_sst_unique_id_in_manifest(self.inner) != 0 }
+    }
+
+    /// Use this filesystem temperature when creating WAL files. When not `kUnknown`, this
+    /// overrides any temperature set by OptimizeForLogWrite functions.
+    pub fn set_wal_write_temperature(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_wal_write_temperature(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `wal_write_temperature` option.
+    pub fn get_wal_write_temperature(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_wal_write_temperature(self.inner) }
+    }
+
+    /// The maximum number of microseconds that a write operation will use a yielding spin
+    /// loop to coordinate with other write threads before blocking on a mutex.  (Assuming
+    /// write_thread_slow_yield_usec is set properly) increasing this value is likely to
+    /// increase RocksDB throughput at the expense of increased CPU usage.
+    ///
+    /// Default: 100
+    pub fn set_write_thread_max_yield_usec(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_write_thread_max_yield_usec(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `write_thread_max_yield_usec` option.
+    pub fn get_write_thread_max_yield_usec(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_write_thread_max_yield_usec(self.inner) }
+    }
+
+    /// The latency in microseconds after which a std::this_thread::yield call (sched_yield on
+    /// Linux) is considered to be a signal that other processes or threads would like to use
+    /// the current core. Increasing this makes writer threads more likely to take CPU by
+    /// spinning, which will show up as an increase in the number of involuntary context
+    /// switches.
+    ///
+    /// Default: 3
+    pub fn set_write_thread_slow_yield_usec(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_write_thread_slow_yield_usec(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `write_thread_slow_yield_usec` option.
+    pub fn get_write_thread_slow_yield_usec(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_write_thread_slow_yield_usec(self.inner) }
+    }
 }
 
 impl Default for Options {
@@ -4129,6 +6317,54 @@ impl FlushOptions {
         unsafe {
             ffi::rocksdb_flushoptions_set_wait(self.inner, c_uchar::from(wait));
         }
+    }
+
+    /// If true, the flush would proceed immediately even it means writes will stall for the
+    /// duration of the flush; if false the operation will wait until it's possible to do
+    /// flush w/o causing stall or until required flush is performed by someone else
+    /// (foreground call or background thread). Default: false
+    pub fn set_allow_write_stall(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_flushoptions_set_allow_write_stall(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `allow_write_stall` option.
+    pub fn get_allow_write_stall(&self) -> bool {
+        unsafe { ffi::rocksdb_flushoptions_get_allow_write_stall(self.inner) != 0 }
+    }
+
+    /// If true, use atomic flush to flush all column families atomically, regardless of the
+    /// DBOptions::atomic_flush setting. When used with DB::Flush() or internally via
+    /// GetLiveFilesStorageInfo(), this forces all column families to be flushed in a single
+    /// atomic operation. Default: false (uses DBOptions::atomic_flush setting).
+    pub fn set_force_atomic_flush(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_flushoptions_set_force_atomic_flush(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `force_atomic_flush` option.
+    pub fn get_force_atomic_flush(&self) -> bool {
+        unsafe { ffi::rocksdb_flushoptions_get_force_atomic_flush(self.inner) != 0 }
+    }
+
+    /// If true (and `wait` is also true), Flush() will not return until the registered
+    /// EventListener::OnFlushCompleted callbacks for the flushed memtables have finished
+    /// running. By default (false), Flush(wait=true) may return as soon as the flush result
+    /// is committed, which can be before (or while) the OnFlushCompleted callbacks execute on
+    /// the background flush thread. Set this to true when the caller needs to observe the
+    /// effects of its OnFlushCompleted listener(s) immediately after Flush() returns. Has no
+    /// effect when `wait == false`. Default: false
+    pub fn set_listener_wait(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_flushoptions_set_listener_wait(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `listener_wait` option.
+    pub fn get_listener_wait(&self) -> bool {
+        unsafe { ffi::rocksdb_flushoptions_get_listener_wait(self.inner) != 0 }
     }
 }
 
@@ -4222,6 +6458,56 @@ impl WriteOptions {
                 c_uchar::from(v),
             );
         }
+    }
+
+    /// EXPERIMENTAL
+    pub fn set_io_activity(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_writeoptions_set_io_activity(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `io_activity` option.
+    pub fn get_io_activity(&self) -> c_int {
+        unsafe { ffi::rocksdb_writeoptions_get_io_activity(self.inner) }
+    }
+
+    /// `protection_bytes_per_key` is the number of bytes used to store protection information
+    /// for each key entry. Currently supported values are zero (disabled) and eight.
+    ///
+    /// Default: zero (disabled).
+    pub fn set_protection_bytes_per_key(&mut self, val: usize) {
+        unsafe {
+            ffi::rocksdb_writeoptions_set_protection_bytes_per_key(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `protection_bytes_per_key` option.
+    pub fn get_protection_bytes_per_key(&self) -> usize {
+        unsafe { ffi::rocksdb_writeoptions_get_protection_bytes_per_key(self.inner) }
+    }
+
+    /// For file reads associated with this option, charge the internal rate limiter (see
+    /// `DBOptions::rate_limiter`) at the specified priority. The special value
+    /// `Env::IO_TOTAL` disables charging the rate limiter.
+    ///
+    /// The rate limiting is bypassed no matter this option's value for file reads on plain
+    /// tables (these can exist when `ColumnFamilyOptions::table_factory` is a
+    /// `PlainTableFactory`) and cuckoo tables (these can exist when
+    /// `ColumnFamilyOptions::table_factory` is a `CuckooTableFactory`).
+    ///
+    /// The bytes charged to rate limiter may not exactly match the file read bytes since
+    /// there are some seemingly insignificant reads, like for file headers/footers, that we
+    /// currently do not charge to rate limiter.
+    pub fn set_rate_limiter_priority(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_writeoptions_set_rate_limiter_priority(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `rate_limiter_priority` option.
+    pub fn get_rate_limiter_priority(&self) -> c_int {
+        unsafe { ffi::rocksdb_writeoptions_get_rate_limiter_priority(self.inner) }
     }
 }
 
@@ -4709,6 +6995,192 @@ impl ReadOptions {
             ffi::rocksdb_readoptions_set_iter_start_ts(self.inner, ptr, len);
         }
     }
+
+    /// For iterators, RocksDB does auto-readahead on noticing more than two sequential reads
+    /// for a table file if user doesn't provide readahead_size. The readahead starts at 8KB
+    /// and doubles on every additional read upto max_auto_readahead_size only when reads are
+    /// sequential. However at each level, if iterator moves over next file, readahead_size
+    /// starts again from 8KB.
+    ///
+    /// By enabling this option, RocksDB will do some enhancements for prefetching the data.
+    pub fn set_adaptive_readahead(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_adaptive_readahead(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `adaptive_readahead` option.
+    pub fn get_adaptive_readahead(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_adaptive_readahead(self.inner) != 0 }
+    }
+
+    /// When set, the iterator may defer loading and/or preparing the value when moving to a
+    /// different entry (i.e. during SeekToFirst/SeekToLast/Seek/ SeekForPrev/Next/Prev
+    /// operations). This can be used to save on I/O and/or CPU when the values associated
+    /// with certain keys may not be used by the application. See also
+    /// IteratorBase::PrepareValue().
+    ///
+    /// Note: this option currently only applies to 1) large values stored in blob files using
+    /// BlobDB and 2) multi-column-family iterators (CoalescingIterator and
+    /// AttributeGroupIterator). Otherwise, it has no effect.
+    ///
+    /// Default: false
+    pub fn set_allow_unprepared_value(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_allow_unprepared_value(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `allow_unprepared_value` option.
+    pub fn get_allow_unprepared_value(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_allow_unprepared_value(self.inner) != 0 }
+    }
+
+    /// When true, by default use total_order_seek = true, and RocksDB can selectively enable
+    /// prefix seek mode if won't generate a different result from total_order_seek, based on
+    /// seek key, and iterator upper bound. BUG: Using
+    /// Comparator::IsSameLengthImmediateSuccessor and SliceTransform::FullLengthEnabled to
+    /// enable prefix mode in cases where prefix of upper bound differs from prefix of seek
+    /// key has a flaw. If present in the DB, "short keys" (shorter than "full length" prefix)
+    /// can be omitted from auto_prefix_mode iteration when they would be present in
+    /// total_order_seek iteration, regardless of whether the short keys are "in domain" of
+    /// the prefix extractor. This is not an issue if no short keys are added to DB or are not
+    /// expected to be returned by such iterators. (We are also assuming the new condition on
+    /// IsSameLengthImmediateSuccessor is satisfied; see its BUG section). A bug example is in
+    /// DBTest2::AutoPrefixMode1, search for "BUG".
+    pub fn set_auto_prefix_mode(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_auto_prefix_mode(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `auto_prefix_mode` option.
+    pub fn get_auto_prefix_mode(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_auto_prefix_mode(self.inner) != 0 }
+    }
+
+    /// If auto_readahead_size is set to true, it will auto tune the readahead_size during
+    /// scans internally based on block cache data when block cache is enabled, iteration
+    /// upper bound when `iterate_upper_bound != nullptr` and prefix when
+    /// `prefix_same_as_start == true`
+    ///
+    /// Besides enabling block cache, it also requires `iterate_upper_bound != nullptr` or
+    /// `prefix_same_as_start == true` for this option to take effect
+    ///
+    /// To be specific, it does the following: (1) When `iterate_upper_bound` is specified,
+    /// trim the readahead so the readahead does not exceed iteration upper bound (2) When
+    /// `prefix_same_as_start` is set to true, trim the readahead so data blocks containing
+    /// keys that are not in the same prefix as the seek key in `Seek()` are not prefetched
+    /// - Limition: `Seek(key)` instead of `SeekToFirst()` needs to be called in order for
+    ///   this trimming to take effect
+    ///
+    /// NOTE: - Used for forward Scans only.
+    /// - If there is a backward scans, this option will be disabled internally and won't be
+    ///   enabled again if the forward scan is issued again.
+    ///
+    /// Default: true
+    pub fn get_auto_readahead_size(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_auto_readahead_size(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL
+    ///
+    /// Long-running iterators are holding onto memory and storage resources long after they
+    /// are obsolete. This setting (when enabled) will fix that problem for as long as
+    /// iterator periodically makes some progress and its supplied `read_options` was
+    /// configured with non-nullptr `snapshot` value. The feature is engineered so that the
+    /// performance impact should be negligible. We expect the default value to be true some
+    /// time in the future.
+    ///
+    /// NOTE 1: Does not have effect on TransactionDB with WRITE_PREPARED or WRITE_UNPREPARED
+    /// policies (currently incompatible).
+    ///
+    /// NOTE 2: True is not recommended if using user-defined timestamp with
+    /// persist_user_defined_timestamps=false and non-nullptr ReadOptions::timestamp or
+    /// ReadOptions::iter_start_ts, because auto-refreshing iterator will not prevent user
+    /// timestamp information from being dropped during iteration. Auto-refresh might be
+    /// disabled for this combination in the future.
+    ///
+    /// Default: false
+    pub fn set_auto_refresh_iterator_with_snapshot(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_auto_refresh_iterator_with_snapshot(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `auto_refresh_iterator_with_snapshot` option.
+    pub fn get_auto_refresh_iterator_with_snapshot(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_auto_refresh_iterator_with_snapshot(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL
+    pub fn set_io_activity(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_io_activity(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `io_activity` option.
+    pub fn get_io_activity(&self) -> c_int {
+        unsafe { ffi::rocksdb_readoptions_get_io_activity(self.inner) }
+    }
+
+    /// When the number of merge operands applied exceeds this threshold during a successful
+    /// query, the operation will return a special OK Status with subcode
+    /// kMergeOperandThresholdExceeded. Currently only applies to point lookups and is
+    /// disabled by default.
+    pub fn set_merge_operand_count_threshold(&mut self, val: usize) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_merge_operand_count_threshold(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `merge_operand_count_threshold` option.
+    pub fn get_merge_operand_count_threshold(&self) -> usize {
+        unsafe { ffi::rocksdb_readoptions_get_merge_operand_count_threshold(self.inner) }
+    }
+
+    /// For file reads associated with this option, charge the internal rate limiter (see
+    /// `DBOptions::rate_limiter`) at the specified priority. The special value
+    /// `Env::IO_TOTAL` disables charging the rate limiter.
+    ///
+    /// The rate limiting is bypassed no matter this option's value for file reads on plain
+    /// tables (these can exist when `ColumnFamilyOptions::table_factory` is a
+    /// `PlainTableFactory`) and cuckoo tables (these can exist when
+    /// `ColumnFamilyOptions::table_factory` is a `CuckooTableFactory`).
+    ///
+    /// The bytes charged to rate limiter may not exactly match the file read bytes since
+    /// there are some seemingly insignificant reads, like for file headers/footers, that we
+    /// currently do not charge to rate limiter.
+    pub fn set_rate_limiter_priority(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_rate_limiter_priority(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `rate_limiter_priority` option.
+    pub fn get_rate_limiter_priority(&self) -> c_int {
+        unsafe { ffi::rocksdb_readoptions_get_rate_limiter_priority(self.inner) }
+    }
+
+    /// Soft limit on the cumulative value size read by a single MultiGet, to bound how much
+    /// it buffers. It always makes progress: at least one key is read even if its value alone
+    /// exceeds the limit. Once the returned size exceeds the limit, subsequent keys get
+    /// status Aborted (so a caller can retry them, and cannot loop forever on a single value
+    /// that by itself exceeds the limit).
+    pub fn set_value_size_soft_limit(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_readoptions_set_value_size_soft_limit(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `value_size_soft_limit` option.
+    pub fn get_value_size_soft_limit(&self) -> u64 {
+        unsafe { ffi::rocksdb_readoptions_get_value_size_soft_limit(self.inner) }
+    }
 }
 
 impl Default for ReadOptions {
@@ -4777,6 +7249,294 @@ impl IngestExternalFileOptions {
         unsafe {
             ffi::rocksdb_ingestexternalfileoptions_set_ingest_behind(self.inner, c_uchar::from(v));
         }
+    }
+
+    /// Normally (true), IngestExternalFile() will trigger and block for flushing memtable(s)
+    /// if there is overlap between ingested files and memtable(s). If allow_blocking_flush is
+    /// set to false, IngestExternalFile() will fail if the file key range overlaps with the
+    /// memtable key range (memtable flush required).
+    pub fn get_allow_blocking_flush(&self) -> bool {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_allow_blocking_flush(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL, SUBJECT TO CHANGE
+    ///
+    /// Enables special mode of ingestion that allows files generated by a live DB, instead of
+    /// SstFileWriter. When true:
+    /// - Allows files to be ingested when their cf_id doesn't match the CF they are being
+    ///   ingested into.
+    /// - Allows files with any sequence numbers to be ingested.
+    /// - Original sequence numbers are preserved (no reassignment).
+    ///
+    /// REQUIREMENTS:
+    /// - Ingested files must NOT overlap with any existing data in the DB. Since no
+    ///   sequence number reassignment is performed on db generated files. Ingestion will
+    ///   fail if any overlap is detected. However, input files are allowed to overlap with
+    ///   each other when this option is enabled. This is useful when ingesting multiple
+    ///   levels of files from a CF, where levels naturally overlap with each other.
+    /// - CAUTION: If input files overlap with each other, then for any given user key
+    ///   appearing in multiple files, earlier files MUST have smaller sequence numbers than
+    ///   later files. Later files will be placed at a higher level (smaller level number).
+    ///   This is to ensure the LSM invariant where for the same key, recent updates are in
+    ///   higher levels. This means that if you are ingesting files from multiple levels of
+    ///   a CF, you should put files from lower levels first, and files from higher levels
+    ///   later. Example for getting files from a CF for ingestion:
+    ///
+    /// ColumnFamilyMetaData cf_meta; from_db->GetColumnFamilyMetaData(from_cf, &cf_meta); //
+    /// iterate in reverse to start from lowest level for (auto level_meta =
+    /// cf_meta.levels.rbegin(); level_meta != cf_meta.levels.rend(); ++level_meta) { // L0
+    /// files need to be added in reverse order so we iterate in reverse // within a level too
+    /// for (auto file_meta = level_meta->files.rbegin(); file_meta !=
+    /// level_meta->files.rend(); ++file_meta) { // Add file for ingestion } }
+    ///
+    /// WARNING: Violating the sequence number ordering requirement will cause LSM invariant
+    /// violations and may lead to incorrect reads or data corruption.
+    /// - If you would like to enforce that the ingested files do not overlap with each
+    ///   other, you can set `fail_if_not_bottommost_level` to true. If ingested files
+    ///   overlap with each other, some file will be placed above Lmax, failing the
+    ///   ingestion if the option is set.
+    /// - `write_global_seqno` must be false (sequence numbers cannot be reassigned).
+    pub fn set_allow_db_generated_files(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_allow_db_generated_files(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `allow_db_generated_files` option.
+    pub fn get_allow_db_generated_files(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_get_allow_db_generated_files(self.inner) != 0
+        }
+    }
+
+    /// Enables assiging a global sequence number to each ingested file, i.e., all keys in the
+    /// ingested file will be treated as having this seqno. If set to false, we will use the
+    /// sequence numbers in the ingested file as is, and IngestExternalFile() will fail if the
+    /// ingested key range overlaps with existing keys or tombstones or output of ongoing
+    /// compaction in the CF (the conditions under which a global seqno must be assigned to
+    /// the ingested file). If the ingested files overlap with each other, we need to assign
+    /// global sequence to the ingested files and this option needs to be enabled. One
+    /// exception to this is when ingesting DB generated SST files (see option
+    /// allow_db_generated_files below). DB generated files do not support global seqno
+    /// assignment and can be ingested even if they overlap with each other. This option has
+    /// no effect when allow_db_generated_files is enabled.
+    pub fn get_allow_global_seqno(&self) -> bool {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_allow_global_seqno(self.inner) != 0 }
+    }
+
+    /// Set to TRUE if user wants file to be ingested to the last level. An error of
+    /// Status::TryAgain() will be returned if a file cannot fit in the last level when
+    /// calling DB::IngestExternalFile()/DB::IngestExternalFiles(). The user should clear the
+    /// last level in the overlapping range before re-attempt.
+    ///
+    /// ingest_behind takes precedence over fail_if_not_bottommost_level.
+    ///
+    /// XXX: "bottommost" is obsolete/confusing terminology to refer to last level
+    pub fn get_fail_if_not_bottommost_level(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_get_fail_if_not_bottommost_level(self.inner) != 0
+        }
+    }
+
+    /// If set to true, ingestion falls back to copy when hard linking fails. This applies to
+    /// both `move_files` and `link_files`.
+    pub fn set_failed_move_fall_back_to_copy(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_failed_move_fall_back_to_copy(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `failed_move_fall_back_to_copy` option.
+    pub fn get_failed_move_fall_back_to_copy(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_get_failed_move_fall_back_to_copy(self.inner)
+                != 0
+        }
+    }
+
+    /// Maximum number of threads used to open table readers for the files being ingested
+    /// during commit, can speed up ingestion performance, when ingesting multiple files at
+    /// once.
+    pub fn set_file_opening_threads(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_file_opening_threads(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `file_opening_threads` option.
+    pub fn get_file_opening_threads(&self) -> c_int {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_file_opening_threads(self.inner) }
+    }
+
+    /// Should the "data block"/"index block" read for this iteration be placed in block
+    /// cache? Callers may wish to set this field to false for bulk scans. This would help not
+    /// to the change eviction order of existing items in the block cache.
+    pub fn set_fill_cache(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_fill_cache(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `fill_cache` option.
+    pub fn get_fill_cache(&self) -> bool {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_fill_cache(self.inner) != 0 }
+    }
+
+    /// Set to true if you would like duplicate keys in the file being ingested to be skipped
+    /// rather than overwriting existing data under that key. Use case: back-fill of some
+    /// historical data in the database without over-writing existing newer version of data.
+    /// This option could only be used if the CF has been running with
+    /// cf_allow_ingest_behind=true since CF creation (or before any write). All files will be
+    /// ingested at the bottommost level with seqno=0.
+    pub fn get_ingest_behind(&self) -> bool {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_ingest_behind(self.inner) != 0 }
+    }
+
+    /// Same as move_files except that input files will NOT be unlinked. Only one of
+    /// `move_files` and `link_files` can be set at the same time.
+    pub fn set_link_files(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_link_files(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Returns the value of the `link_files` option.
+    pub fn get_link_files(&self) -> bool {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_link_files(self.inner) != 0 }
+    }
+
+    /// Can be set to true to move the files instead of copying them. The input files will be
+    /// unlinked after successful ingestion. The implementation depends on hard links
+    /// (LinkFile) instead of traditional move (RenameFile) to maximize the chances to restore
+    /// to the original state upon failure.
+    pub fn get_move_files(&self) -> bool {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_move_files(self.inner) != 0 }
+    }
+
+    /// Controls whether external file ingestion should prefetch index and filter blocks while
+    /// opening table readers during commit. Setting this to false can reduce commit latency
+    /// for bulk loads into Lmax when
+    /// (BlockBasedTableOptions::cache_index_and_filter_blocks=true or partitioned
+    /// filters/indexes are enabled).
+    pub fn set_prefetch_lmax_index_and_filter_blocks(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_prefetch_lmax_index_and_filter_blocks(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `prefetch_lmax_index_and_filter_blocks` option.
+    pub fn get_prefetch_lmax_index_and_filter_blocks(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_get_prefetch_lmax_index_and_filter_blocks(
+                self.inner,
+            ) != 0
+        }
+    }
+
+    /// If set to false, an ingested file keys could appear in existing snapshots that where
+    /// created before the file was ingested.
+    pub fn get_snapshot_consistency(&self) -> bool {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_snapshot_consistency(self.inner) != 0 }
+    }
+
+    /// Set to true if you would like to verify the checksums of each block of the external
+    /// SST file before ingestion. Warning: setting this to true causes slowdown in file
+    /// ingestion because the external SST file has to be read.
+    pub fn set_verify_checksums_before_ingest(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_verify_checksums_before_ingest(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `verify_checksums_before_ingest` option.
+    pub fn get_verify_checksums_before_ingest(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_get_verify_checksums_before_ingest(self.inner)
+                != 0
+        }
+    }
+
+    /// When verify_checksums_before_ingest = true, RocksDB uses default readahead setting to
+    /// scan the file while verifying checksums before ingestion. Users can override the
+    /// default value using this option. Using a large readahead size (> 2MB) can typically
+    /// improve the performance of forward iteration on spinning disks.
+    pub fn set_verify_checksums_readahead_size(&mut self, val: usize) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_verify_checksums_readahead_size(
+                self.inner, val,
+            );
+        }
+    }
+
+    /// Returns the value of the `verify_checksums_readahead_size` option.
+    pub fn get_verify_checksums_readahead_size(&self) -> usize {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_get_verify_checksums_readahead_size(self.inner)
+        }
+    }
+
+    /// Set to TRUE if user wants to verify the sst file checksum of ingested files. The DB
+    /// checksum function will generate the checksum of each ingested file (if
+    /// file_checksum_gen_factory is set) and compare the checksum function name and checksum
+    /// with the ingested checksum information.
+    ///
+    /// If this option is set to True: 1) if DB does not enable checksum
+    /// (file_checksum_gen_factory == nullptr), the ingested checksum information will be
+    /// ignored; 2) If DB enable the checksum function, we calculate the sst file checksum
+    /// after the file is moved or copied and compare the checksum and checksum name. If
+    /// checksum or checksum function name does not match, ingestion will be failed. If the
+    /// verification is successful, checksum and checksum function name will be stored in
+    /// Manifest. If this option is set to FALSE, 1) if DB does not enable checksum, the
+    /// ingested checksum information will be ignored; 2) if DB enable the checksum, we only
+    /// verify the ingested checksum function name and we trust the ingested checksum. If the
+    /// checksum function name matches, we store the checksum in Manifest. DB does not
+    /// calculate the checksum during ingestion. However, if no checksum information is
+    /// provided with the ingested files, DB will generate the checksum and store in the
+    /// Manifest.
+    pub fn set_verify_file_checksum(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_verify_file_checksum(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `verify_file_checksum` option.
+    pub fn get_verify_file_checksum(&self) -> bool {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_verify_file_checksum(self.inner) != 0 }
+    }
+
+    /// DEPRECATED - Set to true if you would like to write global_seqno to the external SST
+    /// file on ingestion for backward compatibility before RocksDB 5.16.0. Such old versions
+    /// of RocksDB expect any global_seqno to be written to the SST file rather than recorded
+    /// in the DB manifest. This functionality was deprecated because (a) random writes might
+    /// be costly or unsupported on some FileSystems, and (b) the file checksum changes with
+    /// such a write.
+    pub fn set_write_global_seqno(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_write_global_seqno(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `write_global_seqno` option.
+    pub fn get_write_global_seqno(&self) -> bool {
+        unsafe { ffi::rocksdb_ingestexternalfileoptions_get_write_global_seqno(self.inner) != 0 }
     }
 }
 
@@ -4999,6 +7759,56 @@ impl FifoCompactOptions {
             ffi::rocksdb_fifo_compaction_options_set_max_table_files_size(self.inner, nbytes);
         }
     }
+
+    /// DEPRECATED When not 0, if the data in the file is older than this threshold, RocksDB
+    /// will soon move the file to warm temperature.
+    pub fn set_age_for_warm(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_fifo_compaction_options_set_age_for_warm(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `age_for_warm` option.
+    pub fn get_age_for_warm(&self) -> u64 {
+        unsafe { ffi::rocksdb_fifo_compaction_options_get_age_for_warm(self.inner) }
+    }
+
+    /// EXPERIMENTAL If true, when compaction is picked for kChangeTemperature reason, allow
+    /// the trivia copy of the sst file from source FileSystem to destination FileSystem. If
+    /// false, the changeTemperature will be the non-trivial copy by iterating/appending
+    /// blocks by blocks of the sst file.
+    pub fn set_allow_trivial_copy_when_change_temperature(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_fifo_compaction_options_set_allow_trivial_copy_when_change_temperature(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `allow_trivial_copy_when_change_temperature` option.
+    pub fn get_allow_trivial_copy_when_change_temperature(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_fifo_compaction_options_get_allow_trivial_copy_when_change_temperature(
+                self.inner,
+            ) != 0
+        }
+    }
+
+    /// EXPERIMENTAL If 'allow_trivia_copy_op_when_change_temperature=true', the tmp buffer
+    /// size to copy the file from the source FileSystem to the destnation FileSystem. If
+    /// 'allow_trivia_copy_op_when_change_temperature=false', this field will not be used. The
+    /// minmum buffer size must be at least 4KiB
+    pub fn set_trivial_copy_buffer_size(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_fifo_compaction_options_set_trivial_copy_buffer_size(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `trivial_copy_buffer_size` option.
+    pub fn get_trivial_copy_buffer_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(self.inner) }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -5113,6 +7923,102 @@ impl UniversalCompactOptions {
     pub fn set_stop_style(&mut self, style: UniversalCompactionStopStyle) {
         unsafe {
             ffi::rocksdb_universal_compaction_options_set_stop_style(self.inner, style as c_int);
+        }
+    }
+
+    /// Option to optimize the manual compaction by enabling trivial move for non overlapping
+    /// files. Default: false
+    pub fn set_allow_trivial_move(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_universal_compaction_options_set_allow_trivial_move(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `allow_trivial_move` option.
+    pub fn get_allow_trivial_move(&self) -> bool {
+        unsafe { ffi::rocksdb_universal_compaction_options_get_allow_trivial_move(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL If true, try to limit compaction size under max_compaction_bytes. This
+    /// might cause higher write amplification, but can prevent some problem caused by large
+    /// compactions. Default: false
+    pub fn set_incremental(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_universal_compaction_options_set_incremental(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `incremental` option.
+    pub fn get_incremental(&self) -> bool {
+        unsafe { ffi::rocksdb_universal_compaction_options_get_incremental(self.inner) != 0 }
+    }
+
+    /// The limit on the number of sorted runs. RocksDB will try to keep the number of sorted
+    /// runs at most this number. While compactions are running, the number of sorted runs may
+    /// be temporarily higher than this number.
+    ///
+    /// Since universal compaction checks if there is compaction to do when the number of
+    /// sorted runs is at least level0_file_num_compaction_trigger, it is suggested to set
+    /// level0_file_num_compaction_trigger to be no larger than max_read_amp.
+    ///
+    /// Values: -1: special flag to let RocksDB pick default. Currently, RocksDB will fall
+    /// back to the behavior before this option is introduced, which is to use
+    /// level0_file_num_compaction_trigger as the limit. This may change in the future to
+    /// behave as 0 below. 0: Let RocksDB auto-tune. Currently, we determine the max number of
+    /// sorted runs based on the current DB size, size_ratio and write_buffer_size. Note that
+    /// this is only supported for the default stop_style kCompactionStopStyleTotalSize. For
+    /// kCompactionStopStyleSimilarSize, this behaves as if -1 is configured. N > 0: limit the
+    /// number of sorted runs to be at most N. N should be at least the compaction trigger
+    /// specified by level0_file_num_compaction_trigger. If 0 < max_read_amp <
+    /// level0_file_num_compaction_trigger, Status::NotSupported() will be returned during DB
+    /// open. N < -1: Status::NotSupported() will be returned during DB open.
+    ///
+    /// Default: -1
+    pub fn set_max_read_amp(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_universal_compaction_options_set_max_read_amp(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `max_read_amp` option.
+    pub fn get_max_read_amp(&self) -> c_int {
+        unsafe { ffi::rocksdb_universal_compaction_options_get_max_read_amp(self.inner) }
+    }
+
+    /// If true, auto universal compaction picking will adjust to minimize locking of input
+    /// files when bottom priority compactions are waiting to run. This can increase the
+    /// likelihood of existing L0s being selected for compaction, thereby improving write
+    /// stall and reducing read regression. It may increase the overrall write amplification
+    /// and compaction load on low priority threads.
+    ///
+    /// Default: true (enabled)
+    ///
+    /// This options does not apply to manual compactions.
+    ///
+    /// This option is temporary in case turning on this feature causes problems and users
+    /// need to undo it quickly. This option is planned for removal in the near future with
+    /// default value set to true.
+    ///
+    /// Dynamically changeable through the SetOptions() API.
+    pub fn set_reduce_file_locking(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_universal_compaction_options_set_reduce_file_locking(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `reduce_file_locking` option.
+    pub fn get_reduce_file_locking(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_universal_compaction_options_get_reduce_file_locking(self.inner) != 0
         }
     }
 }
@@ -5233,6 +8139,28 @@ impl CompactOptions {
             ffi::rocksdb_compactoptions_set_blob_garbage_collection_age_cutoff(self.inner, v);
         }
     }
+
+    /// If set to < 0 or > 1, RocksDB leaves blob_garbage_collection_age_cutoff from
+    /// ColumnFamilyOptions in effect. Otherwise, it will override the user-provided setting.
+    /// This enables customers to selectively override the age cutoff.
+    pub fn get_blob_garbage_collection_age_cutoff(&self) -> f64 {
+        unsafe { ffi::rocksdb_compactoptions_get_blob_garbage_collection_age_cutoff(self.inner) }
+    }
+
+    /// If set to kForce, RocksDB will override enable_blob_file_garbage_collection to true;
+    /// if set to kDisable, RocksDB will override it to false, and kUseDefault leaves the
+    /// setting in effect. This enables customers to both force-enable and force-disable GC
+    /// when calling CompactRange.
+    pub fn set_blob_garbage_collection_policy(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_compactoptions_set_blob_garbage_collection_policy(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `blob_garbage_collection_policy` option.
+    pub fn get_blob_garbage_collection_policy(&self) -> c_int {
+        unsafe { ffi::rocksdb_compactoptions_get_blob_garbage_collection_policy(self.inner) }
+    }
 }
 
 pub struct WaitForCompactOptions {
@@ -5291,6 +8219,21 @@ impl WaitForCompactOptions {
         unsafe {
             ffi::rocksdb_wait_for_compact_options_set_timeout(self.inner, microseconds);
         }
+    }
+
+    /// A boolean to wait for purge to complete
+    pub fn set_wait_for_purge(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_wait_for_compact_options_set_wait_for_purge(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `wait_for_purge` option.
+    pub fn get_wait_for_purge(&self) -> bool {
+        unsafe { ffi::rocksdb_wait_for_compact_options_get_wait_for_purge(self.inner) != 0 }
     }
 }
 

--- a/src/transactions/options.rs
+++ b/src/transactions/options.rs
@@ -126,6 +126,181 @@ impl TransactionOptions {
             ffi::rocksdb_transaction_options_set_max_write_batch_size(self.inner, size);
         }
     }
+
+    /// The following three options enable optimizations for large transaction commit to
+    /// bypass memtable write.
+    /// - If any transaction's commit should bybass memtable write, set
+    ///   commit_bypass_memtable to true.
+    /// - If only bypass memtable write for transactions with >= n operations, set
+    ///   commit_bypass_memtable to false, large_txn_commit_optimize_threshold to n, and
+    ///   large_txn_commit_optimize_byte_threshold to 0. Similarly for only optimize when a
+    ///   transaction's write batch size is >= n.
+    /// - If bypass memtable write for transactions with >= n operations or >= x bytes, set
+    ///   commit_bypass_memtable to false, large_txn_commit_optimize_threshold to n, and
+    ///   large_txn_commit_optimize_byte_threshold to x.
+    ///
+    /// EXPERIMENTAL, SUBJECT TO CHANGE Only supports write-committed policy. If set to true,
+    /// the transaction will skip memtable write and ingest into the DB directly during
+    /// Commit(). This makes Commit() much faster for transactions with many operations.
+    /// Transaction neeeds to call Prepare() before Commit() for this option to take effect.
+    /// Transactions with Merge() or PutEntity() is not supported yet.
+    ///
+    /// Note that the transaction will be ingested as an immutable memtable for CFs it
+    /// updates, and the current memtable will be switched to a new one. So ingesting many
+    /// transactions in a short period of time may cause stall due to too many memtables. Note
+    /// that the ingestion relies on the transaction's underlying index,
+    /// (WriteBatchWithIndex), so updates that are added to the transaction without indexing
+    /// (i.e. added directly to the transaction underlying write batch through
+    /// Transaction::GetWriteBatch()->GetWriteBatch()) are not supported, and the optimization
+    /// will not apply in that case.
+    ///
+    /// NOTE: since WBWI keep track of the most recent update per key, a Put followed by a
+    /// SingleDelete will be written to DB as a SingleDelete. This can cause flush/compaction
+    /// to report `num_single_del_mismatch` due to consecutive SingleDeletes.
+    pub fn set_commit_bypass_memtable(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_transaction_options_set_commit_bypass_memtable(self.inner, u8::from(val));
+        }
+    }
+
+    /// Returns the value of the `commit_bypass_memtable` option.
+    pub fn get_commit_bypass_memtable(&self) -> bool {
+        unsafe { ffi::rocksdb_transaction_options_get_commit_bypass_memtable(self.inner) != 0 }
+    }
+
+    /// Setting to true means that before acquiring locks, this transaction will check if
+    /// doing so will cause a deadlock. If so, it will return with Status::Busy.  The user
+    /// should retry their transaction.
+    pub fn get_deadlock_detect(&self) -> bool {
+        unsafe { ffi::rocksdb_transaction_options_get_deadlock_detect(self.inner) != 0 }
+    }
+
+    /// EXPERIMENTAL, SUBJECT TO CHANGE When the size of a transaction's write batch is at
+    /// least this threshold, we will enable optimizations for commiting a large transaction.
+    /// See comment for `commit_bypass_memtable` for more optimization detail.
+    ///
+    /// Default: 0 (disabled).
+    pub fn set_large_txn_commit_optimize_byte_threshold(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_transaction_options_set_large_txn_commit_optimize_byte_threshold(
+                self.inner, val,
+            );
+        }
+    }
+
+    /// Returns the value of the `large_txn_commit_optimize_byte_threshold` option.
+    pub fn get_large_txn_commit_optimize_byte_threshold(&self) -> u64 {
+        unsafe {
+            ffi::rocksdb_transaction_options_get_large_txn_commit_optimize_byte_threshold(
+                self.inner,
+            )
+        }
+    }
+
+    /// EXPERIMENTAL, SUBJECT TO CHANGE When the number of updates in a transaction is at
+    /// least this threshold, we will enable optimizations for commiting a large transaction.
+    /// See comment for `commit_bypass_memtable` for more optimization detail.
+    ///
+    /// Default: 0 (disabled).
+    pub fn set_large_txn_commit_optimize_threshold(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_transaction_options_set_large_txn_commit_optimize_threshold(
+                self.inner, val,
+            );
+        }
+    }
+
+    /// Returns the value of the `large_txn_commit_optimize_threshold` option.
+    pub fn get_large_txn_commit_optimize_threshold(&self) -> u32 {
+        unsafe {
+            ffi::rocksdb_transaction_options_get_large_txn_commit_optimize_threshold(self.inner)
+        }
+    }
+
+    /// The maximum number of bytes used for the write batch. 0 means no limit.
+    pub fn get_max_write_batch_size(&self) -> usize {
+        unsafe { ffi::rocksdb_transaction_options_get_max_write_batch_size(self.inner) }
+    }
+
+    /// Setting set_snapshot=true is the same as calling Transaction::SetSnapshot().
+    pub fn get_set_snapshot(&self) -> bool {
+        unsafe { ffi::rocksdb_transaction_options_get_set_snapshot(self.inner) != 0 }
+    }
+
+    /// If true, the TransactionDB implementation might skip concurrency control unless it is
+    /// overridden by TransactionOptions or TransactionDBWriteOptimizations. This can be used
+    /// in conjunction with DBOptions::unordered_write when the TransactionDB is used solely
+    /// for write ordering rather than concurrency control.
+    pub fn set_skip_concurrency_control(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_transaction_options_set_skip_concurrency_control(
+                self.inner,
+                u8::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `skip_concurrency_control` option.
+    pub fn get_skip_concurrency_control(&self) -> bool {
+        unsafe { ffi::rocksdb_transaction_options_get_skip_concurrency_control(self.inner) != 0 }
+    }
+
+    /// In pessimistic transaction, if this is true, then you can skip Prepare before Commit,
+    /// otherwise, you must Prepare before Commit.
+    pub fn get_skip_prepare(&self) -> bool {
+        unsafe { ffi::rocksdb_transaction_options_get_skip_prepare(self.inner) != 0 }
+    }
+
+    /// If set, it states that the CommitTimeWriteBatch represents the latest state of the
+    /// application, has only one sub-batch, i.e., no duplicate keys,  and meant to be used
+    /// later during recovery. It enables an optimization to postpone updating the memtable
+    /// with CommitTimeWriteBatch to only SwitchMemtable or recovery. This option does not
+    /// affect write-committed. Only write-prepared/write-unprepared transactions will be
+    /// affected.
+    pub fn set_use_only_the_last_commit_time_batch_for_recovery(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_transaction_options_set_use_only_the_last_commit_time_batch_for_recovery(
+                self.inner,
+                u8::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `use_only_the_last_commit_time_batch_for_recovery` option.
+    pub fn get_use_only_the_last_commit_time_batch_for_recovery(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_transaction_options_get_use_only_the_last_commit_time_batch_for_recovery(
+                self.inner,
+            ) != 0
+        }
+    }
+
+    /// DO NOT USE. This is only a temporary option dedicated for MyRocks that will soon be
+    /// removed. In normal use cases, meta info like column family's timestamp size is tracked
+    /// at the transaction layer, so it's not necessary and even detrimental to track such
+    /// info inside the internal WriteBatch because it may let anti-patterns like bypassing
+    /// Transaction write APIs and directly write to its internal `WriteBatch` retrieved like
+    /// this:
+    /// <https://github.com/facebook/mysql-5.6/blob/fb-mysql-8.0.32/storage/rocksdb/ha_rocksdb.cc#L4949-L4950>
+    /// Setting this option to true will keep aforementioned use case continue to work before
+    /// it's refactored out. When this flag is enabled, we also intentionally only track the
+    /// timestamp size in APIs that MyRocks currently are using, including Put, Merge, Delete
+    /// DeleteRange, SingleDelete.
+    pub fn set_write_batch_track_timestamp_size(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_transaction_options_set_write_batch_track_timestamp_size(
+                self.inner,
+                u8::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `write_batch_track_timestamp_size` option.
+    pub fn get_write_batch_track_timestamp_size(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_transaction_options_get_write_batch_track_timestamp_size(self.inner) != 0
+        }
+    }
 }
 
 impl Drop for TransactionOptions {
@@ -226,6 +401,117 @@ impl TransactionDBOptions {
             ffi::rocksdb_transactiondb_options_set_num_stripes(self.inner, num_stripes);
         }
     }
+
+    /// A flag to control for the whole DB whether user-defined timestamp based validation are
+    /// enabled when applicable. Only WriteCommittedTxn support user-defined timestamps so
+    /// this option only applies in this case.
+    pub fn set_enable_udt_validation(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_set_enable_udt_validation(self.inner, u8::from(val));
+        }
+    }
+
+    /// Returns the value of the `enable_udt_validation` option.
+    pub fn get_enable_udt_validation(&self) -> bool {
+        unsafe { ffi::rocksdb_transactiondb_options_get_enable_udt_validation(self.inner) != 0 }
+    }
+
+    /// Stores the number of latest deadlocks to track
+    pub fn set_max_num_deadlocks(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_set_max_num_deadlocks(self.inner, val);
+        }
+    }
+
+    /// Returns the value of the `max_num_deadlocks` option.
+    pub fn get_max_num_deadlocks(&self) -> u32 {
+        unsafe { ffi::rocksdb_transactiondb_options_get_max_num_deadlocks(self.inner) }
+    }
+
+    /// Increasing this value will increase the concurrency by dividing the lock table (per
+    /// column family) into more sub-tables, each with their own separate mutex.
+    pub fn get_num_stripes(&self) -> usize {
+        unsafe { ffi::rocksdb_transactiondb_options_get_num_stripes(self.inner) }
+    }
+
+    /// TODO(myabandeh): remove this option Note: this is a temporary option as a hot fix in
+    /// rollback of writeprepared txns in myrocks. MyRocks uses merge operands for autoinc
+    /// column id without however obtaining locks. This breaks the assumption behind the
+    /// rollback logic in myrocks. This hack of simply not rolling back merge operands works
+    /// for the special way that myrocks uses this operands.
+    pub fn set_rollback_merge_operands(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_set_rollback_merge_operands(
+                self.inner,
+                u8::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `rollback_merge_operands` option.
+    pub fn get_rollback_merge_operands(&self) -> bool {
+        unsafe { ffi::rocksdb_transactiondb_options_get_rollback_merge_operands(self.inner) != 0 }
+    }
+
+    /// If true, the TransactionDB implementation might skip concurrency control unless it is
+    /// overridden by TransactionOptions or TransactionDBWriteOptimizations. This can be used
+    /// in conjunction with DBOptions::unordered_write when the TransactionDB is used solely
+    /// for write ordering rather than concurrency control.
+    pub fn set_skip_concurrency_control(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_set_skip_concurrency_control(
+                self.inner,
+                u8::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `skip_concurrency_control` option.
+    pub fn get_skip_concurrency_control(&self) -> bool {
+        unsafe { ffi::rocksdb_transactiondb_options_get_skip_concurrency_control(self.inner) != 0 }
+    }
+
+    /// Deprecated, this option has no effect and may be removed in the future. Use
+    /// TransactionOptions::large_txn_commit_optimize_threshold instead.
+    ///
+    /// This option is only valid for write committed. If the number of updates in a
+    /// transaction is at least this threshold, then the transaction commit will skip
+    /// insertions into memtable as an optimization to reduce commit latency. See comment for
+    /// TransactionOptions::commit_bypass_memtable for more detail. Setting
+    /// TransactionOptions::commit_bypass_memtable to true takes precedence over this option.
+    pub fn set_txn_commit_bypass_memtable_threshold(&mut self, val: u32) {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_set_txn_commit_bypass_memtable_threshold(
+                self.inner, val,
+            );
+        }
+    }
+
+    /// Returns the value of the `txn_commit_bypass_memtable_threshold` option.
+    pub fn get_txn_commit_bypass_memtable_threshold(&self) -> u32 {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_get_txn_commit_bypass_memtable_threshold(self.inner)
+        }
+    }
+
+    /// EXPERIMENTAL
+    ///
+    /// Flag to enable/disable the per key point lock manager.
+    pub fn set_use_per_key_point_lock_mgr(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_set_use_per_key_point_lock_mgr(
+                self.inner,
+                u8::from(val),
+            );
+        }
+    }
+
+    /// Returns the value of the `use_per_key_point_lock_mgr` option.
+    pub fn get_use_per_key_point_lock_mgr(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_get_use_per_key_point_lock_mgr(self.inner) != 0
+        }
+    }
 }
 
 impl Drop for TransactionDBOptions {
@@ -284,6 +570,11 @@ impl OptimisticTransactionOptions {
                 u8::from(snapshot),
             );
         }
+    }
+
+    /// Setting set_snapshot=true is the same as calling Transaction::SetSnapshot().
+    pub fn get_set_snapshot(&self) -> bool {
+        unsafe { ffi::rocksdb_optimistictransaction_options_get_set_snapshot(self.inner) != 0 }
     }
 }
 

--- a/tests/test_capi_options_roundtrip.rs
+++ b/tests/test_capi_options_roundtrip.rs
@@ -1,0 +1,1199 @@
+// Round-trip coverage for the RocksDB C API options exposed in this change.
+//
+// Each option is set to a known value and read back through the matching
+// getter, which is what catches a setter and getter that disagree or a bool
+// cast that got inverted.
+
+use rust_rocksdb::{
+    BlockBasedOptions, CompactOptions, CuckooTableOptions, FifoCompactOptions, FlushOptions,
+    IngestExternalFileOptions, Options, ReadOptions, TransactionDBOptions, TransactionOptions,
+    UniversalCompactOptions, WaitForCompactOptions, WriteOptions,
+};
+
+#[test]
+fn roundtrip_block_based_options() {
+    let mut o = BlockBasedOptions::default();
+    o.set_data_block_hash_table_util_ratio(0.5);
+    assert_eq!(
+        o.get_data_block_hash_table_util_ratio(),
+        0.5,
+        "BlockBasedOptions::data_block_hash_table_util_ratio"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_decouple_partitioned_filters(true);
+    assert!(
+        o.get_decouple_partitioned_filters(),
+        "BlockBasedOptions::decouple_partitioned_filters"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_decouple_partitioned_filters(false);
+    assert!(
+        !o.get_decouple_partitioned_filters(),
+        "BlockBasedOptions::decouple_partitioned_filters"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_detect_filter_construct_corruption(true);
+    assert!(
+        o.get_detect_filter_construct_corruption(),
+        "BlockBasedOptions::detect_filter_construct_corruption"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_detect_filter_construct_corruption(false);
+    assert!(
+        !o.get_detect_filter_construct_corruption(),
+        "BlockBasedOptions::detect_filter_construct_corruption"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_enable_index_compression(true);
+    assert!(
+        o.get_enable_index_compression(),
+        "BlockBasedOptions::enable_index_compression"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_enable_index_compression(false);
+    assert!(
+        !o.get_enable_index_compression(),
+        "BlockBasedOptions::enable_index_compression"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_fail_if_no_udi_on_open(true);
+    assert!(
+        o.get_fail_if_no_udi_on_open(),
+        "BlockBasedOptions::fail_if_no_udi_on_open"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_fail_if_no_udi_on_open(false);
+    assert!(
+        !o.get_fail_if_no_udi_on_open(),
+        "BlockBasedOptions::fail_if_no_udi_on_open"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_index_shortening(7);
+    assert_eq!(
+        o.get_index_shortening(),
+        7,
+        "BlockBasedOptions::index_shortening"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_initial_auto_readahead_size(4096);
+    assert_eq!(
+        o.get_initial_auto_readahead_size(),
+        4096,
+        "BlockBasedOptions::initial_auto_readahead_size"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_max_auto_readahead_size(4096);
+    assert_eq!(
+        o.get_max_auto_readahead_size(),
+        4096,
+        "BlockBasedOptions::max_auto_readahead_size"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_num_file_reads_for_auto_readahead(4096);
+    assert_eq!(
+        o.get_num_file_reads_for_auto_readahead(),
+        4096,
+        "BlockBasedOptions::num_file_reads_for_auto_readahead"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_prepopulate_block_cache(7);
+    assert_eq!(
+        o.get_prepopulate_block_cache(),
+        7,
+        "BlockBasedOptions::prepopulate_block_cache"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_read_amp_bytes_per_bit(7);
+    assert_eq!(
+        o.get_read_amp_bytes_per_bit(),
+        7,
+        "BlockBasedOptions::read_amp_bytes_per_bit"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_super_block_alignment_size(4096);
+    assert_eq!(
+        o.get_super_block_alignment_size(),
+        4096,
+        "BlockBasedOptions::super_block_alignment_size"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_super_block_alignment_space_overhead_ratio(4096);
+    assert_eq!(
+        o.get_super_block_alignment_space_overhead_ratio(),
+        4096,
+        "BlockBasedOptions::super_block_alignment_space_overhead_ratio"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_use_udi_as_primary_index(true);
+    assert!(
+        o.get_use_udi_as_primary_index(),
+        "BlockBasedOptions::use_udi_as_primary_index"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_use_udi_as_primary_index(false);
+    assert!(
+        !o.get_use_udi_as_primary_index(),
+        "BlockBasedOptions::use_udi_as_primary_index"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_verify_compression(true);
+    assert!(
+        o.get_verify_compression(),
+        "BlockBasedOptions::verify_compression"
+    );
+    let mut o = BlockBasedOptions::default();
+    o.set_verify_compression(false);
+    assert!(
+        !o.get_verify_compression(),
+        "BlockBasedOptions::verify_compression"
+    );
+}
+
+#[test]
+fn roundtrip_compact_options() {
+    let mut o = CompactOptions::default();
+    o.set_blob_garbage_collection_policy(7);
+    assert_eq!(
+        o.get_blob_garbage_collection_policy(),
+        7,
+        "CompactOptions::blob_garbage_collection_policy"
+    );
+}
+
+#[test]
+fn roundtrip_cuckoo_table_options() {
+    let mut o = CuckooTableOptions::default();
+    o.set_hash_table_ratio(0.5);
+    assert_eq!(
+        o.get_hash_table_ratio(),
+        0.5,
+        "CuckooTableOptions::hash_table_ratio"
+    );
+}
+
+#[test]
+fn roundtrip_fifo_compact_options() {
+    let mut o = FifoCompactOptions::default();
+    o.set_age_for_warm(4096);
+    assert_eq!(
+        o.get_age_for_warm(),
+        4096,
+        "FifoCompactOptions::age_for_warm"
+    );
+    let mut o = FifoCompactOptions::default();
+    o.set_allow_trivial_copy_when_change_temperature(true);
+    assert!(
+        o.get_allow_trivial_copy_when_change_temperature(),
+        "FifoCompactOptions::allow_trivial_copy_when_change_temperature"
+    );
+    let mut o = FifoCompactOptions::default();
+    o.set_allow_trivial_copy_when_change_temperature(false);
+    assert!(
+        !o.get_allow_trivial_copy_when_change_temperature(),
+        "FifoCompactOptions::allow_trivial_copy_when_change_temperature"
+    );
+    let mut o = FifoCompactOptions::default();
+    o.set_trivial_copy_buffer_size(4096);
+    assert_eq!(
+        o.get_trivial_copy_buffer_size(),
+        4096,
+        "FifoCompactOptions::trivial_copy_buffer_size"
+    );
+}
+
+#[test]
+fn roundtrip_flush_options() {
+    let mut o = FlushOptions::default();
+    o.set_allow_write_stall(true);
+    assert!(o.get_allow_write_stall(), "FlushOptions::allow_write_stall");
+    let mut o = FlushOptions::default();
+    o.set_allow_write_stall(false);
+    assert!(
+        !o.get_allow_write_stall(),
+        "FlushOptions::allow_write_stall"
+    );
+    let mut o = FlushOptions::default();
+    o.set_force_atomic_flush(true);
+    assert!(
+        o.get_force_atomic_flush(),
+        "FlushOptions::force_atomic_flush"
+    );
+    let mut o = FlushOptions::default();
+    o.set_force_atomic_flush(false);
+    assert!(
+        !o.get_force_atomic_flush(),
+        "FlushOptions::force_atomic_flush"
+    );
+    let mut o = FlushOptions::default();
+    o.set_listener_wait(true);
+    assert!(o.get_listener_wait(), "FlushOptions::listener_wait");
+    let mut o = FlushOptions::default();
+    o.set_listener_wait(false);
+    assert!(!o.get_listener_wait(), "FlushOptions::listener_wait");
+}
+
+#[test]
+fn roundtrip_ingest_external_file_options() {
+    let mut o = IngestExternalFileOptions::default();
+    o.set_allow_db_generated_files(true);
+    assert!(
+        o.get_allow_db_generated_files(),
+        "IngestExternalFileOptions::allow_db_generated_files"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_allow_db_generated_files(false);
+    assert!(
+        !o.get_allow_db_generated_files(),
+        "IngestExternalFileOptions::allow_db_generated_files"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_failed_move_fall_back_to_copy(true);
+    assert!(
+        o.get_failed_move_fall_back_to_copy(),
+        "IngestExternalFileOptions::failed_move_fall_back_to_copy"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_failed_move_fall_back_to_copy(false);
+    assert!(
+        !o.get_failed_move_fall_back_to_copy(),
+        "IngestExternalFileOptions::failed_move_fall_back_to_copy"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_file_opening_threads(7);
+    assert_eq!(
+        o.get_file_opening_threads(),
+        7,
+        "IngestExternalFileOptions::file_opening_threads"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_fill_cache(true);
+    assert!(o.get_fill_cache(), "IngestExternalFileOptions::fill_cache");
+    let mut o = IngestExternalFileOptions::default();
+    o.set_fill_cache(false);
+    assert!(!o.get_fill_cache(), "IngestExternalFileOptions::fill_cache");
+    let mut o = IngestExternalFileOptions::default();
+    o.set_link_files(true);
+    assert!(o.get_link_files(), "IngestExternalFileOptions::link_files");
+    let mut o = IngestExternalFileOptions::default();
+    o.set_link_files(false);
+    assert!(!o.get_link_files(), "IngestExternalFileOptions::link_files");
+    let mut o = IngestExternalFileOptions::default();
+    o.set_prefetch_lmax_index_and_filter_blocks(true);
+    assert!(
+        o.get_prefetch_lmax_index_and_filter_blocks(),
+        "IngestExternalFileOptions::prefetch_lmax_index_and_filter_blocks"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_prefetch_lmax_index_and_filter_blocks(false);
+    assert!(
+        !o.get_prefetch_lmax_index_and_filter_blocks(),
+        "IngestExternalFileOptions::prefetch_lmax_index_and_filter_blocks"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_verify_checksums_before_ingest(true);
+    assert!(
+        o.get_verify_checksums_before_ingest(),
+        "IngestExternalFileOptions::verify_checksums_before_ingest"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_verify_checksums_before_ingest(false);
+    assert!(
+        !o.get_verify_checksums_before_ingest(),
+        "IngestExternalFileOptions::verify_checksums_before_ingest"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_verify_checksums_readahead_size(4096);
+    assert_eq!(
+        o.get_verify_checksums_readahead_size(),
+        4096,
+        "IngestExternalFileOptions::verify_checksums_readahead_size"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_verify_file_checksum(true);
+    assert!(
+        o.get_verify_file_checksum(),
+        "IngestExternalFileOptions::verify_file_checksum"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_verify_file_checksum(false);
+    assert!(
+        !o.get_verify_file_checksum(),
+        "IngestExternalFileOptions::verify_file_checksum"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_write_global_seqno(true);
+    assert!(
+        o.get_write_global_seqno(),
+        "IngestExternalFileOptions::write_global_seqno"
+    );
+    let mut o = IngestExternalFileOptions::default();
+    o.set_write_global_seqno(false);
+    assert!(
+        !o.get_write_global_seqno(),
+        "IngestExternalFileOptions::write_global_seqno"
+    );
+}
+
+#[test]
+fn roundtrip_options() {
+    let mut o = Options::default();
+    o.set_allow_2pc(true);
+    assert!(o.get_allow_2pc(), "Options::allow_2pc");
+    let mut o = Options::default();
+    o.set_allow_2pc(false);
+    assert!(!o.get_allow_2pc(), "Options::allow_2pc");
+    let mut o = Options::default();
+    o.set_allow_data_in_errors(true);
+    assert!(
+        o.get_allow_data_in_errors(),
+        "Options::allow_data_in_errors"
+    );
+    let mut o = Options::default();
+    o.set_allow_data_in_errors(false);
+    assert!(
+        !o.get_allow_data_in_errors(),
+        "Options::allow_data_in_errors"
+    );
+    let mut o = Options::default();
+    o.set_allow_fallocate(true);
+    assert!(o.get_allow_fallocate(), "Options::allow_fallocate");
+    let mut o = Options::default();
+    o.set_allow_fallocate(false);
+    assert!(!o.get_allow_fallocate(), "Options::allow_fallocate");
+    let mut o = Options::default();
+    o.set_async_wal_precreate(true);
+    assert!(o.get_async_wal_precreate(), "Options::async_wal_precreate");
+    let mut o = Options::default();
+    o.set_async_wal_precreate(false);
+    assert!(!o.get_async_wal_precreate(), "Options::async_wal_precreate");
+    let mut o = Options::default();
+    o.set_avoid_flush_during_recovery(true);
+    assert!(
+        o.get_avoid_flush_during_recovery(),
+        "Options::avoid_flush_during_recovery"
+    );
+    let mut o = Options::default();
+    o.set_avoid_flush_during_recovery(false);
+    assert!(
+        !o.get_avoid_flush_during_recovery(),
+        "Options::avoid_flush_during_recovery"
+    );
+    let mut o = Options::default();
+    o.set_avoid_flush_during_shutdown(true);
+    assert!(
+        o.get_avoid_flush_during_shutdown(),
+        "Options::avoid_flush_during_shutdown"
+    );
+    let mut o = Options::default();
+    o.set_avoid_flush_during_shutdown(false);
+    assert!(
+        !o.get_avoid_flush_during_shutdown(),
+        "Options::avoid_flush_during_shutdown"
+    );
+    let mut o = Options::default();
+    o.set_background_close_inactive_wals(true);
+    assert!(
+        o.get_background_close_inactive_wals(),
+        "Options::background_close_inactive_wals"
+    );
+    let mut o = Options::default();
+    o.set_background_close_inactive_wals(false);
+    assert!(
+        !o.get_background_close_inactive_wals(),
+        "Options::background_close_inactive_wals"
+    );
+    let mut o = Options::default();
+    o.set_best_efforts_recovery(true);
+    assert!(
+        o.get_best_efforts_recovery(),
+        "Options::best_efforts_recovery"
+    );
+    let mut o = Options::default();
+    o.set_best_efforts_recovery(false);
+    assert!(
+        !o.get_best_efforts_recovery(),
+        "Options::best_efforts_recovery"
+    );
+    let mut o = Options::default();
+    o.set_bgerror_resume_retry_interval(4096);
+    assert_eq!(
+        o.get_bgerror_resume_retry_interval(),
+        4096,
+        "Options::bgerror_resume_retry_interval"
+    );
+    let mut o = Options::default();
+    o.set_blob_direct_write_partitions(7);
+    assert_eq!(
+        o.get_blob_direct_write_partitions(),
+        7,
+        "Options::blob_direct_write_partitions"
+    );
+    let mut o = Options::default();
+    o.set_block_protection_bytes_per_key(3);
+    assert_eq!(
+        o.get_block_protection_bytes_per_key(),
+        3,
+        "Options::block_protection_bytes_per_key"
+    );
+    let mut o = Options::default();
+    o.set_bottommost_file_compaction_delay(7);
+    assert_eq!(
+        o.get_bottommost_file_compaction_delay(),
+        7,
+        "Options::bottommost_file_compaction_delay"
+    );
+    let mut o = Options::default();
+    o.set_cf_allow_ingest_behind(true);
+    assert!(
+        o.get_cf_allow_ingest_behind(),
+        "Options::cf_allow_ingest_behind"
+    );
+    let mut o = Options::default();
+    o.set_cf_allow_ingest_behind(false);
+    assert!(
+        !o.get_cf_allow_ingest_behind(),
+        "Options::cf_allow_ingest_behind"
+    );
+    let mut o = Options::default();
+    o.set_compaction_verify_record_count(true);
+    assert!(
+        o.get_compaction_verify_record_count(),
+        "Options::compaction_verify_record_count"
+    );
+    let mut o = Options::default();
+    o.set_compaction_verify_record_count(false);
+    assert!(
+        !o.get_compaction_verify_record_count(),
+        "Options::compaction_verify_record_count"
+    );
+    let mut o = Options::default();
+    o.set_default_temperature(7);
+    assert_eq!(
+        o.get_default_temperature(),
+        7,
+        "Options::default_temperature"
+    );
+    let mut o = Options::default();
+    o.set_default_write_temperature(7);
+    assert_eq!(
+        o.get_default_write_temperature(),
+        7,
+        "Options::default_write_temperature"
+    );
+    let mut o = Options::default();
+    o.set_delayed_write_rate(4096);
+    assert_eq!(
+        o.get_delayed_write_rate(),
+        4096,
+        "Options::delayed_write_rate"
+    );
+    let mut o = Options::default();
+    o.set_disallow_memtable_writes(true);
+    assert!(
+        o.get_disallow_memtable_writes(),
+        "Options::disallow_memtable_writes"
+    );
+    let mut o = Options::default();
+    o.set_disallow_memtable_writes(false);
+    assert!(
+        !o.get_disallow_memtable_writes(),
+        "Options::disallow_memtable_writes"
+    );
+    let mut o = Options::default();
+    o.set_enable_blob_direct_write(true);
+    assert!(
+        o.get_enable_blob_direct_write(),
+        "Options::enable_blob_direct_write"
+    );
+    let mut o = Options::default();
+    o.set_enable_blob_direct_write(false);
+    assert!(
+        !o.get_enable_blob_direct_write(),
+        "Options::enable_blob_direct_write"
+    );
+    let mut o = Options::default();
+    o.set_enable_thread_tracking(true);
+    assert!(
+        o.get_enable_thread_tracking(),
+        "Options::enable_thread_tracking"
+    );
+    let mut o = Options::default();
+    o.set_enable_thread_tracking(false);
+    assert!(
+        !o.get_enable_thread_tracking(),
+        "Options::enable_thread_tracking"
+    );
+    let mut o = Options::default();
+    o.set_enforce_single_del_contracts(true);
+    assert!(
+        o.get_enforce_single_del_contracts(),
+        "Options::enforce_single_del_contracts"
+    );
+    let mut o = Options::default();
+    o.set_enforce_single_del_contracts(false);
+    assert!(
+        !o.get_enforce_single_del_contracts(),
+        "Options::enforce_single_del_contracts"
+    );
+    let mut o = Options::default();
+    o.set_enforce_write_buffer_manager_during_recovery(true);
+    assert!(
+        o.get_enforce_write_buffer_manager_during_recovery(),
+        "Options::enforce_write_buffer_manager_during_recovery"
+    );
+    let mut o = Options::default();
+    o.set_enforce_write_buffer_manager_during_recovery(false);
+    assert!(
+        !o.get_enforce_write_buffer_manager_during_recovery(),
+        "Options::enforce_write_buffer_manager_during_recovery"
+    );
+    let mut o = Options::default();
+    o.set_fast_sst_open(true);
+    assert!(o.get_fast_sst_open(), "Options::fast_sst_open");
+    let mut o = Options::default();
+    o.set_fast_sst_open(false);
+    assert!(!o.get_fast_sst_open(), "Options::fast_sst_open");
+    let mut o = Options::default();
+    o.set_flush_verify_memtable_count(true);
+    assert!(
+        o.get_flush_verify_memtable_count(),
+        "Options::flush_verify_memtable_count"
+    );
+    let mut o = Options::default();
+    o.set_flush_verify_memtable_count(false);
+    assert!(
+        !o.get_flush_verify_memtable_count(),
+        "Options::flush_verify_memtable_count"
+    );
+    let mut o = Options::default();
+    o.set_follower_catchup_retry_count(4096);
+    assert_eq!(
+        o.get_follower_catchup_retry_count(),
+        4096,
+        "Options::follower_catchup_retry_count"
+    );
+    let mut o = Options::default();
+    o.set_follower_catchup_retry_wait_ms(4096);
+    assert_eq!(
+        o.get_follower_catchup_retry_wait_ms(),
+        4096,
+        "Options::follower_catchup_retry_wait_ms"
+    );
+    let mut o = Options::default();
+    o.set_follower_refresh_catchup_period_ms(4096);
+    assert_eq!(
+        o.get_follower_refresh_catchup_period_ms(),
+        4096,
+        "Options::follower_refresh_catchup_period_ms"
+    );
+    let mut o = Options::default();
+    o.set_force_consistency_checks(true);
+    assert!(
+        o.get_force_consistency_checks(),
+        "Options::force_consistency_checks"
+    );
+    let mut o = Options::default();
+    o.set_force_consistency_checks(false);
+    assert!(
+        !o.get_force_consistency_checks(),
+        "Options::force_consistency_checks"
+    );
+    let mut o = Options::default();
+    o.set_last_level_temperature(7);
+    assert_eq!(
+        o.get_last_level_temperature(),
+        7,
+        "Options::last_level_temperature"
+    );
+    let mut o = Options::default();
+    o.set_log_readahead_size(4096);
+    assert_eq!(
+        o.get_log_readahead_size(),
+        4096,
+        "Options::log_readahead_size"
+    );
+    let mut o = Options::default();
+    o.set_lowest_used_cache_tier(7);
+    assert_eq!(
+        o.get_lowest_used_cache_tier(),
+        7,
+        "Options::lowest_used_cache_tier"
+    );
+    let mut o = Options::default();
+    o.set_max_bgerror_resume_count(7);
+    assert_eq!(
+        o.get_max_bgerror_resume_count(),
+        7,
+        "Options::max_bgerror_resume_count"
+    );
+    let mut o = Options::default();
+    o.set_max_compaction_trigger_wakeup_seconds(4096);
+    assert_eq!(
+        o.get_max_compaction_trigger_wakeup_seconds(),
+        4096,
+        "Options::max_compaction_trigger_wakeup_seconds"
+    );
+    let mut o = Options::default();
+    o.set_max_manifest_space_amp_pct(7);
+    assert_eq!(
+        o.get_max_manifest_space_amp_pct(),
+        7,
+        "Options::max_manifest_space_amp_pct"
+    );
+    let mut o = Options::default();
+    o.set_max_write_batch_group_size_bytes(4096);
+    assert_eq!(
+        o.get_max_write_batch_group_size_bytes(),
+        4096,
+        "Options::max_write_batch_group_size_bytes"
+    );
+    let mut o = Options::default();
+    o.set_memtable_max_range_deletions(7);
+    assert_eq!(
+        o.get_memtable_max_range_deletions(),
+        7,
+        "Options::memtable_max_range_deletions"
+    );
+    let mut o = Options::default();
+    o.set_memtable_protection_bytes_per_key(7);
+    assert_eq!(
+        o.get_memtable_protection_bytes_per_key(),
+        7,
+        "Options::memtable_protection_bytes_per_key"
+    );
+    let mut o = Options::default();
+    o.set_memtable_verify_per_key_checksum_on_seek(true);
+    assert!(
+        o.get_memtable_verify_per_key_checksum_on_seek(),
+        "Options::memtable_verify_per_key_checksum_on_seek"
+    );
+    let mut o = Options::default();
+    o.set_memtable_verify_per_key_checksum_on_seek(false);
+    assert!(
+        !o.get_memtable_verify_per_key_checksum_on_seek(),
+        "Options::memtable_verify_per_key_checksum_on_seek"
+    );
+    let mut o = Options::default();
+    o.set_metadata_write_temperature(7);
+    assert_eq!(
+        o.get_metadata_write_temperature(),
+        7,
+        "Options::metadata_write_temperature"
+    );
+    let mut o = Options::default();
+    o.set_min_tombstones_for_range_conversion(7);
+    assert_eq!(
+        o.get_min_tombstones_for_range_conversion(),
+        7,
+        "Options::min_tombstones_for_range_conversion"
+    );
+    let mut o = Options::default();
+    o.set_optimize_manifest_for_recovery(true);
+    assert!(
+        o.get_optimize_manifest_for_recovery(),
+        "Options::optimize_manifest_for_recovery"
+    );
+    let mut o = Options::default();
+    o.set_optimize_manifest_for_recovery(false);
+    assert!(
+        !o.get_optimize_manifest_for_recovery(),
+        "Options::optimize_manifest_for_recovery"
+    );
+    let mut o = Options::default();
+    o.set_paranoid_file_checks(true);
+    assert!(
+        o.get_paranoid_file_checks(),
+        "Options::paranoid_file_checks"
+    );
+    let mut o = Options::default();
+    o.set_paranoid_file_checks(false);
+    assert!(
+        !o.get_paranoid_file_checks(),
+        "Options::paranoid_file_checks"
+    );
+    let mut o = Options::default();
+    o.set_paranoid_memory_checks(true);
+    assert!(
+        o.get_paranoid_memory_checks(),
+        "Options::paranoid_memory_checks"
+    );
+    let mut o = Options::default();
+    o.set_paranoid_memory_checks(false);
+    assert!(
+        !o.get_paranoid_memory_checks(),
+        "Options::paranoid_memory_checks"
+    );
+    let mut o = Options::default();
+    o.set_persist_stats_to_disk(true);
+    assert!(
+        o.get_persist_stats_to_disk(),
+        "Options::persist_stats_to_disk"
+    );
+    let mut o = Options::default();
+    o.set_persist_stats_to_disk(false);
+    assert!(
+        !o.get_persist_stats_to_disk(),
+        "Options::persist_stats_to_disk"
+    );
+    let mut o = Options::default();
+    o.set_persist_user_defined_timestamps(true);
+    assert!(
+        o.get_persist_user_defined_timestamps(),
+        "Options::persist_user_defined_timestamps"
+    );
+    let mut o = Options::default();
+    o.set_persist_user_defined_timestamps(false);
+    assert!(
+        !o.get_persist_user_defined_timestamps(),
+        "Options::persist_user_defined_timestamps"
+    );
+    let mut o = Options::default();
+    o.set_preclude_last_level_data_seconds(4096);
+    assert_eq!(
+        o.get_preclude_last_level_data_seconds(),
+        4096,
+        "Options::preclude_last_level_data_seconds"
+    );
+    let mut o = Options::default();
+    o.set_prefix_seek_opt_in_only(true);
+    assert!(
+        o.get_prefix_seek_opt_in_only(),
+        "Options::prefix_seek_opt_in_only"
+    );
+    let mut o = Options::default();
+    o.set_prefix_seek_opt_in_only(false);
+    assert!(
+        !o.get_prefix_seek_opt_in_only(),
+        "Options::prefix_seek_opt_in_only"
+    );
+    let mut o = Options::default();
+    o.set_preserve_internal_time_seconds(4096);
+    assert_eq!(
+        o.get_preserve_internal_time_seconds(),
+        4096,
+        "Options::preserve_internal_time_seconds"
+    );
+    let mut o = Options::default();
+    o.set_read_io_executor_threads(7);
+    assert_eq!(
+        o.get_read_io_executor_threads(),
+        7,
+        "Options::read_io_executor_threads"
+    );
+    let mut o = Options::default();
+    o.set_read_triggered_compaction_threshold(0.5);
+    assert_eq!(
+        o.get_read_triggered_compaction_threshold(),
+        0.5,
+        "Options::read_triggered_compaction_threshold"
+    );
+    let mut o = Options::default();
+    o.set_reuse_manifest_on_open(true);
+    assert!(
+        o.get_reuse_manifest_on_open(),
+        "Options::reuse_manifest_on_open"
+    );
+    let mut o = Options::default();
+    o.set_reuse_manifest_on_open(false);
+    assert!(
+        !o.get_reuse_manifest_on_open(),
+        "Options::reuse_manifest_on_open"
+    );
+    let mut o = Options::default();
+    o.set_sample_for_compression(4096);
+    assert_eq!(
+        o.get_sample_for_compression(),
+        4096,
+        "Options::sample_for_compression"
+    );
+    let mut o = Options::default();
+    o.set_stats_history_buffer_size(4096);
+    assert_eq!(
+        o.get_stats_history_buffer_size(),
+        4096,
+        "Options::stats_history_buffer_size"
+    );
+    let mut o = Options::default();
+    o.set_strict_bytes_per_sync(true);
+    assert!(
+        o.get_strict_bytes_per_sync(),
+        "Options::strict_bytes_per_sync"
+    );
+    let mut o = Options::default();
+    o.set_strict_bytes_per_sync(false);
+    assert!(
+        !o.get_strict_bytes_per_sync(),
+        "Options::strict_bytes_per_sync"
+    );
+    let mut o = Options::default();
+    o.set_strict_max_successive_merges(true);
+    assert!(
+        o.get_strict_max_successive_merges(),
+        "Options::strict_max_successive_merges"
+    );
+    let mut o = Options::default();
+    o.set_strict_max_successive_merges(false);
+    assert!(
+        !o.get_strict_max_successive_merges(),
+        "Options::strict_max_successive_merges"
+    );
+    let mut o = Options::default();
+    o.set_target_file_size_is_upper_bound(true);
+    assert!(
+        o.get_target_file_size_is_upper_bound(),
+        "Options::target_file_size_is_upper_bound"
+    );
+    let mut o = Options::default();
+    o.set_target_file_size_is_upper_bound(false);
+    assert!(
+        !o.get_target_file_size_is_upper_bound(),
+        "Options::target_file_size_is_upper_bound"
+    );
+    let mut o = Options::default();
+    o.set_track_and_verify_wals(true);
+    assert!(
+        o.get_track_and_verify_wals(),
+        "Options::track_and_verify_wals"
+    );
+    let mut o = Options::default();
+    o.set_track_and_verify_wals(false);
+    assert!(
+        !o.get_track_and_verify_wals(),
+        "Options::track_and_verify_wals"
+    );
+    let mut o = Options::default();
+    o.set_two_write_queues(true);
+    assert!(o.get_two_write_queues(), "Options::two_write_queues");
+    let mut o = Options::default();
+    o.set_two_write_queues(false);
+    assert!(!o.get_two_write_queues(), "Options::two_write_queues");
+    let mut o = Options::default();
+    o.set_uncache_aggressiveness(7);
+    assert_eq!(
+        o.get_uncache_aggressiveness(),
+        7,
+        "Options::uncache_aggressiveness"
+    );
+    let mut o = Options::default();
+    o.set_use_direct_io_for_compaction_reads(true);
+    assert!(
+        o.get_use_direct_io_for_compaction_reads(),
+        "Options::use_direct_io_for_compaction_reads"
+    );
+    let mut o = Options::default();
+    o.set_use_direct_io_for_compaction_reads(false);
+    assert!(
+        !o.get_use_direct_io_for_compaction_reads(),
+        "Options::use_direct_io_for_compaction_reads"
+    );
+    let mut o = Options::default();
+    o.set_verify_manifest_content_on_close(true);
+    assert!(
+        o.get_verify_manifest_content_on_close(),
+        "Options::verify_manifest_content_on_close"
+    );
+    let mut o = Options::default();
+    o.set_verify_manifest_content_on_close(false);
+    assert!(
+        !o.get_verify_manifest_content_on_close(),
+        "Options::verify_manifest_content_on_close"
+    );
+    let mut o = Options::default();
+    o.set_verify_output_flags(7);
+    assert_eq!(
+        o.get_verify_output_flags(),
+        7,
+        "Options::verify_output_flags"
+    );
+    let mut o = Options::default();
+    o.set_verify_sst_unique_id_in_manifest(true);
+    assert!(
+        o.get_verify_sst_unique_id_in_manifest(),
+        "Options::verify_sst_unique_id_in_manifest"
+    );
+    let mut o = Options::default();
+    o.set_verify_sst_unique_id_in_manifest(false);
+    assert!(
+        !o.get_verify_sst_unique_id_in_manifest(),
+        "Options::verify_sst_unique_id_in_manifest"
+    );
+    let mut o = Options::default();
+    o.set_wal_write_temperature(7);
+    assert_eq!(
+        o.get_wal_write_temperature(),
+        7,
+        "Options::wal_write_temperature"
+    );
+    let mut o = Options::default();
+    o.set_write_thread_max_yield_usec(4096);
+    assert_eq!(
+        o.get_write_thread_max_yield_usec(),
+        4096,
+        "Options::write_thread_max_yield_usec"
+    );
+    let mut o = Options::default();
+    o.set_write_thread_slow_yield_usec(4096);
+    assert_eq!(
+        o.get_write_thread_slow_yield_usec(),
+        4096,
+        "Options::write_thread_slow_yield_usec"
+    );
+}
+
+#[test]
+fn roundtrip_read_options() {
+    let mut o = ReadOptions::default();
+    o.set_adaptive_readahead(true);
+    assert!(
+        o.get_adaptive_readahead(),
+        "ReadOptions::adaptive_readahead"
+    );
+    let mut o = ReadOptions::default();
+    o.set_adaptive_readahead(false);
+    assert!(
+        !o.get_adaptive_readahead(),
+        "ReadOptions::adaptive_readahead"
+    );
+    let mut o = ReadOptions::default();
+    o.set_allow_unprepared_value(true);
+    assert!(
+        o.get_allow_unprepared_value(),
+        "ReadOptions::allow_unprepared_value"
+    );
+    let mut o = ReadOptions::default();
+    o.set_allow_unprepared_value(false);
+    assert!(
+        !o.get_allow_unprepared_value(),
+        "ReadOptions::allow_unprepared_value"
+    );
+    let mut o = ReadOptions::default();
+    o.set_auto_prefix_mode(true);
+    assert!(o.get_auto_prefix_mode(), "ReadOptions::auto_prefix_mode");
+    let mut o = ReadOptions::default();
+    o.set_auto_prefix_mode(false);
+    assert!(!o.get_auto_prefix_mode(), "ReadOptions::auto_prefix_mode");
+    let mut o = ReadOptions::default();
+    o.set_auto_refresh_iterator_with_snapshot(true);
+    assert!(
+        o.get_auto_refresh_iterator_with_snapshot(),
+        "ReadOptions::auto_refresh_iterator_with_snapshot"
+    );
+    let mut o = ReadOptions::default();
+    o.set_auto_refresh_iterator_with_snapshot(false);
+    assert!(
+        !o.get_auto_refresh_iterator_with_snapshot(),
+        "ReadOptions::auto_refresh_iterator_with_snapshot"
+    );
+    let mut o = ReadOptions::default();
+    o.set_merge_operand_count_threshold(4096);
+    assert_eq!(
+        o.get_merge_operand_count_threshold(),
+        4096,
+        "ReadOptions::merge_operand_count_threshold"
+    );
+    let mut o = ReadOptions::default();
+    o.set_value_size_soft_limit(4096);
+    assert_eq!(
+        o.get_value_size_soft_limit(),
+        4096,
+        "ReadOptions::value_size_soft_limit"
+    );
+}
+
+#[test]
+fn roundtrip_transaction_db_options() {
+    let mut o = TransactionDBOptions::default();
+    o.set_enable_udt_validation(true);
+    assert!(
+        o.get_enable_udt_validation(),
+        "TransactionDBOptions::enable_udt_validation"
+    );
+    let mut o = TransactionDBOptions::default();
+    o.set_enable_udt_validation(false);
+    assert!(
+        !o.get_enable_udt_validation(),
+        "TransactionDBOptions::enable_udt_validation"
+    );
+    let mut o = TransactionDBOptions::default();
+    o.set_max_num_deadlocks(7);
+    assert_eq!(
+        o.get_max_num_deadlocks(),
+        7,
+        "TransactionDBOptions::max_num_deadlocks"
+    );
+    let mut o = TransactionDBOptions::default();
+    o.set_rollback_merge_operands(true);
+    assert!(
+        o.get_rollback_merge_operands(),
+        "TransactionDBOptions::rollback_merge_operands"
+    );
+    let mut o = TransactionDBOptions::default();
+    o.set_rollback_merge_operands(false);
+    assert!(
+        !o.get_rollback_merge_operands(),
+        "TransactionDBOptions::rollback_merge_operands"
+    );
+    let mut o = TransactionDBOptions::default();
+    o.set_txn_commit_bypass_memtable_threshold(7);
+    assert_eq!(
+        o.get_txn_commit_bypass_memtable_threshold(),
+        7,
+        "TransactionDBOptions::txn_commit_bypass_memtable_threshold"
+    );
+    let mut o = TransactionDBOptions::default();
+    o.set_use_per_key_point_lock_mgr(true);
+    assert!(
+        o.get_use_per_key_point_lock_mgr(),
+        "TransactionDBOptions::use_per_key_point_lock_mgr"
+    );
+    let mut o = TransactionDBOptions::default();
+    o.set_use_per_key_point_lock_mgr(false);
+    assert!(
+        !o.get_use_per_key_point_lock_mgr(),
+        "TransactionDBOptions::use_per_key_point_lock_mgr"
+    );
+}
+
+#[test]
+fn roundtrip_transaction_options() {
+    let mut o = TransactionOptions::default();
+    o.set_commit_bypass_memtable(true);
+    assert!(
+        o.get_commit_bypass_memtable(),
+        "TransactionOptions::commit_bypass_memtable"
+    );
+    let mut o = TransactionOptions::default();
+    o.set_commit_bypass_memtable(false);
+    assert!(
+        !o.get_commit_bypass_memtable(),
+        "TransactionOptions::commit_bypass_memtable"
+    );
+    let mut o = TransactionOptions::default();
+    o.set_large_txn_commit_optimize_byte_threshold(4096);
+    assert_eq!(
+        o.get_large_txn_commit_optimize_byte_threshold(),
+        4096,
+        "TransactionOptions::large_txn_commit_optimize_byte_threshold"
+    );
+    let mut o = TransactionOptions::default();
+    o.set_large_txn_commit_optimize_threshold(7);
+    assert_eq!(
+        o.get_large_txn_commit_optimize_threshold(),
+        7,
+        "TransactionOptions::large_txn_commit_optimize_threshold"
+    );
+    let mut o = TransactionOptions::default();
+    o.set_skip_concurrency_control(true);
+    assert!(
+        o.get_skip_concurrency_control(),
+        "TransactionOptions::skip_concurrency_control"
+    );
+    let mut o = TransactionOptions::default();
+    o.set_skip_concurrency_control(false);
+    assert!(
+        !o.get_skip_concurrency_control(),
+        "TransactionOptions::skip_concurrency_control"
+    );
+    let mut o = TransactionOptions::default();
+    o.set_use_only_the_last_commit_time_batch_for_recovery(true);
+    assert!(
+        o.get_use_only_the_last_commit_time_batch_for_recovery(),
+        "TransactionOptions::use_only_the_last_commit_time_batch_for_recovery"
+    );
+    let mut o = TransactionOptions::default();
+    o.set_use_only_the_last_commit_time_batch_for_recovery(false);
+    assert!(
+        !o.get_use_only_the_last_commit_time_batch_for_recovery(),
+        "TransactionOptions::use_only_the_last_commit_time_batch_for_recovery"
+    );
+    let mut o = TransactionOptions::default();
+    o.set_write_batch_track_timestamp_size(true);
+    assert!(
+        o.get_write_batch_track_timestamp_size(),
+        "TransactionOptions::write_batch_track_timestamp_size"
+    );
+    let mut o = TransactionOptions::default();
+    o.set_write_batch_track_timestamp_size(false);
+    assert!(
+        !o.get_write_batch_track_timestamp_size(),
+        "TransactionOptions::write_batch_track_timestamp_size"
+    );
+}
+
+#[test]
+fn roundtrip_universal_compact_options() {
+    let mut o = UniversalCompactOptions::default();
+    o.set_allow_trivial_move(true);
+    assert!(
+        o.get_allow_trivial_move(),
+        "UniversalCompactOptions::allow_trivial_move"
+    );
+    let mut o = UniversalCompactOptions::default();
+    o.set_allow_trivial_move(false);
+    assert!(
+        !o.get_allow_trivial_move(),
+        "UniversalCompactOptions::allow_trivial_move"
+    );
+    let mut o = UniversalCompactOptions::default();
+    o.set_incremental(true);
+    assert!(o.get_incremental(), "UniversalCompactOptions::incremental");
+    let mut o = UniversalCompactOptions::default();
+    o.set_incremental(false);
+    assert!(!o.get_incremental(), "UniversalCompactOptions::incremental");
+    let mut o = UniversalCompactOptions::default();
+    o.set_max_read_amp(7);
+    assert_eq!(
+        o.get_max_read_amp(),
+        7,
+        "UniversalCompactOptions::max_read_amp"
+    );
+    let mut o = UniversalCompactOptions::default();
+    o.set_reduce_file_locking(true);
+    assert!(
+        o.get_reduce_file_locking(),
+        "UniversalCompactOptions::reduce_file_locking"
+    );
+    let mut o = UniversalCompactOptions::default();
+    o.set_reduce_file_locking(false);
+    assert!(
+        !o.get_reduce_file_locking(),
+        "UniversalCompactOptions::reduce_file_locking"
+    );
+}
+
+#[test]
+fn roundtrip_wait_for_compact_options() {
+    let mut o = WaitForCompactOptions::default();
+    o.set_wait_for_purge(true);
+    assert!(
+        o.get_wait_for_purge(),
+        "WaitForCompactOptions::wait_for_purge"
+    );
+    let mut o = WaitForCompactOptions::default();
+    o.set_wait_for_purge(false);
+    assert!(
+        !o.get_wait_for_purge(),
+        "WaitForCompactOptions::wait_for_purge"
+    );
+}
+
+#[test]
+fn roundtrip_write_options() {
+    let mut o = WriteOptions::default();
+    o.set_io_activity(7);
+    assert_eq!(o.get_io_activity(), 7, "WriteOptions::io_activity");
+    let mut o = WriteOptions::default();
+    o.set_protection_bytes_per_key(4096);
+    assert_eq!(
+        o.get_protection_bytes_per_key(),
+        4096,
+        "WriteOptions::protection_bytes_per_key"
+    );
+    let mut o = WriteOptions::default();
+    o.set_rate_limiter_priority(7);
+    assert_eq!(
+        o.get_rate_limiter_priority(),
+        7,
+        "WriteOptions::rate_limiter_priority"
+    );
+}


### PR DESCRIPTION
RocksDB 11.6.0 generated a large batch of new C API functions and the wrapper never caught up. Measuring against the bundled 11.8.1 headers, 691 `rocksdb_*` functions have no safe binding at all.

This PR covers the 307 that sit on types the crate already models, so it adds no new public types.

## What is here

| Target | New methods |
| --- | --- |
| `Options` | 136 |
| `BlockBasedOptions` | 52 |
| `IngestExternalFileOptions` | 26 |
| `ReadOptions` | 17 |
| `TransactionOptions` | 16 |
| `TransactionDBOptions` | 13 |
| `BackupEngineOptions` | 8 |
| `UniversalCompactOptions` | 8 |
| `WriteOptions` / `FlushOptions` / `CuckooTableOptions` / `FifoCompactOptions` | 6 each |
| `CompactOptions` | 3 |
| `WaitForCompactOptions` | 2 |
| `OptimisticTransactionOptions` / `RestoreOptions` | 1 each |

Both setters and getters, per full parity. `min_tombstones_for_range_conversion` is in here, which is what prompted this.

## Docs

Doc comments are lifted from the matching field in the upstream C++ headers instead of restating the setter name. The setter carries the full comment and the getter points back at it, so the text is not duplicated across the pair. Upstream's hanging indents and ad-hoc bullets are reflowed into markdown, since rustdoc otherwise reads them as blockquotes and code blocks.

## Testing

`tests/test_capi_options_roundtrip.rs` sets every newly exposed option and reads it back through its getter. 191 assertions across 13 tests.

The compiler already proves the FFI signatures line up, since the types come straight out of the bindgen output. What that does not catch is a setter and getter that disagree, or a bool cast that got inverted, which is what these tests are for.

`cargo fmt --check` clean, `cargo clippy --all-targets` clean, and `test_rocksdb_options`, `test_backup`, `test_transaction_db`, `test_optimistic_transaction_db`, `test_sst_file_writer` and `test_event_listener` all still pass.

## Deliberately left out

`TransactionDBOptions::write_policy` and `RestoreOptions::mode` are C++ enums (`TxnDBWritePolicy`, and `Mode` with `kPurgeAllFiles`/`kKeepLatestDbSessionIdFiles`/`kVerifyChecksum`). Exposing either as a bare `c_int` would lock a bad signature into the public API, so they should come with real Rust enums. `RestoreOptions::set_mode` also wants a better name.

## Follow-ups

- 266 functions that need new Rust types: `TableProperties` (58), `CompactionJobStats` (35), `LiveFilesStorageInfo` (12+7), trace and replay (22), blob file info (8), WAL files (9), and others
- Event listener info accessors. 10 are simple scalars but 14 return pointers to types that do not exist yet, so the whole group is better done together than split across two PRs
- The 23 `EnvOptions` setters. The type exists in `sst_file_writer.rs` but is private, so exposing them is a public API decision
- The two callback APIs, `readoptions_set_table_filter` and `walfilter_create`