### PR TITLE
Let prefix probers refresh and outlive the DB borrow

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -187,9 +187,22 @@ impl GetIntoBufferResult {
     }
 }
 
+/// Read options tuned for prefix probes.
+fn prefix_probe_read_opts() -> ReadOptions {
+    let mut opts = ReadOptions::default();
+    opts.set_prefix_same_as_start(true);
+    opts
+}
+
 /// A reusable prefix probe that avoids per-call iterator creation/destruction.
 ///
 /// Use this when performing many prefix existence checks in a tight loop.
+///
+/// A prober reads the database as of the sequence number that was current when
+/// it was created, and it pins the memtables and SST files that were current
+/// then. Both are what [`refresh`](PrefixProber::refresh) exists to move
+/// forward. A prober that is only used for a single burst of probes and then
+/// dropped needs neither.
 pub struct PrefixProber<'a, D: DBAccess> {
     raw: DBRawIteratorWithThreadMode<'a, D>,
 }
@@ -197,15 +210,151 @@ pub struct PrefixProber<'a, D: DBAccess> {
 impl<D: DBAccess> PrefixProber<'_, D> {
     /// Returns true if any key exists with the given prefix.
     /// This performs a seek to the prefix and checks the current key.
+    ///
+    /// # Errors
+    ///
+    /// Returns the RocksDB error if the seek failed. A seek that hit an error
+    /// leaves the iterator invalid, so the key check below cannot observe one.
     pub fn exists(&mut self, prefix: &[u8]) -> Result<bool, Error> {
         self.raw.seek(prefix);
-        if self.raw.valid()
-            && let Some(k) = self.raw.key()
-        {
-            return Ok(k.starts_with(prefix));
+        if let Some(key) = self.raw.key() {
+            return Ok(key.starts_with(prefix));
         }
         self.raw.status()?;
         Ok(false)
+    }
+
+    /// Moves the probe to the latest committed state of the database.
+    ///
+    /// Call this before reusing a prober that has been sitting idle. Writes
+    /// that land after the prober was created or last refreshed are invisible
+    /// to it until then.
+    ///
+    /// This is cheap when RocksDB's superversion has not changed, because the
+    /// existing merge tree over the memtables and SST files is kept and only
+    /// the read sequence moves. A flush or a compaction bumps the superversion
+    /// and forces that tree to be rebuilt, which costs roughly what building a
+    /// new prober costs. Refreshing a prober that has not probed yet is a
+    /// pessimisation, because it builds the tree that the first
+    /// [`exists`](PrefixProber::exists) call would otherwise build lazily.
+    ///
+    /// Refreshing also releases the memtables and SST files the prober was
+    /// pinning, which is what lets a flush or a compaction reclaim them. A
+    /// cached prober that is never refreshed holds them for as long as it
+    /// lives, so pool them on a timer rather than on request arrival.
+    ///
+    /// Do not use this against a database that issues `delete_range`. RocksDB
+    /// does not refresh range tombstones correctly, so a refreshed probe can
+    /// report a deleted prefix as still present. See facebook/rocksdb#9255 and
+    /// facebook/rocksdb#7212, both open.
+    ///
+    /// # Errors
+    ///
+    /// Returns the RocksDB error if the refresh failed.
+    pub fn refresh(&mut self) -> Result<(), Error> {
+        self.raw.refresh()
+    }
+}
+
+/// A [`PrefixProber`] that keeps the database open instead of borrowing it.
+///
+/// Use this to cache a prober beyond the scope that built it, for example one
+/// per worker thread. [`PrefixProber`] borrows the database, so it cannot be
+/// held in a thread local or in shared state.
+///
+/// Everything [`PrefixProber`] documents about staleness and pinning applies
+/// here, and matters more, because the point of an owned prober is to outlive
+/// the request that created it. Refresh or drop cached probers on a timer. An
+/// idle one goes on pinning the memtables and SST files it was built over, and
+/// nothing will reclaim them.
+///
+/// `D` is `'static` because the wrapper owns the database rather than borrowing
+/// it. Every `DBWithThreadMode` satisfies that.
+pub struct OwnedPrefixProber<D: DBAccess + 'static> {
+    // Field order is load bearing. Fields drop in declaration order, so the
+    // iterator is destroyed while `_db` still holds the database open.
+    // Reordering these two is a use after free.
+    prober: PrefixProber<'static, D>,
+    _db: Arc<D>,
+}
+
+// No `Deref`/`DerefMut` to `PrefixProber`. `DerefMut` would let two owned
+// probers swap their inner probers, leaving each holding an iterator into the
+// other's database, and dropping one could then free a database the other still
+// points at.
+impl<D: DBAccess + 'static> OwnedPrefixProber<D> {
+    /// Creates an owned prober over the default column family, using read
+    /// options tuned for prefix probes.
+    pub fn new(db: Arc<D>) -> Self {
+        Self::with_opts(db, prefix_probe_read_opts())
+    }
+
+    /// Creates an owned prober over the default column family with the given
+    /// read options.
+    ///
+    /// The prober owns `readopts` so that any buffers it points at, such as
+    /// iterate bounds, stay alive for as long as the iterator.
+    pub fn with_opts(db: Arc<D>, readopts: ReadOptions) -> Self {
+        // A `'static` iterator stores no dangling reference: the database is
+        // recorded on `DBRawIteratorWithThreadMode` as a `PhantomData` lifetime
+        // and nothing reads through it. `_db` is what actually keeps the
+        // database alive, and the field order on the struct is what guarantees
+        // the iterator is destroyed first.
+        let raw = DBRawIteratorWithThreadMode::new(&*db, readopts);
+        Self {
+            prober: PrefixProber { raw },
+            _db: db,
+        }
+    }
+
+    /// Creates an owned prober over one column family, using read options tuned
+    /// for prefix probes.
+    pub fn new_cf(db: Arc<D>, cf_handle: &impl AsColumnFamilyRef) -> Self {
+        Self::cf_with_opts(db, cf_handle, prefix_probe_read_opts())
+    }
+
+    /// Creates an owned prober over one column family with the given read
+    /// options.
+    ///
+    /// `cf_handle` is only read while the iterator is being created. RocksDB
+    /// takes its own reference to the column family, so the handle itself does
+    /// not have to outlive the prober. Dropping the column family while a
+    /// prober over it is alive is still not supported: the prober keeps reading
+    /// the state it was built over, which is no longer meaningful.
+    pub fn cf_with_opts(
+        db: Arc<D>,
+        cf_handle: &impl AsColumnFamilyRef,
+        readopts: ReadOptions,
+    ) -> Self {
+        // See the safety note in `with_opts`.
+        let raw = DBRawIteratorWithThreadMode::new_cf_detached(&*db, cf_handle.inner(), readopts);
+        Self {
+            prober: PrefixProber { raw },
+            _db: db,
+        }
+    }
+
+    /// Returns true if any key exists with the given prefix.
+    ///
+    /// See [`PrefixProber::exists`].
+    ///
+    /// # Errors
+    ///
+    /// Returns the RocksDB error if the seek failed.
+    pub fn exists(&mut self, prefix: &[u8]) -> Result<bool, Error> {
+        self.prober.exists(prefix)
+    }
+
+    /// Moves the probe to the latest committed state of the database.
+    ///
+    /// See [`PrefixProber::refresh`], including its warning about
+    /// `delete_range`.
+    ///
+    /// # Errors
+    ///
+    /// Returns the RocksDB error if the refresh failed.
+    pub fn refresh(&mut self) -> Result<(), Error> {
+        self.prober.refresh()
     }
 }
 
@@ -3270,10 +3419,8 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
     /// need custom tuning (e.g. async IO, readahead, cache-only), use
     /// `prefix_prober_with_opts`.
     pub fn prefix_prober(&self) -> PrefixProber<'_, Self> {
-        let mut opts = ReadOptions::default();
-        opts.set_prefix_same_as_start(true);
         PrefixProber {
-            raw: DBRawIteratorWithThreadMode::new(self, opts),
+            raw: DBRawIteratorWithThreadMode::new(self, prefix_probe_read_opts()),
         }
     }
 
@@ -3292,10 +3439,12 @@ impl<T: ThreadMode, D: DBInner> DBCommon<T, D> {
     /// Creates a reusable prefix prober over the specified column family using
     /// read options optimized for prefix probes.
     pub fn prefix_prober_cf(&self, cf_handle: &impl AsColumnFamilyRef) -> PrefixProber<'_, Self> {
-        let mut opts = ReadOptions::default();
-        opts.set_prefix_same_as_start(true);
         PrefixProber {
-            raw: DBRawIteratorWithThreadMode::new_cf(self, cf_handle.inner(), opts),
+            raw: DBRawIteratorWithThreadMode::new_cf(
+                self,
+                cf_handle.inner(),
+                prefix_probe_read_opts(),
+            ),
         }
     }
 

--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -128,6 +128,9 @@ pub struct DBRawIteratorWithThreadMode<'a, D: DBAccess> {
 }
 
 impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
+    /// Unlike [`new_cf`](Self::new_cf), the `db` borrow is not tied to `'a`.
+    /// That is what lets [`OwnedPrefixProber::with_opts`](crate::OwnedPrefixProber::with_opts)
+    /// build a `'static` iterator, so tying it would break that caller.
     pub(crate) fn new(db: &D, readopts: ReadOptions) -> Self {
         let inner = unsafe { db.create_iterator(&readopts) };
         Self::from_inner(inner, readopts)

--- a/src/db_iterator.rs
+++ b/src/db_iterator.rs
@@ -142,6 +142,22 @@ impl<'a, D: DBAccess> DBRawIteratorWithThreadMode<'a, D> {
         Self::from_inner(inner, readopts)
     }
 
+    /// Same as [`new_cf`](Self::new_cf), but the returned iterator's lifetime
+    /// parameter is not tied to the `db` borrow.
+    ///
+    /// Keeping `db` alive for at least as long as the iterator becomes the
+    /// caller's job, normally by holding an `Arc<D>` next to it and dropping
+    /// the iterator first. Prefer `new_cf` unless you are building an owning
+    /// wrapper such as [`OwnedPrefixProber`](crate::OwnedPrefixProber).
+    pub(crate) fn new_cf_detached(
+        db: &D,
+        cf_handle: *mut ffi::rocksdb_column_family_handle_t,
+        readopts: ReadOptions,
+    ) -> Self {
+        let inner = unsafe { db.create_iterator_cf(cf_handle, &readopts) };
+        Self::from_inner(inner, readopts)
+    }
+
     pub(crate) fn from_inner(
         inner: *mut ffi::rocksdb_iterator_t,
         readopts: impl Into<IterReadOptions>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,8 +147,8 @@ pub use crate::{
     comparator::Comparator,
     db::{
         ColumnFamilyMetaData, CompactFilesResult, DB, DBAccess, DBCommon, DBWithThreadMode,
-        ExportImportFilesMetaData, GetIntoBufferResult, LiveFile, MultiThreaded, PrefixProber,
-        Range, SingleThreaded, ThreadMode, TimestampedValue,
+        ExportImportFilesMetaData, GetIntoBufferResult, LiveFile, MultiThreaded, OwnedPrefixProber,
+        PrefixProber, Range, SingleThreaded, ThreadMode, TimestampedValue,
     },
     db_iterator::{
         DBIterator, DBIteratorWithThreadMode, DBRawIterator, DBRawIteratorWithThreadMode,

--- a/tests/test_prefix.rs
+++ b/tests/test_prefix.rs
@@ -1,4 +1,6 @@
-use rust_rocksdb::{ColumnFamilyDescriptor, DB, Options, ReadOptions};
+use std::sync::Arc;
+
+use rust_rocksdb::{ColumnFamilyDescriptor, DB, Options, OwnedPrefixProber, ReadOptions};
 
 #[test]
 fn prefix_exists_default_cf() {
@@ -84,4 +86,182 @@ fn prefix_exists_cf_and_prober() {
         assert!(prober.exists(b"x").unwrap());
         assert!(!prober.exists(b"z").unwrap());
     }
+}
+
+#[test]
+fn prefix_prober_only_sees_writes_after_refresh() {
+    let tempdir = tempfile::Builder::new()
+        .prefix("rocksdb_test_prefix_prober_refresh")
+        .tempdir()
+        .expect("create tempdir");
+
+    let db = DB::open_default(tempdir.path()).unwrap();
+    db.put(b"a1", b"v1").unwrap();
+
+    let mut prober = db.prefix_prober();
+    assert!(prober.exists(b"a").unwrap());
+    assert!(!prober.exists(b"b").unwrap());
+
+    db.put(b"b1", b"v2").unwrap();
+
+    // The prober reads at the sequence number current when it was built, so the
+    // write above is invisible until it is refreshed.
+    assert!(!prober.exists(b"b").unwrap());
+
+    prober.refresh().unwrap();
+    assert!(prober.exists(b"b").unwrap());
+    assert!(prober.exists(b"a").unwrap());
+}
+
+#[test]
+fn prefix_prober_refresh_survives_a_flush() {
+    let tempdir = tempfile::Builder::new()
+        .prefix("rocksdb_test_prefix_prober_refresh_flush")
+        .tempdir()
+        .expect("create tempdir");
+
+    let db = DB::open_default(tempdir.path()).unwrap();
+    db.put(b"a1", b"v1").unwrap();
+
+    let mut prober = db.prefix_prober();
+    assert!(prober.exists(b"a").unwrap());
+
+    // Flushing installs a new superversion, which sends refresh down its
+    // rebuild path rather than the cheap sequence bump.
+    db.put(b"b1", b"v2").unwrap();
+    db.flush().unwrap();
+    db.put(b"c1", b"v3").unwrap();
+
+    prober.refresh().unwrap();
+    assert!(prober.exists(b"a").unwrap());
+    assert!(prober.exists(b"b").unwrap());
+    assert!(prober.exists(b"c").unwrap());
+}
+
+#[test]
+fn owned_prefix_prober_default_cf() {
+    let tempdir = tempfile::Builder::new()
+        .prefix("rocksdb_test_owned_prefix_prober")
+        .tempdir()
+        .expect("create tempdir");
+
+    let db = Arc::new(DB::open_default(tempdir.path()).unwrap());
+    db.put(b"a1", b"v1").unwrap();
+
+    let mut prober = OwnedPrefixProber::new(Arc::clone(&db));
+    assert!(prober.exists(b"a").unwrap());
+    assert!(!prober.exists(b"b").unwrap());
+
+    db.put(b"b1", b"v2").unwrap();
+    prober.refresh().unwrap();
+    assert!(prober.exists(b"b").unwrap());
+}
+
+#[test]
+fn owned_prefix_prober_cf() {
+    let tempdir = tempfile::Builder::new()
+        .prefix("rocksdb_test_owned_prefix_prober_cf")
+        .tempdir()
+        .expect("create tempdir");
+
+    let mut db_opts = Options::default();
+    db_opts.create_missing_column_families(true);
+    db_opts.create_if_missing(true);
+    let cf_desc = ColumnFamilyDescriptor::new("cf1", Options::default());
+    let db = Arc::new(DB::open_cf_descriptors(&db_opts, tempdir.path(), vec![cf_desc]).unwrap());
+
+    let cf = db.cf_handle("cf1").expect("cf1 handle");
+    db.put_cf(&cf, b"x1", b"vx1").unwrap();
+
+    let mut prober = OwnedPrefixProber::new_cf(Arc::clone(&db), &cf);
+    assert!(prober.exists(b"x").unwrap());
+    assert!(!prober.exists(b"y").unwrap());
+
+    db.put_cf(&cf, b"y1", b"vy1").unwrap();
+    prober.refresh().unwrap();
+    assert!(prober.exists(b"y").unwrap());
+
+    // The prober reads its own column family, not the default one.
+    db.put(b"y2", b"vy2").unwrap();
+    prober.refresh().unwrap();
+    assert!(prober.exists(b"y").unwrap());
+    assert!(!prober.exists(b"y2").unwrap());
+}
+
+#[test]
+fn owned_prefix_prober_keeps_the_db_open() {
+    // The point of the owned prober: it stays usable after every other handle
+    // to the database is gone, and destroys its iterator before releasing the
+    // database. A wrong field order would show up here as a use after free
+    // under the ASan, UBSan and Valgrind jobs.
+    let tempdir = tempfile::Builder::new()
+        .prefix("rocksdb_test_owned_prefix_prober_lifetime")
+        .tempdir()
+        .expect("create tempdir");
+
+    let mut prober = {
+        let mut db_opts = Options::default();
+        db_opts.create_missing_column_families(true);
+        db_opts.create_if_missing(true);
+        let cf_desc = ColumnFamilyDescriptor::new("cf1", Options::default());
+        let db =
+            Arc::new(DB::open_cf_descriptors(&db_opts, tempdir.path(), vec![cf_desc]).unwrap());
+
+        let cf = db.cf_handle("cf1").expect("cf1 handle");
+        db.put_cf(&cf, b"x1", b"vx1").unwrap();
+
+        let prober = OwnedPrefixProber::new_cf(Arc::clone(&db), &cf);
+        assert_eq!(Arc::strong_count(&db), 2);
+        prober
+    };
+
+    // `db` and the `&ColumnFamily` borrowed from it are both out of scope now.
+    assert!(prober.exists(b"x").unwrap());
+    assert!(!prober.exists(b"z").unwrap());
+    prober.refresh().unwrap();
+    assert!(prober.exists(b"x").unwrap());
+
+    drop(prober);
+}
+
+#[test]
+fn owned_prefix_prober_moves_across_threads() {
+    let tempdir = tempfile::Builder::new()
+        .prefix("rocksdb_test_owned_prefix_prober_send")
+        .tempdir()
+        .expect("create tempdir");
+
+    let db = Arc::new(DB::open_default(tempdir.path()).unwrap());
+    db.put(b"a1", b"v1").unwrap();
+
+    let mut prober = OwnedPrefixProber::new(Arc::clone(&db));
+    assert!(prober.exists(b"a").unwrap());
+
+    let handle = std::thread::spawn(move || {
+        prober.refresh().unwrap();
+        prober.exists(b"a").unwrap()
+    });
+
+    assert!(handle.join().unwrap());
+}
+
+#[test]
+fn owned_prefix_prober_honours_custom_read_opts() {
+    let tempdir = tempfile::Builder::new()
+        .prefix("rocksdb_test_owned_prefix_prober_opts")
+        .tempdir()
+        .expect("create tempdir");
+
+    let db = Arc::new(DB::open_default(tempdir.path()).unwrap());
+    db.put(b"a1", b"v1").unwrap();
+    db.put(b"b1", b"v2").unwrap();
+
+    let mut opts = ReadOptions::default();
+    opts.set_prefix_same_as_start(true);
+    opts.fill_cache(false);
+
+    let mut prober = OwnedPrefixProber::with_opts(Arc::clone(&db), opts);
+    assert!(prober.exists(b"a").unwrap());
+    assert!(prober.exists(b"b").unwrap());
+    assert!(!prober.exists(b"c").unwrap());
 }


### PR DESCRIPTION
A `PrefixProber` today reads at the sequence number that was current when it was built, and pins the memtables and SST files from that moment. Fine for a prober used once and dropped. It rules out caching one across requests, which is what the type is otherwise ideal for: it would go stale, and it would stop a flush or a compaction from reclaiming what it pinned.

Three changes.

**`PrefixProber::refresh()`** — a passthrough to the raw iterator's `refresh`. When RocksDB's superversion has not moved, `ArenaWrappedDBIter::Refresh` keeps the existing merge tree and only advances the read sequence, so a cached prober can be brought back up to date without rebuilding the tree over the memtables and every L0 file. When it has moved, the tree is rebuilt and the cost is roughly that of a new prober. Both cases are covered by tests.

**`OwnedPrefixProber`** — holds an `Arc<D>` so a prober can live in a thread local or in shared state. `PrefixProber` borrows the database, so it cannot.

**`exists()`** called `rocksdb_iter_valid` twice per probe, once directly and once inside `key()`. Dropped the outer check.

## Soundness of the owned prober

`DBRawIteratorWithThreadMode` records the database only as a `PhantomData` lifetime and never reads through it, so a `'static` iterator stores no dangling reference. The `Arc<D>` is what keeps the database alive. That leaves two things to get right.

Drop order. Fields drop in declaration order, so the iterator is declared before the `Arc` and is destroyed while the database is still open. `owned_prefix_prober_keeps_the_db_open` guards it: it drops every other handle, then probes, refreshes and drops. I checked the test has teeth by reversing the two fields, which aborts with `pthread lock: Invalid argument` from `rocksdb_iter_destroy` running against a closed database.

No `Deref`/`DerefMut`. `DerefMut` would let two owned probers swap their inner probers, leaving each holding an iterator into the other's database, and dropping one could then free a database the other still points at.

The column family handle is only read while the iterator is being created. RocksDB takes its own reference to the column family, so the handle does not need to outlive the prober. `owned_prefix_prober_keeps_the_db_open` covers that too, since the `&ColumnFamily` it was built from is out of scope by the time it probes.

`new_cf_detached` is `pub(crate)` and documented as the caller taking on the lifetime obligation, so the untied lifetime is not reachable from outside the crate.

## On Miri

Miri cannot run any of this. It does not execute foreign functions, and every path here goes through `rocksdb_create_iterator_cf`. The tests are written so the existing UBSan, TSan and Valgrind memcheck jobs exercise them instead, which do work across FFI. Locally: 56 test binaries pass, `leaks` reports 0 leaks on the prefix binary, clippy is clean, and `RUSTDOCFLAGS=-D warnings cargo doc` is clean.

## Caveat now documented on both types

`Iterator::Refresh` does not refresh range tombstones correctly, so a refreshed probe can report a prefix deleted by `delete_range` as still present. That is facebook/rocksdb#9255 and facebook/rocksdb#7212, both still open. The rustdoc on `refresh` says not to use it against a database that issues `delete_range`.

## Tests

Six new tests in `tests/test_prefix.rs`: refresh visibility (a write is invisible until refresh, which pins down the sequence semantics), refresh across a flush (the rebuild path), owned prober on the default CF and on a named CF, the lifetime test above, and moving an owned prober to another thread.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reusable prefix probing with support for refreshing snapshots.
  * Added owned prefix probers for default and custom column families.
  * Added configurable read options for prefix checks.
  * Owned probers can retain database access and be moved across threads.

* **Bug Fixes**
  * Improved prefix existence checks and iterator error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->