### PR TITLE
Fix the path filters that made CodeRabbit skip every review

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -49,6 +49,11 @@ reviews:
       - dependabot[bot]
 
   path_filters:
+    # One positive pattern makes this whole list an allowlist, and the
+    # `include/**` entry below is one. Without this catch-all, `src/` and
+    # `tests/` match no include, CodeRabbit reports them as "included by none",
+    # and the review is skipped entirely.
+    - "**"
     # Vendored upstream C++. Nothing here is ours to fix, and a submodule bump
     # would otherwise blow past the OSS 100-300 file per-review limit.
     - "!librocksdb-sys/rocksdb/**"


### PR DESCRIPTION
The `path_filters` list in `.coderabbit.yaml` has one positive pattern, `librocksdb-sys/rocksdb/include/**`, which is there so clang and cppcheck can resolve RocksDB headers from `c-api-extensions/`. A single positive pattern turns the whole list into an allowlist, so every other path matches no include and gets dropped.

On #276 that came back as:

> Files ignored due to path filters ... `src/db.rs`, `src/db_iterator.rs`, `src/lib.rs`, `tests/test_prefix.rs` ... excluded by none and included by none

and no review ran. It has behaved this way since the config landed in #269. Everything merged in between was a dependabot bump, which `ignore_usernames` already skips, so #276 is the first PR it actually cost.

Adding `**` as the first filter restores include-by-default and leaves the `!` exclusions doing their job. The exclusions and the header re-include keep their relative order, so vendored C++ stays out of review.

This PR is its own test: if CodeRabbit reviews `.coderabbit.yaml` here instead of reporting it as included by none, the fix works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * Updated path filtering to include all files by default while preserving existing exclusions and inclusions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->