### PR TITLE
Expose the remaining C API accessors on modelled types

### DIFF
--- a/src/backup.rs
+++ b/src/backup.rs
@@ -224,6 +224,18 @@ impl BackupEngine {
             info
         }
     }
+
+    /// Aborts a backup that is currently running.
+    ///
+    /// This is one way. Once it is called on a backup engine, every later backup
+    /// request on that engine fails. The backup directory is left consistent and is
+    /// cleaned up by the next backup or garbage collection performed through a new
+    /// backup engine on the same directory.
+    pub fn stop_backup(&mut self) {
+        unsafe {
+            ffi::rocksdb_backup_engine_stop_backup(self.inner);
+        }
+    }
 }
 
 impl BackupEngineOptions {
@@ -355,6 +367,139 @@ impl BackupEngineOptions {
     /// Returns the value of the `share_files_with_checksum` option.
     pub fn get_share_files_with_checksum(&self) -> bool {
         unsafe { ffi::rocksdb_backup_engine_options_get_share_files_with_checksum(self.inner) != 0 }
+    }
+
+    /// Returns the current `backup_log_files` setting.
+    ///
+    /// See [`Self::set_backup_log_files`] for what this controls.
+    pub fn get_backup_log_files(&self) -> bool {
+        unsafe { ffi::rocksdb_backup_engine_options_get_backup_log_files(self.inner) != 0 }
+    }
+
+    /// Returns the current `backup_rate_limit` setting.
+    ///
+    /// See [`Self::set_backup_rate_limit`] for what this controls.
+    pub fn get_backup_rate_limit(&self) -> u64 {
+        unsafe { ffi::rocksdb_backup_engine_options_get_backup_rate_limit(self.inner) }
+    }
+
+    /// Returns the current `callback_trigger_interval_size` setting.
+    ///
+    /// See [`Self::set_callback_trigger_interval_size`] for what this controls.
+    pub fn get_callback_trigger_interval_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_backup_engine_options_get_callback_trigger_interval_size(self.inner) }
+    }
+
+    /// Returns the current `destroy_old_data` setting.
+    ///
+    /// See [`Self::set_destroy_old_data`] for what this controls.
+    pub fn get_destroy_old_data(&self) -> bool {
+        unsafe { ffi::rocksdb_backup_engine_options_get_destroy_old_data(self.inner) != 0 }
+    }
+
+    /// Returns the current `max_background_operations` setting.
+    ///
+    /// See [`Self::set_max_background_operations`] for what this controls.
+    pub fn get_max_background_operations(&self) -> c_int {
+        unsafe { ffi::rocksdb_backup_engine_options_get_max_background_operations(self.inner) }
+    }
+
+    /// Returns the current `max_valid_backups_to_open` setting.
+    ///
+    /// See [`Self::set_max_valid_backups_to_open`] for what this controls.
+    pub fn get_max_valid_backups_to_open(&self) -> c_int {
+        unsafe { ffi::rocksdb_backup_engine_options_get_max_valid_backups_to_open(self.inner) }
+    }
+
+    /// Returns the current `restore_rate_limit` setting.
+    ///
+    /// See [`Self::set_restore_rate_limit`] for what this controls.
+    pub fn get_restore_rate_limit(&self) -> u64 {
+        unsafe { ffi::rocksdb_backup_engine_options_get_restore_rate_limit(self.inner) }
+    }
+
+    /// Returns the current `share_table_files` setting.
+    ///
+    /// See [`Self::set_share_table_files`] for what this controls.
+    pub fn get_share_table_files(&self) -> bool {
+        unsafe { ffi::rocksdb_backup_engine_options_get_share_table_files(self.inner) != 0 }
+    }
+
+    /// If false, we won't backup log files. This option can be useful for backing up
+    /// in-memory databases where log file are persisted, but table files are in memory.
+    /// Default: true.
+    pub fn set_backup_log_files(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_backup_log_files(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// Max bytes that can be transferred in a second while creating a backup.
+    ///
+    /// If 0, go as fast as you can. This limit only applies to writes.
+    ///
+    /// Default: `0`
+    pub fn set_backup_rate_limit(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_backup_rate_limit(self.inner, val);
+        }
+    }
+
+    /// During backup user can get callback every time next callback_trigger_interval_size
+    /// bytes being copied. Default: 4194304.
+    pub fn set_callback_trigger_interval_size(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_callback_trigger_interval_size(self.inner, val);
+        }
+    }
+
+    /// If true, it will delete whatever backups there are already Default: false.
+    pub fn set_destroy_old_data(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_destroy_old_data(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// For BackupEngineReadOnly, Open() will open at most this many of the latest
+    /// non-corrupted backups.
+    ///
+    /// Note: this setting is ignored (behaves like INT_MAX) for any kind of writable
+    /// BackupEngine because it would inhibit accounting for shared files for proper backup
+    /// deletion, including purging any incompletely created backups on creation of a new
+    /// backup.
+    ///
+    /// Default: INT_MAX.
+    pub fn set_max_valid_backups_to_open(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_max_valid_backups_to_open(self.inner, val);
+        }
+    }
+
+    /// Max bytes that can be transferred in a second during restore. If 0, go as fast as you
+    /// can This limit only applies to writes. To also limit reads, a rate limiter able to
+    /// also limit reads (e.g, its mode = kAllIo) have to be passed in through the option
+    /// "restore_rate_limiter" Default: 0.
+    pub fn set_restore_rate_limit(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_restore_rate_limit(self.inner, val);
+        }
+    }
+
+    /// Share_table_files supports table and blob files.
+    ///
+    /// If share_table_files == true, the backup directory will share table and blob files
+    /// among backups, to save space among backups of the same DB and to enable incremental
+    /// backups by only copying new files. If share_table_files == false, each backup will be
+    /// on its own and will not share any data with other backups.
+    ///
+    /// default: true.
+    pub fn set_share_table_files(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_backup_engine_options_set_share_table_files(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
     }
 }
 

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -1513,6 +1513,39 @@ impl BlockBasedOptions {
     pub fn get_whole_key_filtering(&self) -> bool {
         unsafe { ffi::rocksdb_block_based_options_get_whole_key_filtering(self.inner) != 0 }
     }
+
+    /// Align data blocks on lesser of page size and block size.
+    pub fn set_block_align(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_block_align(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// This is used to close a block before it reaches the configured 'block_size'. If the
+    /// percentage of free space in the current block is less than this specified number and
+    /// adding a new record to the block will exceed the configured block size, then this
+    /// block will be closed and the new record will be written to the next block.
+    pub fn set_block_size_deviation(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_block_size_deviation(self.inner, val);
+        }
+    }
+
+    /// When true, data blocks store keys and values separately. Keys are stored at the
+    /// beginning of the block, followed by values at the end. This can improve read
+    /// performance at a cost of a varint per restart interval (~1 bit per key by default), in
+    /// addition to improving compression. Small values or low block_restart_interval may
+    /// prefer to set this as false.
+    ///
+    /// Default: false.
+    pub fn set_separate_key_value_in_data_block(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_block_based_options_set_separate_key_value_in_data_block(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
 }
 
 impl Default for BlockBasedOptions {
@@ -6280,6 +6313,758 @@ impl Options {
     pub fn get_write_thread_slow_yield_usec(&self) -> u64 {
         unsafe { ffi::rocksdb_options_get_write_thread_slow_yield_usec(self.inner) }
     }
+
+    /// Returns the current `advise_random_on_open` setting.
+    ///
+    /// See [`Self::set_advise_random_on_open`] for what this controls.
+    pub fn get_advise_random_on_open(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_advise_random_on_open(self.inner) != 0 }
+    }
+
+    /// Returns the current `allow_concurrent_memtable_write` setting.
+    ///
+    /// See [`Self::set_allow_concurrent_memtable_write`] for what this controls.
+    pub fn get_allow_concurrent_memtable_write(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_allow_concurrent_memtable_write(self.inner) != 0 }
+    }
+
+    /// Returns the current `allow_ingest_behind` setting.
+    ///
+    /// See [`Self::set_allow_ingest_behind`] for what this controls.
+    pub fn get_allow_ingest_behind(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_allow_ingest_behind(self.inner) != 0 }
+    }
+
+    /// Returns the current `allow_mmap_reads` setting.
+    ///
+    /// See [`Self::set_allow_mmap_reads`] for what this controls.
+    pub fn get_allow_mmap_reads(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_allow_mmap_reads(self.inner) != 0 }
+    }
+
+    /// Returns the current `allow_mmap_writes` setting.
+    ///
+    /// See [`Self::set_allow_mmap_writes`] for what this controls.
+    pub fn get_allow_mmap_writes(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_allow_mmap_writes(self.inner) != 0 }
+    }
+
+    /// Returns the current `arena_block_size` setting.
+    ///
+    /// See [`Self::set_arena_block_size`] for what this controls.
+    pub fn get_arena_block_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_arena_block_size(self.inner) }
+    }
+
+    /// Returns the current `atomic_flush` setting.
+    ///
+    /// See [`Self::set_atomic_flush`] for what this controls.
+    pub fn get_atomic_flush(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_atomic_flush(self.inner) != 0 }
+    }
+
+    /// Returns the current `avoid_unnecessary_blocking_io` setting.
+    ///
+    /// See [`Self::set_avoid_unnecessary_blocking_io`] for what this controls.
+    pub fn get_avoid_unnecessary_blocking_io(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_avoid_unnecessary_blocking_io(self.inner) != 0 }
+    }
+
+    /// Returns the current `blob_compaction_readahead_size` setting.
+    ///
+    /// See [`Self::set_blob_compaction_readahead_size`] for what this controls.
+    pub fn get_blob_compaction_readahead_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_blob_compaction_readahead_size(self.inner) }
+    }
+
+    /// Returns the current `blob_file_size` setting.
+    ///
+    /// See [`Self::set_blob_file_size`] for what this controls.
+    pub fn get_blob_file_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_blob_file_size(self.inner) }
+    }
+
+    /// Returns the current `blob_file_starting_level` setting.
+    ///
+    /// See [`Self::set_blob_file_starting_level`] for what this controls.
+    pub fn get_blob_file_starting_level(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_blob_file_starting_level(self.inner) }
+    }
+
+    /// Returns the current `blob_gc_age_cutoff` setting.
+    ///
+    /// See [`Self::set_blob_gc_age_cutoff`] for what this controls.
+    pub fn get_blob_gc_age_cutoff(&self) -> f64 {
+        unsafe { ffi::rocksdb_options_get_blob_gc_age_cutoff(self.inner) }
+    }
+
+    /// Returns the current `blob_gc_force_threshold` setting.
+    ///
+    /// See [`Self::set_blob_gc_force_threshold`] for what this controls.
+    pub fn get_blob_gc_force_threshold(&self) -> f64 {
+        unsafe { ffi::rocksdb_options_get_blob_gc_force_threshold(self.inner) }
+    }
+
+    /// Returns the current `bloom_locality` setting.
+    ///
+    /// See [`Self::set_bloom_locality`] for what this controls.
+    pub fn get_bloom_locality(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_bloom_locality(self.inner) }
+    }
+
+    /// Returns the current `bottommost_compression_options_use_zstd_dict_trainer` setting.
+    ///
+    /// See [`Self::set_bottommost_compression_options_use_zstd_dict_trainer`] for what this controls.
+    pub fn get_bottommost_compression_options_use_zstd_dict_trainer(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_options_get_bottommost_compression_options_use_zstd_dict_trainer(
+                self.inner,
+            ) != 0
+        }
+    }
+
+    /// Returns the current `bytes_per_sync` setting.
+    ///
+    /// See [`Self::set_bytes_per_sync`] for what this controls.
+    pub fn get_bytes_per_sync(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_bytes_per_sync(self.inner) }
+    }
+
+    /// Returns the current `compaction_readahead_size` setting.
+    ///
+    /// See [`Self::set_compaction_readahead_size`] for what this controls.
+    pub fn get_compaction_readahead_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_compaction_readahead_size(self.inner) }
+    }
+
+    /// Returns the current `compression_options_max_dict_buffer_bytes` setting.
+    ///
+    /// See [`Self::set_compression_options_max_dict_buffer_bytes`] for what this controls.
+    pub fn get_compression_options_max_dict_buffer_bytes(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_compression_options_max_dict_buffer_bytes(self.inner) }
+    }
+
+    /// Returns the current `compression_options_parallel_threads` setting.
+    ///
+    /// See [`Self::set_compression_options_parallel_threads`] for what this controls.
+    pub fn get_compression_options_parallel_threads(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_compression_options_parallel_threads(self.inner) }
+    }
+
+    /// Returns the current `compression_options_use_zstd_dict_trainer` setting.
+    ///
+    /// See [`Self::set_compression_options_use_zstd_dict_trainer`] for what this controls.
+    pub fn get_compression_options_use_zstd_dict_trainer(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_options_get_compression_options_use_zstd_dict_trainer(self.inner) != 0
+        }
+    }
+
+    /// Returns the maximum size of training data passed to zstd's dictionary trainer.
+    pub fn get_compression_options_zstd_max_train_bytes(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_compression_options_zstd_max_train_bytes(self.inner) }
+    }
+
+    /// Returns the current `create_if_missing` setting.
+    ///
+    /// See [`Self::create_if_missing`] for what this controls.
+    pub fn get_create_if_missing(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_create_if_missing(self.inner) != 0 }
+    }
+
+    /// Returns the current `create_missing_column_families` setting.
+    ///
+    /// See [`Self::create_missing_column_families`] for what this controls.
+    pub fn get_create_missing_column_families(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_create_missing_column_families(self.inner) != 0 }
+    }
+
+    /// Returns the current `db_write_buffer_size` setting.
+    ///
+    /// See [`Self::set_db_write_buffer_size`] for what this controls.
+    pub fn get_db_write_buffer_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_db_write_buffer_size(self.inner) }
+    }
+
+    /// Returns the current `delete_obsolete_files_period_micros` setting.
+    ///
+    /// See [`Self::set_delete_obsolete_files_period_micros`] for what this controls.
+    pub fn get_delete_obsolete_files_period_micros(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_delete_obsolete_files_period_micros(self.inner) }
+    }
+
+    /// Returns the current `disable_auto_compactions` setting.
+    ///
+    /// See [`Self::set_disable_auto_compactions`] for what this controls.
+    pub fn get_disable_auto_compactions(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_disable_auto_compactions(self.inner) != 0 }
+    }
+
+    /// Returns the current `enable_blob_files` setting.
+    ///
+    /// See [`Self::set_enable_blob_files`] for what this controls.
+    pub fn get_enable_blob_files(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_enable_blob_files(self.inner) != 0 }
+    }
+
+    /// Returns the current `enable_blob_gc` setting.
+    ///
+    /// See [`Self::set_enable_blob_gc`] for what this controls.
+    pub fn get_enable_blob_gc(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_enable_blob_gc(self.inner) != 0 }
+    }
+
+    /// Returns the current `enable_pipelined_write` setting.
+    ///
+    /// See [`Self::set_enable_pipelined_write`] for what this controls.
+    pub fn get_enable_pipelined_write(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_enable_pipelined_write(self.inner) != 0 }
+    }
+
+    /// Returns the current `enable_write_thread_adaptive_yield` setting.
+    ///
+    /// See [`Self::set_enable_write_thread_adaptive_yield`] for what this controls.
+    pub fn get_enable_write_thread_adaptive_yield(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_enable_write_thread_adaptive_yield(self.inner) != 0 }
+    }
+
+    /// Returns the current `error_if_exists` setting.
+    ///
+    /// See [`Self::set_error_if_exists`] for what this controls.
+    pub fn get_error_if_exists(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_error_if_exists(self.inner) != 0 }
+    }
+
+    /// Returns the current `experimental_mempurge_threshold` setting.
+    ///
+    /// See [`Self::set_experimental_mempurge_threshold`] for what this controls.
+    pub fn get_experimental_mempurge_threshold(&self) -> f64 {
+        unsafe { ffi::rocksdb_options_get_experimental_mempurge_threshold(self.inner) }
+    }
+
+    /// Returns the current `hard_pending_compaction_bytes_limit` setting.
+    ///
+    /// See [`Self::set_hard_pending_compaction_bytes_limit`] for what this controls.
+    pub fn get_hard_pending_compaction_bytes_limit(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_hard_pending_compaction_bytes_limit(self.inner) }
+    }
+
+    /// Number of locks used for inplace update Default: 10000, if inplace_update_support =
+    /// true, else 0.
+    ///
+    /// Dynamically changeable through SetOptions() API.
+    pub fn get_inplace_update_num_locks(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_inplace_update_num_locks(self.inner) }
+    }
+
+    /// Returns the current `inplace_update_support` setting.
+    ///
+    /// See [`Self::set_inplace_update_support`] for what this controls.
+    pub fn get_inplace_update_support(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_inplace_update_support(self.inner) != 0 }
+    }
+
+    /// Returns the current `is_fd_close_on_exec` setting.
+    ///
+    /// See [`Self::set_is_fd_close_on_exec`] for what this controls.
+    pub fn get_is_fd_close_on_exec(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_is_fd_close_on_exec(self.inner) != 0 }
+    }
+
+    /// Returns the current `keep_log_file_num` setting.
+    ///
+    /// See [`Self::set_keep_log_file_num`] for what this controls.
+    pub fn get_keep_log_file_num(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_keep_log_file_num(self.inner) }
+    }
+
+    /// Number of files to trigger level-0 compaction. A value <0 means that level-0
+    /// compaction will not be triggered by number of files at all.
+    ///
+    /// Universal compaction: RocksDB will try to keep the number of sorted runs no more than
+    /// this number. If CompactionOptionsUniversal::max_read_amp is set, then this option will
+    /// be used only as a trigger to look for compaction.
+    /// CompactionOptionsUniversal::max_read_amp will be the limit on the number of sorted
+    /// runs.
+    ///
+    /// Default: 4
+    ///
+    /// Dynamically changeable through SetOptions() API.
+    pub fn get_level0_file_num_compaction_trigger(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_level0_file_num_compaction_trigger(self.inner) }
+    }
+
+    /// Soft limit on number of level-0 files. We start slowing down writes at this point. A
+    /// value <0 means that no writing slow down will be triggered by number of files in
+    /// level-0.
+    ///
+    /// Default: 20
+    ///
+    /// Dynamically changeable through SetOptions() API.
+    pub fn get_level0_slowdown_writes_trigger(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_level0_slowdown_writes_trigger(self.inner) }
+    }
+
+    /// Maximum number of level-0 files.  We stop writes at this point.
+    ///
+    /// Default: 36
+    ///
+    /// Dynamically changeable through SetOptions() API.
+    pub fn get_level0_stop_writes_trigger(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_level0_stop_writes_trigger(self.inner) }
+    }
+
+    /// Returns the current `level_compaction_dynamic_level_bytes` setting.
+    ///
+    /// See [`Self::set_level_compaction_dynamic_level_bytes`] for what this controls.
+    pub fn get_level_compaction_dynamic_level_bytes(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_level_compaction_dynamic_level_bytes(self.inner) != 0 }
+    }
+
+    /// Returns the current `log_file_time_to_roll` setting.
+    ///
+    /// See [`Self::set_log_file_time_to_roll`] for what this controls.
+    pub fn get_log_file_time_to_roll(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_log_file_time_to_roll(self.inner) }
+    }
+
+    /// Returns the current `manifest_preallocation_size` setting.
+    ///
+    /// See [`Self::set_manifest_preallocation_size`] for what this controls.
+    pub fn get_manifest_preallocation_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_manifest_preallocation_size(self.inner) }
+    }
+
+    /// Returns the current `manual_wal_flush` setting.
+    ///
+    /// See [`Self::set_manual_wal_flush`] for what this controls.
+    pub fn get_manual_wal_flush(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_manual_wal_flush(self.inner) != 0 }
+    }
+
+    /// Returns the current `max_background_jobs` setting.
+    ///
+    /// See [`Self::set_max_background_jobs`] for what this controls.
+    pub fn get_max_background_jobs(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_max_background_jobs(self.inner) }
+    }
+
+    /// Returns the current `max_bytes_for_level_base` setting.
+    ///
+    /// See [`Self::set_max_bytes_for_level_base`] for what this controls.
+    pub fn get_max_bytes_for_level_base(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_max_bytes_for_level_base(self.inner) }
+    }
+
+    /// Returns the current `max_bytes_for_level_multiplier` setting.
+    ///
+    /// See [`Self::set_max_bytes_for_level_multiplier`] for what this controls.
+    pub fn get_max_bytes_for_level_multiplier(&self) -> f64 {
+        unsafe { ffi::rocksdb_options_get_max_bytes_for_level_multiplier(self.inner) }
+    }
+
+    /// Returns the current `max_compaction_bytes` setting.
+    ///
+    /// See [`Self::set_max_compaction_bytes`] for what this controls.
+    pub fn get_max_compaction_bytes(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_max_compaction_bytes(self.inner) }
+    }
+
+    /// Returns the current `max_file_opening_threads` setting.
+    ///
+    /// See [`Self::set_max_file_opening_threads`] for what this controls.
+    pub fn get_max_file_opening_threads(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_max_file_opening_threads(self.inner) }
+    }
+
+    /// Returns the current `max_log_file_size` setting.
+    ///
+    /// See [`Self::set_max_log_file_size`] for what this controls.
+    pub fn get_max_log_file_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_max_log_file_size(self.inner) }
+    }
+
+    /// Returns the current `max_manifest_file_size` setting.
+    ///
+    /// See [`Self::set_max_manifest_file_size`] for what this controls.
+    pub fn get_max_manifest_file_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_max_manifest_file_size(self.inner) }
+    }
+
+    /// Returns the current `max_open_files` setting.
+    ///
+    /// See [`Self::set_max_open_files`] for what this controls.
+    pub fn get_max_open_files(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_max_open_files(self.inner) }
+    }
+
+    /// Returns the current `max_sequential_skip_in_iterations` setting.
+    ///
+    /// See [`Self::set_max_sequential_skip_in_iterations`] for what this controls.
+    pub fn get_max_sequential_skip_in_iterations(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_max_sequential_skip_in_iterations(self.inner) }
+    }
+
+    /// Returns the current `max_subcompactions` setting.
+    ///
+    /// See [`Self::set_max_subcompactions`] for what this controls.
+    pub fn get_max_subcompactions(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_max_subcompactions(self.inner) }
+    }
+
+    /// Returns the current `max_successive_merges` setting.
+    ///
+    /// See [`Self::set_max_successive_merges`] for what this controls.
+    pub fn get_max_successive_merges(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_max_successive_merges(self.inner) }
+    }
+
+    /// Returns the current `max_total_wal_size` setting.
+    ///
+    /// See [`Self::set_max_total_wal_size`] for what this controls.
+    pub fn get_max_total_wal_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_max_total_wal_size(self.inner) }
+    }
+
+    /// Returns the current `max_write_buffer_number` setting.
+    ///
+    /// See [`Self::set_max_write_buffer_number`] for what this controls.
+    pub fn get_max_write_buffer_number(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_max_write_buffer_number(self.inner) }
+    }
+
+    /// Returns the current `max_write_buffer_size_to_maintain` setting.
+    ///
+    /// See [`Self::set_max_write_buffer_size_to_maintain`] for what this controls.
+    pub fn get_max_write_buffer_size_to_maintain(&self) -> i64 {
+        unsafe { ffi::rocksdb_options_get_max_write_buffer_size_to_maintain(self.inner) }
+    }
+
+    /// Returns the current `memtable_avg_op_scan_flush_trigger` setting.
+    ///
+    /// See [`Self::set_memtable_avg_op_scan_flush_trigger`] for what this controls.
+    pub fn get_memtable_avg_op_scan_flush_trigger(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_memtable_avg_op_scan_flush_trigger(self.inner) }
+    }
+
+    /// Returns the current `memtable_huge_page_size` setting.
+    ///
+    /// See [`Self::set_memtable_huge_page_size`] for what this controls.
+    pub fn get_memtable_huge_page_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_memtable_huge_page_size(self.inner) }
+    }
+
+    /// Returns the current `memtable_op_scan_flush_trigger` setting.
+    ///
+    /// See [`Self::set_memtable_op_scan_flush_trigger`] for what this controls.
+    pub fn get_memtable_op_scan_flush_trigger(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_memtable_op_scan_flush_trigger(self.inner) }
+    }
+
+    /// Should really be called `memtable_bloom_size_ratio`. Enables a dynamic Bloom filter in
+    /// memtable to optimize many queries that must go beyond the memtable. The size in bytes
+    /// of the filter is write_buffer_size * memtable_prefix_bloom_size_ratio.
+    /// - If prefix_extractor is set, the filter includes prefixes.
+    /// - If memtable_whole_key_filtering, the filter includes whole keys.
+    /// - If both, the filter includes both.
+    /// - If neither, the feature is disabled.
+    ///
+    /// If this value is larger than 0.25, it is sanitized to 0.25.
+    ///
+    /// Default: 0 (disabled)
+    ///
+    /// Dynamically changeable through SetOptions() API.
+    pub fn get_memtable_prefix_bloom_size_ratio(&self) -> f64 {
+        unsafe { ffi::rocksdb_options_get_memtable_prefix_bloom_size_ratio(self.inner) }
+    }
+
+    /// Returns the current `min_blob_size` setting.
+    ///
+    /// See [`Self::set_min_blob_size`] for what this controls.
+    pub fn get_min_blob_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_min_blob_size(self.inner) }
+    }
+
+    /// Returns the current `min_write_buffer_number_to_merge` setting.
+    ///
+    /// See [`Self::set_min_write_buffer_number_to_merge`] for what this controls.
+    pub fn get_min_write_buffer_number_to_merge(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_min_write_buffer_number_to_merge(self.inner) }
+    }
+
+    /// Returns the current `num_levels` setting.
+    ///
+    /// See [`Self::set_num_levels`] for what this controls.
+    pub fn get_num_levels(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_num_levels(self.inner) }
+    }
+
+    /// Returns the current `optimize_filters_for_hits` setting.
+    ///
+    /// See [`Self::set_optimize_filters_for_hits`] for what this controls.
+    pub fn get_optimize_filters_for_hits(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_optimize_filters_for_hits(self.inner) != 0 }
+    }
+
+    /// Returns the current `paranoid_checks` setting.
+    ///
+    /// See [`Self::set_paranoid_checks`] for what this controls.
+    pub fn get_paranoid_checks(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_paranoid_checks(self.inner) != 0 }
+    }
+
+    /// Returns the current `periodic_compaction_seconds` setting.
+    ///
+    /// See [`Self::set_periodic_compaction_seconds`] for what this controls.
+    pub fn get_periodic_compaction_seconds(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_periodic_compaction_seconds(self.inner) }
+    }
+
+    /// Returns the current `recycle_log_file_num` setting.
+    ///
+    /// See [`Self::set_recycle_log_file_num`] for what this controls.
+    pub fn get_recycle_log_file_num(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_recycle_log_file_num(self.inner) }
+    }
+
+    /// Returns the current `report_bg_io_stats` setting.
+    ///
+    /// See [`Self::set_report_bg_io_stats`] for what this controls.
+    pub fn get_report_bg_io_stats(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_report_bg_io_stats(self.inner) != 0 }
+    }
+
+    /// Returns the current `skip_stats_update_on_db_open` setting.
+    ///
+    /// See [`Self::set_skip_stats_update_on_db_open`] for what this controls.
+    pub fn get_skip_stats_update_on_db_open(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_skip_stats_update_on_db_open(self.inner) != 0 }
+    }
+
+    /// Returns the current `soft_pending_compaction_bytes_limit` setting.
+    ///
+    /// See [`Self::set_soft_pending_compaction_bytes_limit`] for what this controls.
+    pub fn get_soft_pending_compaction_bytes_limit(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_soft_pending_compaction_bytes_limit(self.inner) }
+    }
+
+    /// Returns the current `stats_dump_period_sec` setting.
+    ///
+    /// See [`Self::set_stats_dump_period_sec`] for what this controls.
+    pub fn get_stats_dump_period_sec(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_stats_dump_period_sec(self.inner) }
+    }
+
+    /// Returns the current `stats_persist_period_sec` setting.
+    ///
+    /// See [`Self::set_stats_persist_period_sec`] for what this controls.
+    pub fn get_stats_persist_period_sec(&self) -> u32 {
+        unsafe { ffi::rocksdb_options_get_stats_persist_period_sec(self.inner) }
+    }
+
+    /// Number of shards used for table cache.
+    pub fn get_table_cache_numshardbits(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_table_cache_numshardbits(self.inner) }
+    }
+
+    /// Returns the current `target_file_size_base` setting.
+    ///
+    /// See [`Self::set_target_file_size_base`] for what this controls.
+    pub fn get_target_file_size_base(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_target_file_size_base(self.inner) }
+    }
+
+    /// Returns the current `target_file_size_multiplier` setting.
+    ///
+    /// See [`Self::set_target_file_size_multiplier`] for what this controls.
+    pub fn get_target_file_size_multiplier(&self) -> c_int {
+        unsafe { ffi::rocksdb_options_get_target_file_size_multiplier(self.inner) }
+    }
+
+    /// Returns the current `ttl` setting.
+    ///
+    /// See [`Self::set_ttl`] for what this controls.
+    pub fn get_ttl(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_ttl(self.inner) }
+    }
+
+    /// Returns the current `unordered_write` setting.
+    ///
+    /// See [`Self::set_unordered_write`] for what this controls.
+    pub fn get_unordered_write(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_unordered_write(self.inner) != 0 }
+    }
+
+    /// Returns the current `use_adaptive_mutex` setting.
+    ///
+    /// See [`Self::set_use_adaptive_mutex`] for what this controls.
+    pub fn get_use_adaptive_mutex(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_use_adaptive_mutex(self.inner) != 0 }
+    }
+
+    /// Returns the current `use_direct_io_for_flush_and_compaction` setting.
+    ///
+    /// See [`Self::set_use_direct_io_for_flush_and_compaction`] for what this controls.
+    pub fn get_use_direct_io_for_flush_and_compaction(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_use_direct_io_for_flush_and_compaction(self.inner) != 0 }
+    }
+
+    /// Returns the current `use_direct_reads` setting.
+    ///
+    /// See [`Self::set_use_direct_reads`] for what this controls.
+    pub fn get_use_direct_reads(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_use_direct_reads(self.inner) != 0 }
+    }
+
+    /// Returns the current `wal_bytes_per_sync` setting.
+    ///
+    /// See [`Self::set_wal_bytes_per_sync`] for what this controls.
+    pub fn get_wal_bytes_per_sync(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_wal_bytes_per_sync(self.inner) }
+    }
+
+    /// Returns the current `wal_size_limit_mb` setting.
+    ///
+    /// See [`Self::set_wal_size_limit_mb`] for what this controls.
+    pub fn get_wal_size_limit_mb(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_WAL_size_limit_MB(self.inner) }
+    }
+
+    /// Returns the current `wal_ttl_seconds` setting.
+    ///
+    /// See [`Self::set_wal_ttl_seconds`] for what this controls.
+    pub fn get_wal_ttl_seconds(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_WAL_ttl_seconds(self.inner) }
+    }
+
+    /// Returns the current `writable_file_max_buffer_size` setting.
+    ///
+    /// See [`Self::set_writable_file_max_buffer_size`] for what this controls.
+    pub fn get_writable_file_max_buffer_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_options_get_writable_file_max_buffer_size(self.inner) }
+    }
+
+    /// Returns the current `write_buffer_size` setting.
+    ///
+    /// See [`Self::set_write_buffer_size`] for what this controls.
+    pub fn get_write_buffer_size(&self) -> usize {
+        unsafe { ffi::rocksdb_options_get_write_buffer_size(self.inner) }
+    }
+
+    /// Returns the current `write_identity_file` setting.
+    ///
+    /// See [`Self::set_write_identity_file`] for what this controls.
+    pub fn get_write_identity_file(&self) -> bool {
+        unsafe { ffi::rocksdb_options_get_write_identity_file(self.inner) != 0 }
+    }
+
+    /// Enable blob files starting from a certain LSM tree level.
+    ///
+    /// For certain use cases that have a mix of short-lived and long-lived values, it might
+    /// make sense to support extracting large values only during compactions whose output
+    /// level is greater than or equal to a specified LSM tree level (e.g. compactions into
+    /// L1/L2/... or above). This could reduce the space amplification caused by large values
+    /// that are turned into garbage shortly after being written at the price of some write
+    /// amplification incurred by long-lived values whose extraction to blob files is delayed.
+    ///
+    /// Default: 0
+    ///
+    /// Dynamically changeable through the SetOptions() API.
+    pub fn set_blob_file_starting_level(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_options_set_blob_file_starting_level(self.inner, val);
+        }
+    }
+
+    /// Bottommost-level counterpart of
+    /// [`Self::set_compression_options_max_dict_buffer_bytes`].
+    ///
+    /// `enabled` must be true for the bottommost setting to take effect; otherwise
+    /// the non-bottommost compression options apply.
+    pub fn set_bottommost_compression_options_max_dict_buffer_bytes(
+        &mut self,
+        max_dict_buffer_bytes: u64,
+        enabled: bool,
+    ) {
+        unsafe {
+            ffi::rocksdb_options_set_bottommost_compression_options_max_dict_buffer_bytes(
+                self.inner,
+                max_dict_buffer_bytes,
+                c_uchar::from(enabled),
+            );
+        }
+    }
+
+    /// Bottommost-level counterpart of
+    /// [`Self::set_compression_options_use_zstd_dict_trainer`].
+    ///
+    /// `enabled` must be true for the bottommost setting to take effect; otherwise
+    /// the non-bottommost compression options apply.
+    pub fn set_bottommost_compression_options_use_zstd_dict_trainer(
+        &mut self,
+        use_zstd_dict_trainer: bool,
+        enabled: bool,
+    ) {
+        unsafe {
+            ffi::rocksdb_options_set_bottommost_compression_options_use_zstd_dict_trainer(
+                self.inner,
+                c_uchar::from(use_zstd_dict_trainer),
+                c_uchar::from(enabled),
+            );
+        }
+    }
+
+    /// Limits the max buffered data used to build the compression dictionary.
+    ///
+    /// Limiting too strictly may harm dictionary effectiveness, because it forces
+    /// RocksDB to pick samples from the start of the output SST, which may not
+    /// represent the whole file. Setting it below `zstd_max_train_bytes` restricts
+    /// how many samples reach the dictionary trainer, and setting it below
+    /// `max_dict_bytes` restricts the size of the final dictionary.
+    ///
+    /// Default: `0`
+    pub fn set_compression_options_max_dict_buffer_bytes(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_options_set_compression_options_max_dict_buffer_bytes(self.inner, val);
+        }
+    }
+
+    /// Selects how zstd dictionaries are generated.
+    ///
+    /// When true, buffered data is passed to zstd's dictionary trainer. When false,
+    /// zstd's `ZDICT_finalizeDictionary()` is called instead, which saves CPU during
+    /// training but usually gives a worse compression ratio.
+    ///
+    /// Default: `true`
+    pub fn set_compression_options_use_zstd_dict_trainer(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_compression_options_use_zstd_dict_trainer(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// Installs the built-in merge operator that adds 64-bit counters.
+    ///
+    /// Values are RocksDB fixed-width 64-bit integers, and a value that is not
+    /// exactly that width is treated as 0 rather than failing the merge.
+    pub fn set_uint64add_merge_operator(&mut self) {
+        unsafe {
+            ffi::rocksdb_options_set_uint64add_merge_operator(self.inner);
+        }
+    }
+
+    /// It is expected that the Identity file will be obsoleted by recording DB ID in the
+    /// manifest (see write_dbid_to_manifest). Setting this to true maintains the historical
+    /// behavior of writing an Identity file, while setting to false is expected to be the
+    /// future default. This option might eventually be obsolete and removed as Identity files
+    /// are phased out.
+    pub fn set_write_identity_file(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_options_set_write_identity_file(self.inner, c_uchar::from(val));
+        }
+    }
 }
 
 impl Default for Options {
@@ -6365,6 +7150,13 @@ impl FlushOptions {
     /// Returns the value of the `listener_wait` option.
     pub fn get_listener_wait(&self) -> bool {
         unsafe { ffi::rocksdb_flushoptions_get_listener_wait(self.inner) != 0 }
+    }
+
+    /// Returns the current `wait` setting.
+    ///
+    /// See [`Self::set_wait`] for what this controls.
+    pub fn get_wait(&self) -> bool {
+        unsafe { ffi::rocksdb_flushoptions_get_wait(self.inner) != 0 }
     }
 }
 
@@ -6508,6 +7300,48 @@ impl WriteOptions {
     /// Returns the value of the `rate_limiter_priority` option.
     pub fn get_rate_limiter_priority(&self) -> c_int {
         unsafe { ffi::rocksdb_writeoptions_get_rate_limiter_priority(self.inner) }
+    }
+
+    /// Returns the current `disable_wal` setting.
+    ///
+    /// See [`Self::disable_wal`] for what this controls.
+    pub fn get_disable_wal(&self) -> bool {
+        unsafe { ffi::rocksdb_writeoptions_get_disable_WAL(self.inner) != 0 }
+    }
+
+    /// Returns the current `ignore_missing_column_families` setting.
+    ///
+    /// See [`Self::set_ignore_missing_column_families`] for what this controls.
+    pub fn get_ignore_missing_column_families(&self) -> bool {
+        unsafe { ffi::rocksdb_writeoptions_get_ignore_missing_column_families(self.inner) != 0 }
+    }
+
+    /// Returns the current `low_pri` setting.
+    ///
+    /// See [`Self::set_low_pri`] for what this controls.
+    pub fn get_low_pri(&self) -> bool {
+        unsafe { ffi::rocksdb_writeoptions_get_low_pri(self.inner) != 0 }
+    }
+
+    /// Returns the current `memtable_insert_hint_per_batch` setting.
+    ///
+    /// See [`Self::set_memtable_insert_hint_per_batch`] for what this controls.
+    pub fn get_memtable_insert_hint_per_batch(&self) -> bool {
+        unsafe { ffi::rocksdb_writeoptions_get_memtable_insert_hint_per_batch(self.inner) != 0 }
+    }
+
+    /// Returns the current `no_slowdown` setting.
+    ///
+    /// See [`Self::set_no_slowdown`] for what this controls.
+    pub fn get_no_slowdown(&self) -> bool {
+        unsafe { ffi::rocksdb_writeoptions_get_no_slowdown(self.inner) != 0 }
+    }
+
+    /// Returns the current `sync` setting.
+    ///
+    /// See [`Self::set_sync`] for what this controls.
+    pub fn get_sync(&self) -> bool {
+        unsafe { ffi::rocksdb_writeoptions_get_sync(self.inner) != 0 }
     }
 }
 
@@ -7181,6 +8015,108 @@ impl ReadOptions {
     pub fn get_value_size_soft_limit(&self) -> u64 {
         unsafe { ffi::rocksdb_readoptions_get_value_size_soft_limit(self.inner) }
     }
+
+    /// Clears the merge operand count threshold, restoring the default of no limit.
+    ///
+    /// See [`Self::set_merge_operand_count_threshold`].
+    pub fn clear_merge_operand_count_threshold(&mut self) {
+        unsafe {
+            ffi::rocksdb_readoptions_clear_merge_operand_count_threshold(self.inner);
+        }
+    }
+
+    /// Returns the current `async_io` setting.
+    ///
+    /// See [`Self::set_async_io`] for what this controls.
+    pub fn get_async_io(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_async_io(self.inner) != 0 }
+    }
+
+    /// Returns the current `background_purge_on_iterator_cleanup` setting.
+    ///
+    /// See [`Self::set_background_purge_on_iterator_cleanup`] for what this controls.
+    pub fn get_background_purge_on_iterator_cleanup(&self) -> bool {
+        unsafe {
+            ffi::rocksdb_readoptions_get_background_purge_on_iterator_cleanup(self.inner) != 0
+        }
+    }
+
+    /// Returns the current `deadline` setting.
+    ///
+    /// See [`Self::set_deadline`] for what this controls.
+    pub fn get_deadline(&self) -> u64 {
+        unsafe { ffi::rocksdb_readoptions_get_deadline(self.inner) }
+    }
+
+    /// Returns the current `fill_cache` setting.
+    ///
+    /// See [`Self::fill_cache`] for what this controls.
+    pub fn get_fill_cache(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_fill_cache(self.inner) != 0 }
+    }
+
+    /// Returns the current `io_timeout` setting.
+    ///
+    /// See [`Self::set_io_timeout`] for what this controls.
+    pub fn get_io_timeout(&self) -> u64 {
+        unsafe { ffi::rocksdb_readoptions_get_io_timeout(self.inner) }
+    }
+
+    /// Returns the current `max_skippable_internal_keys` setting.
+    ///
+    /// See [`Self::set_max_skippable_internal_keys`] for what this controls.
+    pub fn get_max_skippable_internal_keys(&self) -> u64 {
+        unsafe { ffi::rocksdb_readoptions_get_max_skippable_internal_keys(self.inner) }
+    }
+
+    /// Returns the current `pin_data` setting.
+    ///
+    /// See [`Self::set_pin_data`] for what this controls.
+    pub fn get_pin_data(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_pin_data(self.inner) != 0 }
+    }
+
+    /// Returns the current `prefix_same_as_start` setting.
+    ///
+    /// See [`Self::set_prefix_same_as_start`] for what this controls.
+    pub fn get_prefix_same_as_start(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_prefix_same_as_start(self.inner) != 0 }
+    }
+
+    /// Returns the current `readahead_size` setting.
+    ///
+    /// See [`Self::set_readahead_size`] for what this controls.
+    pub fn get_readahead_size(&self) -> usize {
+        unsafe { ffi::rocksdb_readoptions_get_readahead_size(self.inner) }
+    }
+
+    /// Returns the current `tailing` setting.
+    ///
+    /// See [`Self::set_tailing`] for what this controls.
+    pub fn get_tailing(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_tailing(self.inner) != 0 }
+    }
+
+    /// Returns the current `total_order_seek` setting.
+    ///
+    /// See [`Self::set_total_order_seek`] for what this controls.
+    pub fn get_total_order_seek(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_total_order_seek(self.inner) != 0 }
+    }
+
+    /// Returns the current `verify_checksums` setting.
+    ///
+    /// See [`Self::set_verify_checksums`] for what this controls.
+    pub fn get_verify_checksums(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_get_verify_checksums(self.inner) != 0 }
+    }
+
+    /// Returns whether a merge operand count threshold is set.
+    ///
+    /// See [`Self::set_merge_operand_count_threshold`].
+    pub fn has_merge_operand_count_threshold(&self) -> bool {
+        unsafe { ffi::rocksdb_readoptions_has_merge_operand_count_threshold(self.inner) != 0 }
+    }
 }
 
 impl Default for ReadOptions {
@@ -7538,6 +8474,23 @@ impl IngestExternalFileOptions {
     pub fn get_write_global_seqno(&self) -> bool {
         unsafe { ffi::rocksdb_ingestexternalfileoptions_get_write_global_seqno(self.inner) != 0 }
     }
+
+    /// Set to TRUE if user wants file to be ingested to the last level. An error of
+    /// Status::TryAgain() will be returned if a file cannot fit in the last level when
+    /// calling DB::IngestExternalFile()/DB::IngestExternalFiles(). The user should clear the
+    /// last level in the overlapping range before re-attempt.
+    ///
+    /// ingest_behind takes precedence over fail_if_not_bottommost_level.
+    ///
+    /// XXX: "bottommost" is obsolete/confusing terminology to refer to last level.
+    pub fn set_fail_if_not_bottommost_level(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_ingestexternalfileoptions_set_fail_if_not_bottommost_level(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
 }
 
 impl Default for IngestExternalFileOptions {
@@ -7809,6 +8762,100 @@ impl FifoCompactOptions {
     pub fn get_trivial_copy_buffer_size(&self) -> u64 {
         unsafe { ffi::rocksdb_fifo_compaction_options_get_trivial_copy_buffer_size(self.inner) }
     }
+
+    /// Returns the current `allow_compaction` setting.
+    ///
+    /// See [`Self::set_allow_compaction`] for what this controls.
+    pub fn get_allow_compaction(&self) -> bool {
+        unsafe { ffi::rocksdb_fifo_compaction_options_get_allow_compaction(self.inner) != 0 }
+    }
+
+    /// Returns the current `max_data_files_size` setting.
+    ///
+    /// See [`Self::set_max_data_files_size`] for what this controls.
+    pub fn get_max_data_files_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_fifo_compaction_options_get_max_data_files_size(self.inner) }
+    }
+
+    /// Returns the current `max_table_files_size` setting.
+    ///
+    /// See [`Self::set_max_table_files_size`] for what this controls.
+    pub fn get_max_table_files_size(&self) -> u64 {
+        unsafe { ffi::rocksdb_fifo_compaction_options_get_max_table_files_size(self.inner) }
+    }
+
+    /// Returns the current `use_kv_ratio_compaction` setting.
+    ///
+    /// See [`Self::set_use_kv_ratio_compaction`] for what this controls.
+    pub fn get_use_kv_ratio_compaction(&self) -> bool {
+        unsafe { ffi::rocksdb_fifo_compaction_options_get_use_kv_ratio_compaction(self.inner) != 0 }
+    }
+
+    /// If true, try to do compaction to compact smaller files into larger ones. Minimum files
+    /// to compact follows options.level0_file_num_compaction_trigger and compaction won't
+    /// trigger if average compact bytes per del file is larger than
+    /// options.write_buffer_size. This is to protect large files from being compacted again.
+    /// Default: false;
+    pub fn set_allow_compaction(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_fifo_compaction_options_set_allow_compaction(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
+
+    /// When non-zero, FIFO compaction uses the combined size of SST files and blob files for
+    /// size-based trimming decisions. When the total data size (SST + blob) exceeds this
+    /// limit, the oldest SST files are dropped along with their associated blob files.
+    ///
+    /// When non-zero, this takes precedence over max_table_files_size for all FIFO compaction
+    /// decisions: size-based dropping, TTL threshold checks, and compaction score
+    /// computation. max_table_files_size is ignored.
+    ///
+    /// When zero (default), FIFO compaction uses max_table_files_size which only considers
+    /// SST file sizes, maintaining backward compatibility.
+    ///
+    /// This option is primarily intended for use with integrated BlobDB where blob files can
+    /// represent a significant portion of the total data.
+    ///
+    /// Dynamically changeable through SetOptions() API. Default: 0 (use max_table_files_size
+    /// behavior).
+    pub fn set_max_data_files_size(&mut self, val: u64) {
+        unsafe {
+            ffi::rocksdb_fifo_compaction_options_set_max_data_files_size(self.inner, val);
+        }
+    }
+
+    /// When true, enables a capacity-derived intra-L0 compaction strategy optimized for
+    /// BlobDB workloads where SST files are much smaller than write_buffer_size. Uses the
+    /// observed key/value size ratio (SST vs blob file sizes) to compute a target compacted
+    /// file size, producing uniform files for predictable FIFO trimming.
+    ///
+    /// Uses level0_file_num_compaction_trigger as the target max L0 file count.
+    ///
+    /// When max_compaction_bytes is 0, the target is auto-calculated from the data capacity
+    /// and observed SST/blob ratio. When max_compaction_bytes is explicitly set to a non-zero
+    /// value, it overrides the auto-calculated target.
+    ///
+    /// Recommends:
+    /// - allow_compaction = true (master switch for intra-L0 compaction)
+    /// - max_data_files_size > 0 (needed to compute the target file size) If these are not
+    ///   met, kv_ratio compaction is skipped and the old cost-based intra-L0 compaction
+    ///   algorithm is used as a fallback.
+    ///
+    /// When false, the old intra-L0 strategy is used if allow_compaction is true
+    /// (PickCostBasedIntraL0Compaction with 1.1 * write_buffer_size guard).
+    ///
+    /// Dynamically changeable through SetOptions() API. Default: false.
+    pub fn set_use_kv_ratio_compaction(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_fifo_compaction_options_set_use_kv_ratio_compaction(
+                self.inner,
+                c_uchar::from(val),
+            );
+        }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -8021,6 +9068,45 @@ impl UniversalCompactOptions {
             ffi::rocksdb_universal_compaction_options_get_reduce_file_locking(self.inner) != 0
         }
     }
+
+    /// Returns the current `compression_size_percent` setting.
+    ///
+    /// See [`Self::set_compression_size_percent`] for what this controls.
+    pub fn get_compression_size_percent(&self) -> c_int {
+        unsafe {
+            ffi::rocksdb_universal_compaction_options_get_compression_size_percent(self.inner)
+        }
+    }
+
+    /// Returns the current `max_merge_width` setting.
+    ///
+    /// See [`Self::set_max_merge_width`] for what this controls.
+    pub fn get_max_merge_width(&self) -> c_int {
+        unsafe { ffi::rocksdb_universal_compaction_options_get_max_merge_width(self.inner) }
+    }
+
+    /// Returns the current `max_size_amplification_percent` setting.
+    ///
+    /// See [`Self::set_max_size_amplification_percent`] for what this controls.
+    pub fn get_max_size_amplification_percent(&self) -> c_int {
+        unsafe {
+            ffi::rocksdb_universal_compaction_options_get_max_size_amplification_percent(self.inner)
+        }
+    }
+
+    /// Returns the current `min_merge_width` setting.
+    ///
+    /// See [`Self::set_min_merge_width`] for what this controls.
+    pub fn get_min_merge_width(&self) -> c_int {
+        unsafe { ffi::rocksdb_universal_compaction_options_get_min_merge_width(self.inner) }
+    }
+
+    /// Returns the current `size_ratio` setting.
+    ///
+    /// See [`Self::set_size_ratio`] for what this controls.
+    pub fn get_size_ratio(&self) -> c_int {
+        unsafe { ffi::rocksdb_universal_compaction_options_get_size_ratio(self.inner) }
+    }
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
@@ -8161,6 +9247,84 @@ impl CompactOptions {
     pub fn get_blob_garbage_collection_policy(&self) -> c_int {
         unsafe { ffi::rocksdb_compactoptions_get_blob_garbage_collection_policy(self.inner) }
     }
+
+    /// Returns the current `allow_write_stall` setting.
+    ///
+    /// See [`Self::set_allow_write_stall`] for what this controls.
+    pub fn get_allow_write_stall(&self) -> bool {
+        unsafe { ffi::rocksdb_compactoptions_get_allow_write_stall(self.inner) != 0 }
+    }
+
+    /// Returns the current `bottommost_level_compaction` setting.
+    ///
+    /// See [`Self::set_bottommost_level_compaction`] for what this controls.
+    pub fn get_bottommost_level_compaction(&self) -> bool {
+        unsafe { ffi::rocksdb_compactoptions_get_bottommost_level_compaction(self.inner) != 0 }
+    }
+
+    /// Returns the current `change_level` setting.
+    ///
+    /// See [`Self::set_change_level`] for what this controls.
+    pub fn get_change_level(&self) -> bool {
+        unsafe { ffi::rocksdb_compactoptions_get_change_level(self.inner) != 0 }
+    }
+
+    /// Returns the current `exclusive_manual_compaction` setting.
+    ///
+    /// See [`Self::set_exclusive_manual_compaction`] for what this controls.
+    pub fn get_exclusive_manual_compaction(&self) -> bool {
+        unsafe { ffi::rocksdb_compactoptions_get_exclusive_manual_compaction(self.inner) != 0 }
+    }
+
+    /// Returns the current `max_subcompactions` setting.
+    ///
+    /// See [`Self::set_max_subcompactions`] for what this controls.
+    pub fn get_max_subcompactions(&self) -> c_int {
+        unsafe { ffi::rocksdb_compactoptions_get_max_subcompactions(self.inner) }
+    }
+
+    /// Returns the current `target_level` setting.
+    ///
+    /// See [`Self::set_target_level`] for what this controls.
+    pub fn get_target_level(&self) -> c_int {
+        unsafe { ffi::rocksdb_compactoptions_get_target_level(self.inner) }
+    }
+
+    /// Returns the current `target_path_id` setting.
+    ///
+    /// See [`Self::set_target_path_id`] for what this controls.
+    pub fn get_target_path_id(&self) -> c_int {
+        unsafe { ffi::rocksdb_compactoptions_get_target_path_id(self.inner) }
+    }
+
+    /// If true, the flush would proceed immediately even it means writes will stall for the
+    /// duration of the flush; if false the operation will wait until it's possible to do
+    /// flush w/o causing stall or until required flush is performed by someone else
+    /// (foreground call or background thread). Default: false.
+    pub fn set_allow_write_stall(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_compactoptions_set_allow_write_stall(self.inner, c_uchar::from(val));
+        }
+    }
+
+    /// This value represents the maximum number of threads that will concurrently perform a
+    /// compaction job by breaking it into multiple, smaller ones that are run simultaneously.
+    /// Default: 1 (i.e. no subcompactions)
+    ///
+    /// Dynamically changeable through SetDBOptions() API.
+    pub fn set_max_subcompactions(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_compactoptions_set_max_subcompactions(self.inner, val);
+        }
+    }
+
+    /// Compaction outputs will be placed in options.db_paths\[target_path_id\]. Behavior is
+    /// undefined if target_path_id is out of range.
+    pub fn set_target_path_id(&mut self, val: c_int) {
+        unsafe {
+            ffi::rocksdb_compactoptions_set_target_path_id(self.inner, val);
+        }
+    }
 }
 
 pub struct WaitForCompactOptions {
@@ -8234,6 +9398,44 @@ impl WaitForCompactOptions {
     /// Returns the value of the `wait_for_purge` option.
     pub fn get_wait_for_purge(&self) -> bool {
         unsafe { ffi::rocksdb_wait_for_compact_options_get_wait_for_purge(self.inner) != 0 }
+    }
+
+    /// Returns the current `abort_on_pause` setting.
+    ///
+    /// See [`Self::set_abort_on_pause`] for what this controls.
+    pub fn get_abort_on_pause(&self) -> bool {
+        unsafe { ffi::rocksdb_wait_for_compact_options_get_abort_on_pause(self.inner) != 0 }
+    }
+
+    /// Returns the current `close_db` setting.
+    ///
+    /// See [`Self::set_close_db`] for what this controls.
+    pub fn get_close_db(&self) -> bool {
+        unsafe { ffi::rocksdb_wait_for_compact_options_get_close_db(self.inner) != 0 }
+    }
+
+    /// Returns the current `flush` setting.
+    ///
+    /// See [`Self::set_flush`] for what this controls.
+    pub fn get_flush(&self) -> bool {
+        unsafe { ffi::rocksdb_wait_for_compact_options_get_flush(self.inner) != 0 }
+    }
+
+    /// Returns the current `timeout` setting.
+    ///
+    /// See [`Self::set_timeout`] for what this controls.
+    pub fn get_timeout(&self) -> u64 {
+        unsafe { ffi::rocksdb_wait_for_compact_options_get_timeout(self.inner) }
+    }
+
+    /// A boolean to call Close() after waiting is done. By the time Close() is called here,
+    /// there should be no background jobs in progress and no new background jobs should be
+    /// added. DB may not have been closed if Close() returned Aborted status due to
+    /// unreleased snapshots in the system. See comments in DB::Close() for details.
+    pub fn set_close_db(&mut self, val: bool) {
+        unsafe {
+            ffi::rocksdb_wait_for_compact_options_set_close_db(self.inner, c_uchar::from(val));
+        }
     }
 }
 
@@ -8347,6 +9549,13 @@ impl ImportColumnFamilyOptions {
                 c_uchar::from(move_files),
             );
         }
+    }
+
+    /// Returns the current `move_files` setting.
+    ///
+    /// See [`Self::set_move_files`] for what this controls.
+    pub fn get_move_files(&self) -> bool {
+        unsafe { ffi::rocksdb_import_column_family_options_get_move_files(self.inner) != 0 }
     }
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -139,6 +139,34 @@ impl Env {
             ffi::rocksdb_env_lower_high_priority_thread_pool_cpu_priority(self.0.inner);
         }
     }
+
+    /// Returns the current `background_threads` setting.
+    ///
+    /// See [`Self::set_background_threads`] for what this controls.
+    pub fn get_background_threads(&self) -> c_int {
+        unsafe { ffi::rocksdb_env_get_background_threads(self.0.inner) }
+    }
+
+    /// Returns the current `bottom_priority_background_threads` setting.
+    ///
+    /// See [`Self::set_bottom_priority_background_threads`] for what this controls.
+    pub fn get_bottom_priority_background_threads(&self) -> c_int {
+        unsafe { ffi::rocksdb_env_get_bottom_priority_background_threads(self.0.inner) }
+    }
+
+    /// Returns the current `high_priority_background_threads` setting.
+    ///
+    /// See [`Self::set_high_priority_background_threads`] for what this controls.
+    pub fn get_high_priority_background_threads(&self) -> c_int {
+        unsafe { ffi::rocksdb_env_get_high_priority_background_threads(self.0.inner) }
+    }
+
+    /// Returns the current `low_priority_background_threads` setting.
+    ///
+    /// See [`Self::set_low_priority_background_threads`] for what this controls.
+    pub fn get_low_priority_background_threads(&self) -> c_int {
+        unsafe { ffi::rocksdb_env_get_low_priority_background_threads(self.0.inner) }
+    }
 }
 
 unsafe impl Send for EnvWrapper {}

--- a/src/event_listener.rs
+++ b/src/event_listener.rs
@@ -285,6 +285,36 @@ impl FlushJobInfo {
     pub fn flush_reason(&self) -> DBFlushReason {
         unsafe { DBFlushReason::from(ffi::rocksdb_flushjobinfo_flush_reason(self.inner)) }
     }
+
+    /// Number of blob files created by this flush.
+    pub fn blob_file_addition_infos_count(&self) -> usize {
+        unsafe { ffi::rocksdb_flushjobinfo_blob_file_addition_infos_count(self.inner) }
+    }
+
+    /// The id of the column family where the compaction happened.
+    pub fn cf_id(&self) -> u32 {
+        unsafe { ffi::rocksdb_flushjobinfo_cf_id(self.inner) }
+    }
+
+    /// The file number of the newly created file.
+    pub fn file_number(&self) -> u64 {
+        unsafe { ffi::rocksdb_flushjobinfo_file_number(self.inner) }
+    }
+
+    /// The id of the job (which could be flush or compaction) that created the file.
+    pub fn job_id(&self) -> i32 {
+        unsafe { ffi::rocksdb_flushjobinfo_job_id(self.inner) }
+    }
+
+    /// The oldest blob file referenced by the newly created file.
+    pub fn oldest_blob_file_number(&self) -> u64 {
+        unsafe { ffi::rocksdb_flushjobinfo_oldest_blob_file_number(self.inner) }
+    }
+
+    /// The id of the thread that completed this flush job.
+    pub fn thread_id(&self) -> u64 {
+        unsafe { ffi::rocksdb_flushjobinfo_thread_id(self.inner) }
+    }
 }
 
 pub struct CompactionJobInfo {
@@ -362,6 +392,67 @@ impl CompactionJobInfo {
             DBCompactionReason::from(ffi::rocksdb_compactionjobinfo_compaction_reason(self.inner))
         }
     }
+
+    /// Whether this compaction was aborted via AbortAllCompactions().
+    pub fn aborted(&self) -> bool {
+        unsafe { ffi::rocksdb_compactionjobinfo_aborted(self.inner) != 0 }
+    }
+
+    /// Number of blob files created by this compaction.
+    pub fn blob_file_addition_infos_count(&self) -> usize {
+        unsafe { ffi::rocksdb_compactionjobinfo_blob_file_addition_infos_count(self.inner) }
+    }
+
+    /// Number of blob files this compaction produced garbage for.
+    pub fn blob_file_garbage_infos_count(&self) -> usize {
+        unsafe { ffi::rocksdb_compactionjobinfo_blob_file_garbage_infos_count(self.inner) }
+    }
+
+    /// The id of the column family where the compaction happened.
+    pub fn cf_id(&self) -> u32 {
+        unsafe { ffi::rocksdb_compactionjobinfo_cf_id(self.inner) }
+    }
+
+    /// Number of entries in the per-input-file detail list.
+    ///
+    /// This counts the same files as [`Self::input_file_count`], reported from the
+    /// richer per-file records rather than the plain path list.
+    pub fn input_file_infos_count(&self) -> usize {
+        unsafe { ffi::rocksdb_compactionjobinfo_input_file_infos_count(self.inner) }
+    }
+
+    /// The id of the job (which could be flush or compaction) that created the file.
+    pub fn job_id(&self) -> i32 {
+        unsafe { ffi::rocksdb_compactionjobinfo_job_id(self.inner) }
+    }
+
+    /// The number of compaction input files (table files).
+    pub fn num_input_files(&self) -> usize {
+        unsafe { ffi::rocksdb_compactionjobinfo_num_input_files(self.inner) }
+    }
+
+    /// The number of L0 files in the CF right before and after the compaction.
+    pub fn num_l0_files(&self) -> i32 {
+        unsafe { ffi::rocksdb_compactionjobinfo_num_l0_files(self.inner) }
+    }
+
+    /// Number of entries in the per-output-file detail list.
+    ///
+    /// This counts the same files as [`Self::output_file_count`], reported from the
+    /// richer per-file records rather than the plain path list.
+    pub fn output_file_infos_count(&self) -> usize {
+        unsafe { ffi::rocksdb_compactionjobinfo_output_file_infos_count(self.inner) }
+    }
+
+    /// Number of files whose table properties this compaction collected.
+    pub fn table_properties_count(&self) -> usize {
+        unsafe { ffi::rocksdb_compactionjobinfo_table_properties_count(self.inner) }
+    }
+
+    /// The id of the thread that completed this flush job.
+    pub fn thread_id(&self) -> u64 {
+        unsafe { ffi::rocksdb_compactionjobinfo_thread_id(self.inner) }
+    }
 }
 
 pub struct SubcompactionJobInfo {
@@ -410,6 +501,23 @@ impl SubcompactionJobInfo {
             ))
         }
     }
+
+    /// The id of the column family where the compaction happened.
+    pub fn cf_id(&self) -> u32 {
+        unsafe { ffi::rocksdb_subcompactionjobinfo_cf_id(self.inner) }
+    }
+
+    /// The id of the job (which could be flush or compaction) that created the file.
+    pub fn job_id(&self) -> i32 {
+        unsafe { ffi::rocksdb_subcompactionjobinfo_job_id(self.inner) }
+    }
+
+    /// Sub-compaction job id, which is only unique within the same compaction, so use both
+    /// 'job_id' and 'subcompaction_job_id' to identify a subcompaction within an instance.
+    /// For non subcompaction job, it's set to -1.
+    pub fn subcompaction_job_id(&self) -> i32 {
+        unsafe { ffi::rocksdb_subcompactionjobinfo_subcompaction_job_id(self.inner) }
+    }
 }
 
 pub struct IngestionInfo {
@@ -432,6 +540,11 @@ impl IngestionInfo {
 
             Some(cf_name_vec)
         }
+    }
+
+    /// The global sequence number assigned to keys in this file.
+    pub fn global_seqno(&self) -> u64 {
+        unsafe { ffi::rocksdb_externalfileingestioninfo_global_seqno(self.inner) }
     }
 }
 

--- a/src/transactions/options.rs
+++ b/src/transactions/options.rs
@@ -301,6 +301,69 @@ impl TransactionOptions {
             ffi::rocksdb_transaction_options_get_write_batch_track_timestamp_size(self.inner) != 0
         }
     }
+
+    /// Returns the current `deadlock_detect_depth` setting.
+    ///
+    /// See [`Self::set_deadlock_detect_depth`] for what this controls.
+    pub fn get_deadlock_detect_depth(&self) -> i64 {
+        unsafe { ffi::rocksdb_transaction_options_get_deadlock_detect_depth(self.inner) }
+    }
+
+    /// Returns the current `deadlock_timeout_us` setting.
+    ///
+    /// See [`Self::set_deadlock_timeout_us`] for what this controls.
+    pub fn get_deadlock_timeout_us(&self) -> i64 {
+        unsafe { ffi::rocksdb_transaction_options_get_deadlock_timeout_us(self.inner) }
+    }
+
+    /// Returns the current `expiration` setting.
+    ///
+    /// See [`Self::set_expiration`] for what this controls.
+    pub fn get_expiration(&self) -> i64 {
+        unsafe { ffi::rocksdb_transaction_options_get_expiration(self.inner) }
+    }
+
+    /// Returns the current `lock_timeout` setting.
+    ///
+    /// See [`Self::set_lock_timeout`] for what this controls.
+    pub fn get_lock_timeout(&self) -> i64 {
+        unsafe { ffi::rocksdb_transaction_options_get_lock_timeout(self.inner) }
+    }
+
+    /// Returns the current `write_batch_flush_threshold` setting.
+    ///
+    /// See [`Self::set_write_batch_flush_threshold`] for what this controls.
+    pub fn get_write_batch_flush_threshold(&self) -> i64 {
+        unsafe { ffi::rocksdb_transaction_options_get_write_batch_flush_threshold(self.inner) }
+    }
+
+    /// Timeout in microseconds before perform dead lock detection. If 0, deadlock detection
+    /// will be performed immediately.
+    ///
+    /// To optimize performance, this parameter could be tuned.
+    ///
+    /// When deadlock happens very frequently, deadlock timeout should be set to 0, so
+    /// deadlock will be detected immediately.
+    ///
+    /// When deadlock happen very rarely, this timeout could be turned to be slightly longer
+    /// than the typical transaction execution time, so that transaction will be waked up to
+    /// take the lock before this timeout, which will allow the transaction to save the CPU
+    /// time on deadlock detection.
+    ///
+    /// Deadlock timeout is always smaller than lock_timeout.
+    pub fn set_deadlock_timeout_us(&mut self, val: i64) {
+        unsafe {
+            ffi::rocksdb_transaction_options_set_deadlock_timeout_us(self.inner, val);
+        }
+    }
+
+    /// See TransactionDBOptions::default_write_batch_flush_threshold for description. If a
+    /// negative value is specified, then the default value from TransactionDBOptions is used.
+    pub fn set_write_batch_flush_threshold(&mut self, val: i64) {
+        unsafe {
+            ffi::rocksdb_transaction_options_set_write_batch_flush_threshold(self.inner, val);
+        }
+    }
 }
 
 impl Drop for TransactionOptions {
@@ -510,6 +573,50 @@ impl TransactionDBOptions {
     pub fn get_use_per_key_point_lock_mgr(&self) -> bool {
         unsafe {
             ffi::rocksdb_transactiondb_options_get_use_per_key_point_lock_mgr(self.inner) != 0
+        }
+    }
+
+    /// Returns the current `default_lock_timeout` setting.
+    ///
+    /// See [`Self::set_default_lock_timeout`] for what this controls.
+    pub fn get_default_lock_timeout(&self) -> i64 {
+        unsafe { ffi::rocksdb_transactiondb_options_get_default_lock_timeout(self.inner) }
+    }
+
+    /// Returns the current `default_write_batch_flush_threshold` setting.
+    ///
+    /// See [`Self::set_default_write_batch_flush_threshold`] for what this controls.
+    pub fn get_default_write_batch_flush_threshold(&self) -> i64 {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_get_default_write_batch_flush_threshold(self.inner)
+        }
+    }
+
+    /// Returns the current `max_num_locks` setting.
+    ///
+    /// See [`Self::set_max_num_locks`] for what this controls.
+    pub fn get_max_num_locks(&self) -> i64 {
+        unsafe { ffi::rocksdb_transactiondb_options_get_max_num_locks(self.inner) }
+    }
+
+    /// If positive, specifies the default wait timeout in milliseconds when a transaction
+    /// attempts to lock a key if not specified by TransactionOptions::lock_timeout.
+    ///
+    /// If 0, no waiting is done if a lock cannot instantly be acquired. If negative, there is
+    /// no timeout.  Not using a timeout is not recommended as it can lead to deadlocks.
+    /// Currently, there is no deadlock-detection to recover from a deadlock.
+    pub fn get_transaction_lock_timeout(&self) -> i64 {
+        unsafe { ffi::rocksdb_transactiondb_options_get_transaction_lock_timeout(self.inner) }
+    }
+
+    /// This option is only valid for write unprepared. If a write batch exceeds this
+    /// threshold, then the transaction will implicitly flush the currently pending writes
+    /// into the database. A value of 0 or less means no limit.
+    pub fn set_default_write_batch_flush_threshold(&mut self, val: i64) {
+        unsafe {
+            ffi::rocksdb_transactiondb_options_set_default_write_batch_flush_threshold(
+                self.inner, val,
+            );
         }
     }
 }

--- a/src/transactions/transaction.rs
+++ b/src/transactions/transaction.rs
@@ -937,6 +937,28 @@ impl<DB> Transaction<'_, DB> {
         }
         Ok(())
     }
+
+    /// Sets the commit timestamp for this transaction.
+    ///
+    /// Only meaningful when the column family uses user-defined timestamps. RocksDB
+    /// reports an unsupported timestamp through a status that the C API discards, so
+    /// calling this on a transaction without timestamp support does nothing.
+    pub fn set_commit_timestamp(&self, val: u64) {
+        unsafe {
+            ffi::rocksdb_transaction_set_commit_timestamp(self.inner, val);
+        }
+    }
+
+    /// Sets the read timestamp used to validate this transaction's reads.
+    ///
+    /// Only meaningful when the column family uses user-defined timestamps. RocksDB
+    /// reports an unsupported timestamp through a status that the C API discards, so
+    /// calling this on a transaction without timestamp support does nothing.
+    pub fn set_read_timestamp_for_validation(&self, val: u64) {
+        unsafe {
+            ffi::rocksdb_transaction_set_read_timestamp_for_validation(self.inner, val);
+        }
+    }
 }
 
 impl<DB> Drop for Transaction<'_, DB> {

--- a/tests/test_capi_accessor_roundtrip.rs
+++ b/tests/test_capi_accessor_roundtrip.rs
@@ -1,0 +1,1274 @@
+//! Round-trip coverage for the option accessors.
+//!
+//! Each field is written through its setter and read back through its getter,
+//! twice with different values, so a getter wired to the wrong option or an
+//! inverted bool cast fails here.
+
+use rust_rocksdb::{
+    BlockBasedOptions, CompactOptions, Env, FifoCompactOptions, FlushOptions,
+    ImportColumnFamilyOptions, IngestExternalFileOptions, Options, ReadOptions,
+    TransactionDBOptions, TransactionOptions, UniversalCompactOptions, WaitForCompactOptions,
+    WriteOptions, backup::BackupEngineOptions,
+};
+
+#[test]
+fn backup_engine_options_roundtrip() {
+    let dir = tempfile::Builder::new()
+        .prefix("backup_engine_options")
+        .tempdir()
+        .unwrap();
+    let mut o = BackupEngineOptions::new(dir.path()).unwrap();
+    {
+        let o = &mut o;
+        o.set_backup_log_files(true);
+        assert!(
+            o.get_backup_log_files(),
+            "BackupEngineOptions::backup_log_files"
+        );
+        o.set_backup_log_files(false);
+        assert!(
+            !o.get_backup_log_files(),
+            "BackupEngineOptions::backup_log_files"
+        );
+        o.set_backup_rate_limit(4096);
+        assert_eq!(
+            o.get_backup_rate_limit(),
+            4096,
+            "BackupEngineOptions::backup_rate_limit"
+        );
+        o.set_backup_rate_limit(1);
+        assert_eq!(
+            o.get_backup_rate_limit(),
+            1,
+            "BackupEngineOptions::backup_rate_limit"
+        );
+        o.set_callback_trigger_interval_size(4096);
+        assert_eq!(
+            o.get_callback_trigger_interval_size(),
+            4096,
+            "BackupEngineOptions::callback_trigger_interval_size"
+        );
+        o.set_callback_trigger_interval_size(1);
+        assert_eq!(
+            o.get_callback_trigger_interval_size(),
+            1,
+            "BackupEngineOptions::callback_trigger_interval_size"
+        );
+        o.set_destroy_old_data(true);
+        assert!(
+            o.get_destroy_old_data(),
+            "BackupEngineOptions::destroy_old_data"
+        );
+        o.set_destroy_old_data(false);
+        assert!(
+            !o.get_destroy_old_data(),
+            "BackupEngineOptions::destroy_old_data"
+        );
+        o.set_max_valid_backups_to_open(11);
+        assert_eq!(
+            o.get_max_valid_backups_to_open(),
+            11,
+            "BackupEngineOptions::max_valid_backups_to_open"
+        );
+        o.set_max_valid_backups_to_open(4);
+        assert_eq!(
+            o.get_max_valid_backups_to_open(),
+            4,
+            "BackupEngineOptions::max_valid_backups_to_open"
+        );
+        o.set_restore_rate_limit(4096);
+        assert_eq!(
+            o.get_restore_rate_limit(),
+            4096,
+            "BackupEngineOptions::restore_rate_limit"
+        );
+        o.set_restore_rate_limit(1);
+        assert_eq!(
+            o.get_restore_rate_limit(),
+            1,
+            "BackupEngineOptions::restore_rate_limit"
+        );
+        o.set_share_table_files(true);
+        assert!(
+            o.get_share_table_files(),
+            "BackupEngineOptions::share_table_files"
+        );
+        o.set_share_table_files(false);
+        assert!(
+            !o.get_share_table_files(),
+            "BackupEngineOptions::share_table_files"
+        );
+    }
+}
+
+#[test]
+fn block_based_options_roundtrip() {
+    let mut o = BlockBasedOptions::default();
+    {
+        let o = &mut o;
+        o.set_block_align(true);
+        assert!(o.get_block_align(), "BlockBasedOptions::block_align");
+        o.set_block_align(false);
+        assert!(!o.get_block_align(), "BlockBasedOptions::block_align");
+        o.set_block_size_deviation(11);
+        assert_eq!(
+            o.get_block_size_deviation(),
+            11,
+            "BlockBasedOptions::block_size_deviation"
+        );
+        o.set_block_size_deviation(4);
+        assert_eq!(
+            o.get_block_size_deviation(),
+            4,
+            "BlockBasedOptions::block_size_deviation"
+        );
+        o.set_separate_key_value_in_data_block(true);
+        assert!(
+            o.get_separate_key_value_in_data_block(),
+            "BlockBasedOptions::separate_key_value_in_data_block"
+        );
+        o.set_separate_key_value_in_data_block(false);
+        assert!(
+            !o.get_separate_key_value_in_data_block(),
+            "BlockBasedOptions::separate_key_value_in_data_block"
+        );
+    }
+}
+
+#[test]
+fn compact_options_roundtrip() {
+    let mut o = CompactOptions::default();
+    {
+        let o = &mut o;
+        o.set_allow_write_stall(true);
+        assert!(
+            o.get_allow_write_stall(),
+            "CompactOptions::allow_write_stall"
+        );
+        o.set_allow_write_stall(false);
+        assert!(
+            !o.get_allow_write_stall(),
+            "CompactOptions::allow_write_stall"
+        );
+        o.set_change_level(true);
+        assert!(o.get_change_level(), "CompactOptions::change_level");
+        o.set_change_level(false);
+        assert!(!o.get_change_level(), "CompactOptions::change_level");
+        o.set_exclusive_manual_compaction(true);
+        assert!(
+            o.get_exclusive_manual_compaction(),
+            "CompactOptions::exclusive_manual_compaction"
+        );
+        o.set_exclusive_manual_compaction(false);
+        assert!(
+            !o.get_exclusive_manual_compaction(),
+            "CompactOptions::exclusive_manual_compaction"
+        );
+        o.set_max_subcompactions(11);
+        assert_eq!(
+            o.get_max_subcompactions(),
+            11,
+            "CompactOptions::max_subcompactions"
+        );
+        o.set_max_subcompactions(4);
+        assert_eq!(
+            o.get_max_subcompactions(),
+            4,
+            "CompactOptions::max_subcompactions"
+        );
+        o.set_target_level(11);
+        assert_eq!(o.get_target_level(), 11, "CompactOptions::target_level");
+        o.set_target_level(4);
+        assert_eq!(o.get_target_level(), 4, "CompactOptions::target_level");
+        o.set_target_path_id(11);
+        assert_eq!(o.get_target_path_id(), 11, "CompactOptions::target_path_id");
+        o.set_target_path_id(4);
+        assert_eq!(o.get_target_path_id(), 4, "CompactOptions::target_path_id");
+    }
+}
+
+#[test]
+fn env_roundtrip() {
+    let mut o = Env::new().unwrap();
+    {
+        let o = &mut o;
+        o.set_background_threads(11);
+        assert_eq!(o.get_background_threads(), 11, "Env::background_threads");
+        o.set_background_threads(4);
+        assert_eq!(o.get_background_threads(), 4, "Env::background_threads");
+        o.set_bottom_priority_background_threads(11);
+        assert_eq!(
+            o.get_bottom_priority_background_threads(),
+            11,
+            "Env::bottom_priority_background_threads"
+        );
+        o.set_bottom_priority_background_threads(4);
+        assert_eq!(
+            o.get_bottom_priority_background_threads(),
+            4,
+            "Env::bottom_priority_background_threads"
+        );
+        o.set_high_priority_background_threads(11);
+        assert_eq!(
+            o.get_high_priority_background_threads(),
+            11,
+            "Env::high_priority_background_threads"
+        );
+        o.set_high_priority_background_threads(4);
+        assert_eq!(
+            o.get_high_priority_background_threads(),
+            4,
+            "Env::high_priority_background_threads"
+        );
+        o.set_low_priority_background_threads(11);
+        assert_eq!(
+            o.get_low_priority_background_threads(),
+            11,
+            "Env::low_priority_background_threads"
+        );
+        o.set_low_priority_background_threads(4);
+        assert_eq!(
+            o.get_low_priority_background_threads(),
+            4,
+            "Env::low_priority_background_threads"
+        );
+    }
+}
+
+#[test]
+fn fifo_compact_options_roundtrip() {
+    let mut o = FifoCompactOptions::default();
+    {
+        let o = &mut o;
+        o.set_allow_compaction(true);
+        assert!(
+            o.get_allow_compaction(),
+            "FifoCompactOptions::allow_compaction"
+        );
+        o.set_allow_compaction(false);
+        assert!(
+            !o.get_allow_compaction(),
+            "FifoCompactOptions::allow_compaction"
+        );
+        o.set_max_data_files_size(4096);
+        assert_eq!(
+            o.get_max_data_files_size(),
+            4096,
+            "FifoCompactOptions::max_data_files_size"
+        );
+        o.set_max_data_files_size(1);
+        assert_eq!(
+            o.get_max_data_files_size(),
+            1,
+            "FifoCompactOptions::max_data_files_size"
+        );
+        o.set_max_table_files_size(4096);
+        assert_eq!(
+            o.get_max_table_files_size(),
+            4096,
+            "FifoCompactOptions::max_table_files_size"
+        );
+        o.set_max_table_files_size(1);
+        assert_eq!(
+            o.get_max_table_files_size(),
+            1,
+            "FifoCompactOptions::max_table_files_size"
+        );
+        o.set_use_kv_ratio_compaction(true);
+        assert!(
+            o.get_use_kv_ratio_compaction(),
+            "FifoCompactOptions::use_kv_ratio_compaction"
+        );
+        o.set_use_kv_ratio_compaction(false);
+        assert!(
+            !o.get_use_kv_ratio_compaction(),
+            "FifoCompactOptions::use_kv_ratio_compaction"
+        );
+    }
+}
+
+#[test]
+fn flush_options_roundtrip() {
+    let mut o = FlushOptions::default();
+    {
+        let o = &mut o;
+        o.set_wait(true);
+        assert!(o.get_wait(), "FlushOptions::wait");
+        o.set_wait(false);
+        assert!(!o.get_wait(), "FlushOptions::wait");
+    }
+}
+
+#[test]
+fn import_column_family_options_roundtrip() {
+    let mut o = ImportColumnFamilyOptions::default();
+    {
+        let o = &mut o;
+        o.set_move_files(true);
+        assert!(o.get_move_files(), "ImportColumnFamilyOptions::move_files");
+        o.set_move_files(false);
+        assert!(!o.get_move_files(), "ImportColumnFamilyOptions::move_files");
+    }
+}
+
+#[test]
+fn ingest_external_file_options_roundtrip() {
+    let mut o = IngestExternalFileOptions::default();
+    {
+        let o = &mut o;
+        o.set_fail_if_not_bottommost_level(true);
+        assert!(
+            o.get_fail_if_not_bottommost_level(),
+            "IngestExternalFileOptions::fail_if_not_bottommost_level"
+        );
+        o.set_fail_if_not_bottommost_level(false);
+        assert!(
+            !o.get_fail_if_not_bottommost_level(),
+            "IngestExternalFileOptions::fail_if_not_bottommost_level"
+        );
+    }
+}
+
+#[test]
+fn options_roundtrip() {
+    let mut o = Options::default();
+    {
+        let o = &mut o;
+        o.set_advise_random_on_open(true);
+        assert!(
+            o.get_advise_random_on_open(),
+            "Options::advise_random_on_open"
+        );
+        o.set_advise_random_on_open(false);
+        assert!(
+            !o.get_advise_random_on_open(),
+            "Options::advise_random_on_open"
+        );
+        o.set_allow_concurrent_memtable_write(true);
+        assert!(
+            o.get_allow_concurrent_memtable_write(),
+            "Options::allow_concurrent_memtable_write"
+        );
+        o.set_allow_concurrent_memtable_write(false);
+        assert!(
+            !o.get_allow_concurrent_memtable_write(),
+            "Options::allow_concurrent_memtable_write"
+        );
+        o.set_allow_ingest_behind(true);
+        assert!(o.get_allow_ingest_behind(), "Options::allow_ingest_behind");
+        o.set_allow_ingest_behind(false);
+        assert!(!o.get_allow_ingest_behind(), "Options::allow_ingest_behind");
+        o.set_allow_mmap_reads(true);
+        assert!(o.get_allow_mmap_reads(), "Options::allow_mmap_reads");
+        o.set_allow_mmap_reads(false);
+        assert!(!o.get_allow_mmap_reads(), "Options::allow_mmap_reads");
+        o.set_allow_mmap_writes(true);
+        assert!(o.get_allow_mmap_writes(), "Options::allow_mmap_writes");
+        o.set_allow_mmap_writes(false);
+        assert!(!o.get_allow_mmap_writes(), "Options::allow_mmap_writes");
+        o.set_arena_block_size(8192);
+        assert_eq!(o.get_arena_block_size(), 8192, "Options::arena_block_size");
+        o.set_arena_block_size(2);
+        assert_eq!(o.get_arena_block_size(), 2, "Options::arena_block_size");
+        o.set_atomic_flush(true);
+        assert!(o.get_atomic_flush(), "Options::atomic_flush");
+        o.set_atomic_flush(false);
+        assert!(!o.get_atomic_flush(), "Options::atomic_flush");
+        o.set_avoid_unnecessary_blocking_io(true);
+        assert!(
+            o.get_avoid_unnecessary_blocking_io(),
+            "Options::avoid_unnecessary_blocking_io"
+        );
+        o.set_avoid_unnecessary_blocking_io(false);
+        assert!(
+            !o.get_avoid_unnecessary_blocking_io(),
+            "Options::avoid_unnecessary_blocking_io"
+        );
+        o.set_blob_compaction_readahead_size(4096);
+        assert_eq!(
+            o.get_blob_compaction_readahead_size(),
+            4096,
+            "Options::blob_compaction_readahead_size"
+        );
+        o.set_blob_compaction_readahead_size(1);
+        assert_eq!(
+            o.get_blob_compaction_readahead_size(),
+            1,
+            "Options::blob_compaction_readahead_size"
+        );
+        o.set_blob_file_size(4096);
+        assert_eq!(o.get_blob_file_size(), 4096, "Options::blob_file_size");
+        o.set_blob_file_size(1);
+        assert_eq!(o.get_blob_file_size(), 1, "Options::blob_file_size");
+        o.set_blob_file_starting_level(11);
+        assert_eq!(
+            o.get_blob_file_starting_level(),
+            11,
+            "Options::blob_file_starting_level"
+        );
+        o.set_blob_file_starting_level(4);
+        assert_eq!(
+            o.get_blob_file_starting_level(),
+            4,
+            "Options::blob_file_starting_level"
+        );
+        o.set_bloom_locality(17);
+        assert_eq!(o.get_bloom_locality(), 17, "Options::bloom_locality");
+        o.set_bloom_locality(3);
+        assert_eq!(o.get_bloom_locality(), 3, "Options::bloom_locality");
+        o.set_bytes_per_sync(4096);
+        assert_eq!(o.get_bytes_per_sync(), 4096, "Options::bytes_per_sync");
+        o.set_bytes_per_sync(1);
+        assert_eq!(o.get_bytes_per_sync(), 1, "Options::bytes_per_sync");
+        o.set_compaction_readahead_size(8192);
+        assert_eq!(
+            o.get_compaction_readahead_size(),
+            8192,
+            "Options::compaction_readahead_size"
+        );
+        o.set_compaction_readahead_size(2);
+        assert_eq!(
+            o.get_compaction_readahead_size(),
+            2,
+            "Options::compaction_readahead_size"
+        );
+        o.set_compression_options_max_dict_buffer_bytes(4096);
+        assert_eq!(
+            o.get_compression_options_max_dict_buffer_bytes(),
+            4096,
+            "Options::compression_options_max_dict_buffer_bytes"
+        );
+        o.set_compression_options_max_dict_buffer_bytes(1);
+        assert_eq!(
+            o.get_compression_options_max_dict_buffer_bytes(),
+            1,
+            "Options::compression_options_max_dict_buffer_bytes"
+        );
+        o.set_compression_options_use_zstd_dict_trainer(true);
+        assert!(
+            o.get_compression_options_use_zstd_dict_trainer(),
+            "Options::compression_options_use_zstd_dict_trainer"
+        );
+        o.set_compression_options_use_zstd_dict_trainer(false);
+        assert!(
+            !o.get_compression_options_use_zstd_dict_trainer(),
+            "Options::compression_options_use_zstd_dict_trainer"
+        );
+        o.create_if_missing(true);
+        assert!(o.get_create_if_missing(), "Options::create_if_missing");
+        o.create_if_missing(false);
+        assert!(!o.get_create_if_missing(), "Options::create_if_missing");
+        o.create_missing_column_families(true);
+        assert!(
+            o.get_create_missing_column_families(),
+            "Options::create_missing_column_families"
+        );
+        o.create_missing_column_families(false);
+        assert!(
+            !o.get_create_missing_column_families(),
+            "Options::create_missing_column_families"
+        );
+        o.set_db_write_buffer_size(8192);
+        assert_eq!(
+            o.get_db_write_buffer_size(),
+            8192,
+            "Options::db_write_buffer_size"
+        );
+        o.set_db_write_buffer_size(2);
+        assert_eq!(
+            o.get_db_write_buffer_size(),
+            2,
+            "Options::db_write_buffer_size"
+        );
+        o.set_delete_obsolete_files_period_micros(4096);
+        assert_eq!(
+            o.get_delete_obsolete_files_period_micros(),
+            4096,
+            "Options::delete_obsolete_files_period_micros"
+        );
+        o.set_delete_obsolete_files_period_micros(1);
+        assert_eq!(
+            o.get_delete_obsolete_files_period_micros(),
+            1,
+            "Options::delete_obsolete_files_period_micros"
+        );
+        o.set_disable_auto_compactions(true);
+        assert!(
+            o.get_disable_auto_compactions(),
+            "Options::disable_auto_compactions"
+        );
+        o.set_disable_auto_compactions(false);
+        assert!(
+            !o.get_disable_auto_compactions(),
+            "Options::disable_auto_compactions"
+        );
+        o.set_enable_blob_files(true);
+        assert!(o.get_enable_blob_files(), "Options::enable_blob_files");
+        o.set_enable_blob_files(false);
+        assert!(!o.get_enable_blob_files(), "Options::enable_blob_files");
+        o.set_enable_blob_gc(true);
+        assert!(o.get_enable_blob_gc(), "Options::enable_blob_gc");
+        o.set_enable_blob_gc(false);
+        assert!(!o.get_enable_blob_gc(), "Options::enable_blob_gc");
+        o.set_enable_pipelined_write(true);
+        assert!(
+            o.get_enable_pipelined_write(),
+            "Options::enable_pipelined_write"
+        );
+        o.set_enable_pipelined_write(false);
+        assert!(
+            !o.get_enable_pipelined_write(),
+            "Options::enable_pipelined_write"
+        );
+        o.set_enable_write_thread_adaptive_yield(true);
+        assert!(
+            o.get_enable_write_thread_adaptive_yield(),
+            "Options::enable_write_thread_adaptive_yield"
+        );
+        o.set_enable_write_thread_adaptive_yield(false);
+        assert!(
+            !o.get_enable_write_thread_adaptive_yield(),
+            "Options::enable_write_thread_adaptive_yield"
+        );
+        o.set_error_if_exists(true);
+        assert!(o.get_error_if_exists(), "Options::error_if_exists");
+        o.set_error_if_exists(false);
+        assert!(!o.get_error_if_exists(), "Options::error_if_exists");
+        o.set_experimental_mempurge_threshold(0.75);
+        assert_eq!(
+            o.get_experimental_mempurge_threshold(),
+            0.75,
+            "Options::experimental_mempurge_threshold"
+        );
+        o.set_experimental_mempurge_threshold(0.25);
+        assert_eq!(
+            o.get_experimental_mempurge_threshold(),
+            0.25,
+            "Options::experimental_mempurge_threshold"
+        );
+        o.set_hard_pending_compaction_bytes_limit(8192);
+        assert_eq!(
+            o.get_hard_pending_compaction_bytes_limit(),
+            8192,
+            "Options::hard_pending_compaction_bytes_limit"
+        );
+        o.set_hard_pending_compaction_bytes_limit(2);
+        assert_eq!(
+            o.get_hard_pending_compaction_bytes_limit(),
+            2,
+            "Options::hard_pending_compaction_bytes_limit"
+        );
+        o.set_inplace_update_support(true);
+        assert!(
+            o.get_inplace_update_support(),
+            "Options::inplace_update_support"
+        );
+        o.set_inplace_update_support(false);
+        assert!(
+            !o.get_inplace_update_support(),
+            "Options::inplace_update_support"
+        );
+        o.set_is_fd_close_on_exec(true);
+        assert!(o.get_is_fd_close_on_exec(), "Options::is_fd_close_on_exec");
+        o.set_is_fd_close_on_exec(false);
+        assert!(!o.get_is_fd_close_on_exec(), "Options::is_fd_close_on_exec");
+        o.set_keep_log_file_num(8192);
+        assert_eq!(
+            o.get_keep_log_file_num(),
+            8192,
+            "Options::keep_log_file_num"
+        );
+        o.set_keep_log_file_num(2);
+        assert_eq!(o.get_keep_log_file_num(), 2, "Options::keep_log_file_num");
+        o.set_level_compaction_dynamic_level_bytes(true);
+        assert!(
+            o.get_level_compaction_dynamic_level_bytes(),
+            "Options::level_compaction_dynamic_level_bytes"
+        );
+        o.set_level_compaction_dynamic_level_bytes(false);
+        assert!(
+            !o.get_level_compaction_dynamic_level_bytes(),
+            "Options::level_compaction_dynamic_level_bytes"
+        );
+        o.set_log_file_time_to_roll(8192);
+        assert_eq!(
+            o.get_log_file_time_to_roll(),
+            8192,
+            "Options::log_file_time_to_roll"
+        );
+        o.set_log_file_time_to_roll(2);
+        assert_eq!(
+            o.get_log_file_time_to_roll(),
+            2,
+            "Options::log_file_time_to_roll"
+        );
+        o.set_manifest_preallocation_size(8192);
+        assert_eq!(
+            o.get_manifest_preallocation_size(),
+            8192,
+            "Options::manifest_preallocation_size"
+        );
+        o.set_manifest_preallocation_size(2);
+        assert_eq!(
+            o.get_manifest_preallocation_size(),
+            2,
+            "Options::manifest_preallocation_size"
+        );
+        o.set_manual_wal_flush(true);
+        assert!(o.get_manual_wal_flush(), "Options::manual_wal_flush");
+        o.set_manual_wal_flush(false);
+        assert!(!o.get_manual_wal_flush(), "Options::manual_wal_flush");
+        o.set_max_background_jobs(11);
+        assert_eq!(
+            o.get_max_background_jobs(),
+            11,
+            "Options::max_background_jobs"
+        );
+        o.set_max_background_jobs(4);
+        assert_eq!(
+            o.get_max_background_jobs(),
+            4,
+            "Options::max_background_jobs"
+        );
+        o.set_max_bytes_for_level_base(4096);
+        assert_eq!(
+            o.get_max_bytes_for_level_base(),
+            4096,
+            "Options::max_bytes_for_level_base"
+        );
+        o.set_max_bytes_for_level_base(1);
+        assert_eq!(
+            o.get_max_bytes_for_level_base(),
+            1,
+            "Options::max_bytes_for_level_base"
+        );
+        o.set_max_bytes_for_level_multiplier(0.75);
+        assert_eq!(
+            o.get_max_bytes_for_level_multiplier(),
+            0.75,
+            "Options::max_bytes_for_level_multiplier"
+        );
+        o.set_max_bytes_for_level_multiplier(0.25);
+        assert_eq!(
+            o.get_max_bytes_for_level_multiplier(),
+            0.25,
+            "Options::max_bytes_for_level_multiplier"
+        );
+        o.set_max_compaction_bytes(4096);
+        assert_eq!(
+            o.get_max_compaction_bytes(),
+            4096,
+            "Options::max_compaction_bytes"
+        );
+        o.set_max_compaction_bytes(1);
+        assert_eq!(
+            o.get_max_compaction_bytes(),
+            1,
+            "Options::max_compaction_bytes"
+        );
+        o.set_max_file_opening_threads(11);
+        assert_eq!(
+            o.get_max_file_opening_threads(),
+            11,
+            "Options::max_file_opening_threads"
+        );
+        o.set_max_file_opening_threads(4);
+        assert_eq!(
+            o.get_max_file_opening_threads(),
+            4,
+            "Options::max_file_opening_threads"
+        );
+        o.set_max_log_file_size(8192);
+        assert_eq!(
+            o.get_max_log_file_size(),
+            8192,
+            "Options::max_log_file_size"
+        );
+        o.set_max_log_file_size(2);
+        assert_eq!(o.get_max_log_file_size(), 2, "Options::max_log_file_size");
+        o.set_max_manifest_file_size(8192);
+        assert_eq!(
+            o.get_max_manifest_file_size(),
+            8192,
+            "Options::max_manifest_file_size"
+        );
+        o.set_max_manifest_file_size(2);
+        assert_eq!(
+            o.get_max_manifest_file_size(),
+            2,
+            "Options::max_manifest_file_size"
+        );
+        o.set_max_open_files(11);
+        assert_eq!(o.get_max_open_files(), 11, "Options::max_open_files");
+        o.set_max_open_files(4);
+        assert_eq!(o.get_max_open_files(), 4, "Options::max_open_files");
+        o.set_max_sequential_skip_in_iterations(4096);
+        assert_eq!(
+            o.get_max_sequential_skip_in_iterations(),
+            4096,
+            "Options::max_sequential_skip_in_iterations"
+        );
+        o.set_max_sequential_skip_in_iterations(1);
+        assert_eq!(
+            o.get_max_sequential_skip_in_iterations(),
+            1,
+            "Options::max_sequential_skip_in_iterations"
+        );
+        o.set_max_subcompactions(17);
+        assert_eq!(
+            o.get_max_subcompactions(),
+            17,
+            "Options::max_subcompactions"
+        );
+        o.set_max_subcompactions(3);
+        assert_eq!(o.get_max_subcompactions(), 3, "Options::max_subcompactions");
+        o.set_max_successive_merges(8192);
+        assert_eq!(
+            o.get_max_successive_merges(),
+            8192,
+            "Options::max_successive_merges"
+        );
+        o.set_max_successive_merges(2);
+        assert_eq!(
+            o.get_max_successive_merges(),
+            2,
+            "Options::max_successive_merges"
+        );
+        o.set_max_total_wal_size(4096);
+        assert_eq!(
+            o.get_max_total_wal_size(),
+            4096,
+            "Options::max_total_wal_size"
+        );
+        o.set_max_total_wal_size(1);
+        assert_eq!(o.get_max_total_wal_size(), 1, "Options::max_total_wal_size");
+        o.set_max_write_buffer_number(11);
+        assert_eq!(
+            o.get_max_write_buffer_number(),
+            11,
+            "Options::max_write_buffer_number"
+        );
+        o.set_max_write_buffer_number(4);
+        assert_eq!(
+            o.get_max_write_buffer_number(),
+            4,
+            "Options::max_write_buffer_number"
+        );
+        o.set_max_write_buffer_size_to_maintain(1024);
+        assert_eq!(
+            o.get_max_write_buffer_size_to_maintain(),
+            1024,
+            "Options::max_write_buffer_size_to_maintain"
+        );
+        o.set_max_write_buffer_size_to_maintain(7);
+        assert_eq!(
+            o.get_max_write_buffer_size_to_maintain(),
+            7,
+            "Options::max_write_buffer_size_to_maintain"
+        );
+        o.set_memtable_avg_op_scan_flush_trigger(17);
+        assert_eq!(
+            o.get_memtable_avg_op_scan_flush_trigger(),
+            17,
+            "Options::memtable_avg_op_scan_flush_trigger"
+        );
+        o.set_memtable_avg_op_scan_flush_trigger(3);
+        assert_eq!(
+            o.get_memtable_avg_op_scan_flush_trigger(),
+            3,
+            "Options::memtable_avg_op_scan_flush_trigger"
+        );
+        o.set_memtable_op_scan_flush_trigger(17);
+        assert_eq!(
+            o.get_memtable_op_scan_flush_trigger(),
+            17,
+            "Options::memtable_op_scan_flush_trigger"
+        );
+        o.set_memtable_op_scan_flush_trigger(3);
+        assert_eq!(
+            o.get_memtable_op_scan_flush_trigger(),
+            3,
+            "Options::memtable_op_scan_flush_trigger"
+        );
+        o.set_min_blob_size(4096);
+        assert_eq!(o.get_min_blob_size(), 4096, "Options::min_blob_size");
+        o.set_min_blob_size(1);
+        assert_eq!(o.get_min_blob_size(), 1, "Options::min_blob_size");
+        o.set_min_write_buffer_number_to_merge(11);
+        assert_eq!(
+            o.get_min_write_buffer_number_to_merge(),
+            11,
+            "Options::min_write_buffer_number_to_merge"
+        );
+        o.set_min_write_buffer_number_to_merge(4);
+        assert_eq!(
+            o.get_min_write_buffer_number_to_merge(),
+            4,
+            "Options::min_write_buffer_number_to_merge"
+        );
+        o.set_num_levels(11);
+        assert_eq!(o.get_num_levels(), 11, "Options::num_levels");
+        o.set_num_levels(4);
+        assert_eq!(o.get_num_levels(), 4, "Options::num_levels");
+        o.set_optimize_filters_for_hits(true);
+        assert!(
+            o.get_optimize_filters_for_hits(),
+            "Options::optimize_filters_for_hits"
+        );
+        o.set_optimize_filters_for_hits(false);
+        assert!(
+            !o.get_optimize_filters_for_hits(),
+            "Options::optimize_filters_for_hits"
+        );
+        o.set_paranoid_checks(true);
+        assert!(o.get_paranoid_checks(), "Options::paranoid_checks");
+        o.set_paranoid_checks(false);
+        assert!(!o.get_paranoid_checks(), "Options::paranoid_checks");
+        o.set_periodic_compaction_seconds(4096);
+        assert_eq!(
+            o.get_periodic_compaction_seconds(),
+            4096,
+            "Options::periodic_compaction_seconds"
+        );
+        o.set_periodic_compaction_seconds(1);
+        assert_eq!(
+            o.get_periodic_compaction_seconds(),
+            1,
+            "Options::periodic_compaction_seconds"
+        );
+        o.set_recycle_log_file_num(8192);
+        assert_eq!(
+            o.get_recycle_log_file_num(),
+            8192,
+            "Options::recycle_log_file_num"
+        );
+        o.set_recycle_log_file_num(2);
+        assert_eq!(
+            o.get_recycle_log_file_num(),
+            2,
+            "Options::recycle_log_file_num"
+        );
+        o.set_report_bg_io_stats(true);
+        assert!(o.get_report_bg_io_stats(), "Options::report_bg_io_stats");
+        o.set_report_bg_io_stats(false);
+        assert!(!o.get_report_bg_io_stats(), "Options::report_bg_io_stats");
+        o.set_skip_stats_update_on_db_open(true);
+        assert!(
+            o.get_skip_stats_update_on_db_open(),
+            "Options::skip_stats_update_on_db_open"
+        );
+        o.set_skip_stats_update_on_db_open(false);
+        assert!(
+            !o.get_skip_stats_update_on_db_open(),
+            "Options::skip_stats_update_on_db_open"
+        );
+        o.set_soft_pending_compaction_bytes_limit(8192);
+        assert_eq!(
+            o.get_soft_pending_compaction_bytes_limit(),
+            8192,
+            "Options::soft_pending_compaction_bytes_limit"
+        );
+        o.set_soft_pending_compaction_bytes_limit(2);
+        assert_eq!(
+            o.get_soft_pending_compaction_bytes_limit(),
+            2,
+            "Options::soft_pending_compaction_bytes_limit"
+        );
+        o.set_target_file_size_base(4096);
+        assert_eq!(
+            o.get_target_file_size_base(),
+            4096,
+            "Options::target_file_size_base"
+        );
+        o.set_target_file_size_base(1);
+        assert_eq!(
+            o.get_target_file_size_base(),
+            1,
+            "Options::target_file_size_base"
+        );
+        o.set_ttl(4096);
+        assert_eq!(o.get_ttl(), 4096, "Options::ttl");
+        o.set_ttl(1);
+        assert_eq!(o.get_ttl(), 1, "Options::ttl");
+        o.set_unordered_write(true);
+        assert!(o.get_unordered_write(), "Options::unordered_write");
+        o.set_unordered_write(false);
+        assert!(!o.get_unordered_write(), "Options::unordered_write");
+        o.set_use_adaptive_mutex(true);
+        assert!(o.get_use_adaptive_mutex(), "Options::use_adaptive_mutex");
+        o.set_use_adaptive_mutex(false);
+        assert!(!o.get_use_adaptive_mutex(), "Options::use_adaptive_mutex");
+        o.set_use_direct_io_for_flush_and_compaction(true);
+        assert!(
+            o.get_use_direct_io_for_flush_and_compaction(),
+            "Options::use_direct_io_for_flush_and_compaction"
+        );
+        o.set_use_direct_io_for_flush_and_compaction(false);
+        assert!(
+            !o.get_use_direct_io_for_flush_and_compaction(),
+            "Options::use_direct_io_for_flush_and_compaction"
+        );
+        o.set_use_direct_reads(true);
+        assert!(o.get_use_direct_reads(), "Options::use_direct_reads");
+        o.set_use_direct_reads(false);
+        assert!(!o.get_use_direct_reads(), "Options::use_direct_reads");
+        o.set_wal_bytes_per_sync(4096);
+        assert_eq!(
+            o.get_wal_bytes_per_sync(),
+            4096,
+            "Options::wal_bytes_per_sync"
+        );
+        o.set_wal_bytes_per_sync(1);
+        assert_eq!(o.get_wal_bytes_per_sync(), 1, "Options::wal_bytes_per_sync");
+        o.set_wal_size_limit_mb(4096);
+        assert_eq!(
+            o.get_wal_size_limit_mb(),
+            4096,
+            "Options::wal_size_limit_mb"
+        );
+        o.set_wal_size_limit_mb(1);
+        assert_eq!(o.get_wal_size_limit_mb(), 1, "Options::wal_size_limit_mb");
+        o.set_wal_ttl_seconds(4096);
+        assert_eq!(o.get_wal_ttl_seconds(), 4096, "Options::wal_ttl_seconds");
+        o.set_wal_ttl_seconds(1);
+        assert_eq!(o.get_wal_ttl_seconds(), 1, "Options::wal_ttl_seconds");
+        o.set_writable_file_max_buffer_size(4096);
+        assert_eq!(
+            o.get_writable_file_max_buffer_size(),
+            4096,
+            "Options::writable_file_max_buffer_size"
+        );
+        o.set_writable_file_max_buffer_size(1);
+        assert_eq!(
+            o.get_writable_file_max_buffer_size(),
+            1,
+            "Options::writable_file_max_buffer_size"
+        );
+        o.set_write_buffer_size(8192);
+        assert_eq!(
+            o.get_write_buffer_size(),
+            8192,
+            "Options::write_buffer_size"
+        );
+        o.set_write_buffer_size(2);
+        assert_eq!(o.get_write_buffer_size(), 2, "Options::write_buffer_size");
+        o.set_write_identity_file(true);
+        assert!(o.get_write_identity_file(), "Options::write_identity_file");
+        o.set_write_identity_file(false);
+        assert!(!o.get_write_identity_file(), "Options::write_identity_file");
+    }
+}
+
+#[test]
+fn read_options_roundtrip() {
+    let mut o = ReadOptions::default();
+    {
+        let o = &mut o;
+        o.set_async_io(true);
+        assert!(o.get_async_io(), "ReadOptions::async_io");
+        o.set_async_io(false);
+        assert!(!o.get_async_io(), "ReadOptions::async_io");
+        o.set_background_purge_on_iterator_cleanup(true);
+        assert!(
+            o.get_background_purge_on_iterator_cleanup(),
+            "ReadOptions::background_purge_on_iterator_cleanup"
+        );
+        o.set_background_purge_on_iterator_cleanup(false);
+        assert!(
+            !o.get_background_purge_on_iterator_cleanup(),
+            "ReadOptions::background_purge_on_iterator_cleanup"
+        );
+        o.set_deadline(4096);
+        assert_eq!(o.get_deadline(), 4096, "ReadOptions::deadline");
+        o.set_deadline(1);
+        assert_eq!(o.get_deadline(), 1, "ReadOptions::deadline");
+        o.fill_cache(true);
+        assert!(o.get_fill_cache(), "ReadOptions::fill_cache");
+        o.fill_cache(false);
+        assert!(!o.get_fill_cache(), "ReadOptions::fill_cache");
+        o.set_io_timeout(4096);
+        assert_eq!(o.get_io_timeout(), 4096, "ReadOptions::io_timeout");
+        o.set_io_timeout(1);
+        assert_eq!(o.get_io_timeout(), 1, "ReadOptions::io_timeout");
+        o.set_max_skippable_internal_keys(4096);
+        assert_eq!(
+            o.get_max_skippable_internal_keys(),
+            4096,
+            "ReadOptions::max_skippable_internal_keys"
+        );
+        o.set_max_skippable_internal_keys(1);
+        assert_eq!(
+            o.get_max_skippable_internal_keys(),
+            1,
+            "ReadOptions::max_skippable_internal_keys"
+        );
+        o.set_pin_data(true);
+        assert!(o.get_pin_data(), "ReadOptions::pin_data");
+        o.set_pin_data(false);
+        assert!(!o.get_pin_data(), "ReadOptions::pin_data");
+        o.set_prefix_same_as_start(true);
+        assert!(
+            o.get_prefix_same_as_start(),
+            "ReadOptions::prefix_same_as_start"
+        );
+        o.set_prefix_same_as_start(false);
+        assert!(
+            !o.get_prefix_same_as_start(),
+            "ReadOptions::prefix_same_as_start"
+        );
+        o.set_readahead_size(8192);
+        assert_eq!(o.get_readahead_size(), 8192, "ReadOptions::readahead_size");
+        o.set_readahead_size(2);
+        assert_eq!(o.get_readahead_size(), 2, "ReadOptions::readahead_size");
+        o.set_tailing(true);
+        assert!(o.get_tailing(), "ReadOptions::tailing");
+        o.set_tailing(false);
+        assert!(!o.get_tailing(), "ReadOptions::tailing");
+        o.set_total_order_seek(true);
+        assert!(o.get_total_order_seek(), "ReadOptions::total_order_seek");
+        o.set_total_order_seek(false);
+        assert!(!o.get_total_order_seek(), "ReadOptions::total_order_seek");
+        o.set_verify_checksums(true);
+        assert!(o.get_verify_checksums(), "ReadOptions::verify_checksums");
+        o.set_verify_checksums(false);
+        assert!(!o.get_verify_checksums(), "ReadOptions::verify_checksums");
+    }
+}
+
+#[test]
+fn transaction_d_b_options_roundtrip() {
+    let mut o = TransactionDBOptions::default();
+    {
+        let o = &mut o;
+        o.set_default_lock_timeout(1024);
+        assert_eq!(
+            o.get_default_lock_timeout(),
+            1024,
+            "TransactionDBOptions::default_lock_timeout"
+        );
+        o.set_default_lock_timeout(7);
+        assert_eq!(
+            o.get_default_lock_timeout(),
+            7,
+            "TransactionDBOptions::default_lock_timeout"
+        );
+        o.set_default_write_batch_flush_threshold(1024);
+        assert_eq!(
+            o.get_default_write_batch_flush_threshold(),
+            1024,
+            "TransactionDBOptions::default_write_batch_flush_threshold"
+        );
+        o.set_default_write_batch_flush_threshold(7);
+        assert_eq!(
+            o.get_default_write_batch_flush_threshold(),
+            7,
+            "TransactionDBOptions::default_write_batch_flush_threshold"
+        );
+        o.set_max_num_locks(1024);
+        assert_eq!(
+            o.get_max_num_locks(),
+            1024,
+            "TransactionDBOptions::max_num_locks"
+        );
+        o.set_max_num_locks(7);
+        assert_eq!(
+            o.get_max_num_locks(),
+            7,
+            "TransactionDBOptions::max_num_locks"
+        );
+    }
+}
+
+#[test]
+fn transaction_options_roundtrip() {
+    let mut o = TransactionOptions::default();
+    {
+        let o = &mut o;
+        o.set_deadlock_detect_depth(1024);
+        assert_eq!(
+            o.get_deadlock_detect_depth(),
+            1024,
+            "TransactionOptions::deadlock_detect_depth"
+        );
+        o.set_deadlock_detect_depth(7);
+        assert_eq!(
+            o.get_deadlock_detect_depth(),
+            7,
+            "TransactionOptions::deadlock_detect_depth"
+        );
+        o.set_deadlock_timeout_us(1024);
+        assert_eq!(
+            o.get_deadlock_timeout_us(),
+            1024,
+            "TransactionOptions::deadlock_timeout_us"
+        );
+        o.set_deadlock_timeout_us(7);
+        assert_eq!(
+            o.get_deadlock_timeout_us(),
+            7,
+            "TransactionOptions::deadlock_timeout_us"
+        );
+        o.set_expiration(1024);
+        assert_eq!(o.get_expiration(), 1024, "TransactionOptions::expiration");
+        o.set_expiration(7);
+        assert_eq!(o.get_expiration(), 7, "TransactionOptions::expiration");
+        o.set_lock_timeout(1024);
+        assert_eq!(
+            o.get_lock_timeout(),
+            1024,
+            "TransactionOptions::lock_timeout"
+        );
+        o.set_lock_timeout(7);
+        assert_eq!(o.get_lock_timeout(), 7, "TransactionOptions::lock_timeout");
+        o.set_write_batch_flush_threshold(1024);
+        assert_eq!(
+            o.get_write_batch_flush_threshold(),
+            1024,
+            "TransactionOptions::write_batch_flush_threshold"
+        );
+        o.set_write_batch_flush_threshold(7);
+        assert_eq!(
+            o.get_write_batch_flush_threshold(),
+            7,
+            "TransactionOptions::write_batch_flush_threshold"
+        );
+    }
+}
+
+#[test]
+fn universal_compact_options_roundtrip() {
+    let mut o = UniversalCompactOptions::default();
+    {
+        let o = &mut o;
+        o.set_compression_size_percent(11);
+        assert_eq!(
+            o.get_compression_size_percent(),
+            11,
+            "UniversalCompactOptions::compression_size_percent"
+        );
+        o.set_compression_size_percent(4);
+        assert_eq!(
+            o.get_compression_size_percent(),
+            4,
+            "UniversalCompactOptions::compression_size_percent"
+        );
+        o.set_max_merge_width(11);
+        assert_eq!(
+            o.get_max_merge_width(),
+            11,
+            "UniversalCompactOptions::max_merge_width"
+        );
+        o.set_max_merge_width(4);
+        assert_eq!(
+            o.get_max_merge_width(),
+            4,
+            "UniversalCompactOptions::max_merge_width"
+        );
+        o.set_max_size_amplification_percent(11);
+        assert_eq!(
+            o.get_max_size_amplification_percent(),
+            11,
+            "UniversalCompactOptions::max_size_amplification_percent"
+        );
+        o.set_max_size_amplification_percent(4);
+        assert_eq!(
+            o.get_max_size_amplification_percent(),
+            4,
+            "UniversalCompactOptions::max_size_amplification_percent"
+        );
+        o.set_min_merge_width(11);
+        assert_eq!(
+            o.get_min_merge_width(),
+            11,
+            "UniversalCompactOptions::min_merge_width"
+        );
+        o.set_min_merge_width(4);
+        assert_eq!(
+            o.get_min_merge_width(),
+            4,
+            "UniversalCompactOptions::min_merge_width"
+        );
+        o.set_size_ratio(11);
+        assert_eq!(
+            o.get_size_ratio(),
+            11,
+            "UniversalCompactOptions::size_ratio"
+        );
+        o.set_size_ratio(4);
+        assert_eq!(o.get_size_ratio(), 4, "UniversalCompactOptions::size_ratio");
+    }
+}
+
+#[test]
+fn wait_for_compact_options_roundtrip() {
+    let mut o = WaitForCompactOptions::default();
+    {
+        let o = &mut o;
+        o.set_abort_on_pause(true);
+        assert!(
+            o.get_abort_on_pause(),
+            "WaitForCompactOptions::abort_on_pause"
+        );
+        o.set_abort_on_pause(false);
+        assert!(
+            !o.get_abort_on_pause(),
+            "WaitForCompactOptions::abort_on_pause"
+        );
+        o.set_close_db(true);
+        assert!(o.get_close_db(), "WaitForCompactOptions::close_db");
+        o.set_close_db(false);
+        assert!(!o.get_close_db(), "WaitForCompactOptions::close_db");
+        o.set_flush(true);
+        assert!(o.get_flush(), "WaitForCompactOptions::flush");
+        o.set_flush(false);
+        assert!(!o.get_flush(), "WaitForCompactOptions::flush");
+        o.set_timeout(4096);
+        assert_eq!(o.get_timeout(), 4096, "WaitForCompactOptions::timeout");
+        o.set_timeout(1);
+        assert_eq!(o.get_timeout(), 1, "WaitForCompactOptions::timeout");
+    }
+}
+
+#[test]
+fn write_options_roundtrip() {
+    let mut o = WriteOptions::default();
+    {
+        let o = &mut o;
+        o.disable_wal(true);
+        assert!(o.get_disable_wal(), "WriteOptions::disable_wal");
+        o.disable_wal(false);
+        assert!(!o.get_disable_wal(), "WriteOptions::disable_wal");
+        o.set_ignore_missing_column_families(true);
+        assert!(
+            o.get_ignore_missing_column_families(),
+            "WriteOptions::ignore_missing_column_families"
+        );
+        o.set_ignore_missing_column_families(false);
+        assert!(
+            !o.get_ignore_missing_column_families(),
+            "WriteOptions::ignore_missing_column_families"
+        );
+        o.set_low_pri(true);
+        assert!(o.get_low_pri(), "WriteOptions::low_pri");
+        o.set_low_pri(false);
+        assert!(!o.get_low_pri(), "WriteOptions::low_pri");
+        o.set_memtable_insert_hint_per_batch(true);
+        assert!(
+            o.get_memtable_insert_hint_per_batch(),
+            "WriteOptions::memtable_insert_hint_per_batch"
+        );
+        o.set_memtable_insert_hint_per_batch(false);
+        assert!(
+            !o.get_memtable_insert_hint_per_batch(),
+            "WriteOptions::memtable_insert_hint_per_batch"
+        );
+        o.set_no_slowdown(true);
+        assert!(o.get_no_slowdown(), "WriteOptions::no_slowdown");
+        o.set_no_slowdown(false);
+        assert!(!o.get_no_slowdown(), "WriteOptions::no_slowdown");
+        o.set_sync(true);
+        assert!(o.get_sync(), "WriteOptions::sync");
+        o.set_sync(false);
+        assert!(!o.get_sync(), "WriteOptions::sync");
+    }
+}

--- a/tests/test_event_listener.rs
+++ b/tests/test_event_listener.rs
@@ -38,6 +38,14 @@ impl EventListener for EventCounter {
         assert_ne!(info.largest_seqno(), 0);
         assert!(info.smallest_seqno() <= info.largest_seqno());
 
+        assert!(info.job_id() > 0);
+        assert_ne!(info.thread_id(), 0);
+        assert_eq!(info.cf_id(), 0, "default column family");
+        assert_ne!(info.file_number(), 0);
+        // This test never enables blob files.
+        assert_eq!(info.oldest_blob_file_number(), 0);
+        assert_eq!(info.blob_file_addition_infos_count(), 0);
+
         if info.flush_reason() == DBFlushReason::KManualFlush {
             self.manual_flush.fetch_add(1, Ordering::SeqCst);
         }
@@ -57,6 +65,21 @@ impl EventListener for EventCounter {
         assert_eq!(info.num_corrupt_keys(), 0);
         assert!(info.output_level() >= 0);
 
+        assert!(info.job_id() > 0);
+        assert_ne!(info.thread_id(), 0);
+        assert_eq!(info.cf_id(), 0, "default column family");
+        assert!(!info.aborted(), "status() already succeeded");
+        // input_files_count walks the file list, num_input_files comes from the
+        // compaction stats; they describe the same set.
+        assert_eq!(info.num_input_files(), input_file_count);
+        assert!(info.num_l0_files() >= 0);
+        assert_eq!(info.input_file_infos_count(), input_file_count);
+        assert_eq!(info.output_file_infos_count(), output_file_count);
+        assert!(info.table_properties_count() > 0);
+        // This test never enables blob files.
+        assert_eq!(info.blob_file_addition_infos_count(), 0);
+        assert_eq!(info.blob_file_garbage_infos_count(), 0);
+
         self.compaction.fetch_add(1, Ordering::SeqCst);
         self.input_records
             .fetch_add(info.input_records() as usize, Ordering::SeqCst);
@@ -74,6 +97,8 @@ impl EventListener for EventCounter {
 
     fn on_external_file_ingested(&self, info: &IngestionInfo) {
         assert!(!info.cf_name().unwrap().is_empty());
+        // Ingesting into a non-empty DB assigns the file a real sequence number.
+        assert_ne!(info.global_seqno(), 0);
         self.ingestion.fetch_add(1, Ordering::SeqCst);
     }
 }


### PR DESCRIPTION
Follow-up to #266. That PR covered the option setters, this one picks up the accessors that were left behind: getters whose setters the crate already wrapped, and the event listener fields that were reachable in C but not in Rust.

203 methods across 21 types, no new public types.

| file | methods |
| --- | --- |
| `src/db_options.rs` | 148 |
| `src/event_listener.rs` | 21 |
| `src/backup.rs` | 16 |
| `src/transactions/options.rs` | 12 |
| `src/env.rs` | 4 |
| `src/transactions/transaction.rs` | 2 |

The event listener ones are the most useful in practice. `FlushJobInfo`, `CompactionJobInfo`, `SubcompactionJobInfo` and `IngestionInfo` had no way to read blob file counts, thread and job ids, the `aborted` flag, or the ingest global seqno, even though the C API exposed all of them.

Doc comments come from the matching field in the upstream C++ headers. Getters link to their setter so the description lives in one place. Where no header field exists the wording is written from the upstream implementation rather than restating the method name.

`Env`, `Cache` and `Transaction` hold their state behind a raw pointer and take `&self` even for mutating calls, so the new methods follow each module's existing receiver convention instead of one blanket rule.

### Left out on purpose

77 functions, for reasons worth stating rather than hiding:

- **Enum-typed accessors.** Returning `DBCompressionType`, `DBCompactionStyle` and friends needs a reverse `c_int` to enum conversion, and the crate has no precedent for one. `DBCompressionType` is also still missing an `Xpress` variant even though `rocksdb_xpress_compression` exists, so unknown values are genuinely reachable. Worth doing properly in its own change.
- **`EnvOptions`.** 22 functions, but the type is still private.
- **Deprecated functions.** Skipped rather than wrapped.
- **`Cache::disown_data`.** Upstream requires the DB to be dropped first and forbids any later use of the cache. `Cache` is a cloneable `Arc` handle shared with the DB, so a safe wrapper is reachable-unsound from safe code. Needs an `unsafe fn` with a `# Safety` section and its own review.
- Smaller cases: `*_destroy` (Drop territory), the writebatch savepoint group (needs error-returning variants), `column_family_handle_get_id` (three CF types behind `AsColumnFamilyRef`, no inherent impl), and a handful of `clear_*`/`has_*` whose setters are not wrapped yet.

### Testing

`tests/test_capi_accessor_roundtrip.rs` sets each field and reads it back through the new getter, 270 assertions over 15 tests. The compiler already proves the FFI signatures line up, so what is worth testing is a getter and setter that disagree or an inverted bool cast.

The event listener accessors cannot be set, so `tests/test_event_listener.rs` asserts on them against a live flush, compaction and file ingest instead. That also confirmed empirically that `num_input_files`, `input_files_count` and `input_file_infos_count` are three distinct C functions that happen to agree.

Local run: fmt clean, clippy clean, `cargo rustdoc -- -D warnings` clean, and the full suite green.