### PR TITLE
Expose DB::resume for background error recovery

### DIFF
--- a/librocksdb-sys/c-api-extensions/c_api_extensions.cc
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.cc
@@ -403,16 +403,26 @@ static constexpr size_t kRustRocksDbBatchError =
     std::numeric_limits<size_t>::max() - 1;
 #endif
 
-#ifndef RUST_ROCKSDB_SYSTEM_BACKEND
 static DB* RustRocksDbRep(rocksdb_t* db) {
   return *reinterpret_cast<DB**>(db);
 }
 
+#ifndef RUST_ROCKSDB_SYSTEM_BACKEND
 static ColumnFamilyHandle* RustRocksDbColumnFamilyRep(
     rocksdb_column_family_handle_t* column_family) {
   return *reinterpret_cast<ColumnFamilyHandle**>(column_family);
 }
 #endif
+
+extern "C" void rust_rocksdb_resume(rocksdb_t* db, char** errptr) {
+  try {
+    RustSaveError(errptr, RustRocksDbRep(db)->Resume());
+  } catch (const std::exception& error) {
+    RustSaveMessage(errptr, error.what());
+  } catch (...) {
+    RustSaveMessage(errptr, "unknown C++ exception in DB::Resume");
+  }
+}
 
 extern "C" rust_rocksdb_pinnable_batch_t*
 rust_rocksdb_batched_multi_get_pinned(

--- a/librocksdb-sys/c-api-extensions/c_api_extensions.h
+++ b/librocksdb-sys/c-api-extensions/c_api_extensions.h
@@ -45,6 +45,12 @@ extern ROCKSDB_LIBRARY_API unsigned char
 rust_rocksdb_options_get_open_files_async(rocksdb_options_t*);
 
 /* -------------------------------------------------------------------------
+ * DB recovery
+ * ------------------------------------------------------------------------- */
+
+extern ROCKSDB_LIBRARY_API void rust_rocksdb_resume(rocksdb_t*, char**);
+
+/* -------------------------------------------------------------------------
  * Batch-owned pinned MultiGet results
  *
  * The upstream batched C API allocates one rocksdb_pinnableslice_t wrapper

--- a/src/db.rs
+++ b/src/db.rs
@@ -1280,6 +1280,23 @@ impl<T: ThreadMode> DBWithThreadMode<T> {
         Ok(db)
     }
 
+    /// Manually, synchronously attempt to resume DB writes after a write failure
+    /// to the underlying filesystem. Returns OK if writes are successfully resumed,
+    /// or there was no outstanding error to recover from. Returns underlying write
+    /// error if it is not recoverable. Returns [`crate::ErrorKind::Busy`] if an
+    /// auto-resume is in progress, without waiting for it to complete.
+    ///
+    /// See <https://github.com/facebook/rocksdb/wiki/Background-Error-Handling>
+    /// See [`crate::Options::set_max_bgerror_resume_count`]
+    /// See [`crate::event_listener::EventListener::on_error_recovery_begin`]
+    pub fn resume(&self) -> Result<(), Error> {
+        unsafe {
+            ffi_try!(ffi::rust_rocksdb_resume(self.inner.inner()));
+        }
+
+        Ok(())
+    }
+
     /// Removes the database entries in the range `["from", "to")` using given write options.
     pub fn delete_range_cf_opt<K: AsRef<[u8]>>(
         &self,


### PR DESCRIPTION
Adds a C API extension for `DB::Resume` and exposes it in the rust bindings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a public API to resume database recovery after a background write error.
  * Reports successful recovery, active automatic recovery, and unrecoverable errors through clear results.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->