### PR TITLE
Fix docs.rs build on latest nightly

### DIFF
--- a/src/compaction_filter_factory.rs
+++ b/src/compaction_filter_factory.rs
@@ -10,11 +10,10 @@ use crate::{
 /// Each compaction will create a new CompactionFilter allowing the
 /// application to know about different compactions.
 ///
-/// See [compaction_filter::CompactionFilter][CompactionFilter] and
+/// See [compaction_filter::CompactionFilter] and
 /// [Options::set_compaction_filter_factory][set_compaction_filter_factory]
 /// for more details
 ///
-/// [CompactionFilter]: ../compaction_filter/trait.CompactionFilter.html
 /// [set_compaction_filter_factory]: ../struct.Options.html#method.set_compaction_filter_factory
 pub trait CompactionFilterFactory {
     type Filter: CompactionFilter;


### PR DESCRIPTION
## Summary

Nightly 2026-08-29 reports `rustdoc::redundant_explicit_links` for the `CompactionFilterFactory` documentation. The link label already resolves to the same trait as its explicit reference target.

Use the direct intra-doc link and remove the unused reference definition. The rendered link still points to `CompactionFilter`, and the docs.rs configuration builds with warnings denied.

Fixes the failure seen in https://github.com/zaidoon1/rust-rocksdb/actions/runs/33239963559/job/99067490804.

## Testing

- `RUSTDOCFLAGS='--cfg docsrs -D warnings' cargo +nightly-2026-08-29 doc --no-deps --features serde1,multi-threaded-cf,raw-ptr`
- `cargo fmt --all -- --check`
- `cargo rustdoc -- -D warnings`
- `cargo test --doc`
- `cargo test --all`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the `CompactionFilterFactory` documentation link for improved navigation.
  * Removed an outdated HTML link reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->