### PR TITLE
Fix the code issues found reviewing master since v0.52.0

### DIFF
--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -20,6 +20,9 @@
 use std::env;
 use std::path::{Path, PathBuf};
 
+#[path = "build_support/x86.rs"]
+mod x86;
+
 // =========================================================================
 // Constants
 // =========================================================================
@@ -1462,11 +1465,13 @@ mod snappy {
             if target.has_feature("sse4.2") {
                 cfg.define("SNAPPY_HAVE_X86_CRC32", Some("1"));
             }
-            // `SNAPPY_HAVE_BMI2` is left off. snappy wants `_MSC_VER &&
-            // __AVX2__` for it, so reaching it would mean passing this build the
-            // same `/arch:` level the RocksDB build gets. That is a gap in our
-            // configuration rather than a limit of snappy, and closing it is a
-            // separate change from this one.
+            // Snappy normally infers BMI2 from MSVC's AVX2 macro. Rust treats
+            // those as independent target features, so select this path from
+            // BMI2 itself and do not raise the compiler's broader `/arch:`
+            // baseline.
+            if let Some(define) = x86::snappy_msvc_bmi2_define(&target.features) {
+                cfg.define(define, Some("1"));
+            }
             return;
         }
 

--- a/librocksdb-sys/build.rs
+++ b/librocksdb-sys/build.rs
@@ -413,6 +413,41 @@ fn compiles_with_cl_exe(cfg: &cc::Build) -> bool {
     compiler.is_like_msvc() && !compiler.is_like_clang_cl()
 }
 
+/// Whether the C++ compiler already predefines `__PCLMUL__` under the flags
+/// currently on `cfg`, including environment flags such as `-march=native`.
+///
+/// GCC and Clang use `-dM`; clang-cl requires `/clang:-dM`. The probe runs
+/// after `apply_target_cpu`, so it also sees a `-march=` derived from Rust's
+/// `-Ctarget-cpu` setting.
+///
+/// Returns `false` for cl.exe and on probe failure. Those paths keep the
+/// conservative Rust target-feature decision.
+fn compiler_defines_pclmul(cfg: &cc::Build) -> bool {
+    let compiler = cfg.get_compiler();
+    let style = if compiler.is_like_clang_cl() {
+        x86::MacroDumpStyle::ClangCl
+    } else if compiler.is_like_gnu() || compiler.is_like_clang() {
+        x86::MacroDumpStyle::GnuLike
+    } else {
+        return false;
+    };
+    let args = x86::pclmul_macro_dump_args(style);
+    let Ok(out) = compiler
+        .to_command()
+        .args(args)
+        .stdin(std::process::Stdio::null())
+        .output()
+    else {
+        return false;
+    };
+    out.status.success()
+        && String::from_utf8_lossy(&out.stdout).lines().any(|line| {
+            line.split_whitespace()
+                .take(2)
+                .eq(["#define", "__PCLMUL__"])
+        })
+}
+
 // =========================================================================
 // Vendored build
 // =========================================================================
@@ -783,20 +818,17 @@ mod vendor {
     /// the pipelining and nothing else: `__SSE4_2__` still selects the hardware
     /// `_mm_crc32_*` path in `DefaultCRC32`.
     ///
-    /// It is decided from the rustc feature set, so it also overrides a compiler
-    /// that was pointed at PCLMUL some other way, such as
-    /// `CXXFLAGS=-march=native` on a machine that has it. `port/lang.h` applies
-    /// the opt-out as an `#undef`, which a command-line flag cannot win against.
-    /// `-Ctarget-cpu` and `-Ctarget-feature` are the supported way to raise the
-    /// baseline, because they move the Rust half too.
+    /// A macro-dump-capable compiler pointed at PCLMUL through the environment
+    /// keeps this kernel. cl.exe stays keyed to Rust's PCLMUL feature because
+    /// its `/arch:AVX*` levels do not promise PCLMUL and RocksDB has no x86
+    /// runtime dispatch for this implementation.
     fn disable_three_way_crc(cfg: &mut cc::Build, target: &Target) {
         cfg.define("NO_PCLMUL", None);
         // Only worth a warning where adding the feature would change the
-        // outcome. On 32-bit and on android the answer is no regardless, and if
+        // outcome. On 32-bit the kernel cannot compile at all, and if
         // PCLMULQDQ is already present then something else ruled the kernel out
         // and telling the user to add it is just wrong.
         let actionable = target.pointer_width == 64
-            && target.os != "android"
             && target.has_feature("sse4.2")
             && !target.has_feature("pclmulqdq");
         if actionable {
@@ -850,16 +882,19 @@ mod vendor {
         if target.has_feature("lzcnt") {
             cfg.flag_if_supported("-mlzcnt");
         }
-        // The android term is inherited and its original justification, that
-        // android does not define `__PCLMUL__` even with the feature, does not
-        // hold: NDK clang defines it from `-mpclmul` like any other clang. Left
-        // alone because it only costs the pipelining and there is no android
-        // target in CI to confirm removing it is safe.
-        let pclmul =
-            target.pointer_width == 64 && target.os != "android" && target.has_feature("pclmulqdq");
-        if pclmul {
+        // NDK clang defines `__PCLMUL__` from `-mpclmul` like any other clang,
+        // so android needs no carve-out.
+        let rust_has_pclmul = target.has_feature("pclmulqdq");
+        if target.pointer_width == 64 && rust_has_pclmul {
             cfg.flag_if_supported("-mpclmul");
-        } else {
+        }
+        let compiler_has_pclmul =
+            target.pointer_width == 64 && !rust_has_pclmul && compiler_defines_pclmul(cfg);
+        if x86::should_disable_three_way_crc(
+            target.pointer_width,
+            rust_has_pclmul,
+            compiler_has_pclmul,
+        ) {
             disable_three_way_crc(cfg, target);
         }
     }
@@ -925,11 +960,11 @@ mod vendor {
         // instruction regardless of `/arch:`, so getting this wrong is an
         // illegal instruction at the first checksum, not a build error.
         //
-        // `level.is_none()` below covers two sub-cases, the SSE4.2 branch and
+        // `level.is_none()` below covers two cases, the SSE4.2 branch and
         // the no-features branch. In the second, `__PCLMUL__` lands without
         // `__SSE4_2__` and `crc32c.cc` ignores it, since it needs both.
-        let pclmul = target.pointer_width == 64 && target.has_feature("pclmulqdq");
-        if !pclmul {
+        let rust_has_pclmul = target.has_feature("pclmulqdq");
+        if x86::should_disable_three_way_crc(target.pointer_width, rust_has_pclmul, false) {
             disable_three_way_crc(cfg, target);
         } else if level.is_none() {
             cfg.define("__PCLMUL__", Some("1"));

--- a/librocksdb-sys/build_support/x86.rs
+++ b/librocksdb-sys/build_support/x86.rs
@@ -1,0 +1,25 @@
+/// The Snappy define justified by the Rust x86 target features on MSVC.
+///
+/// Snappy's own MSVC fallback treats AVX2 as a proxy for BMI2, but Rust lets
+/// callers enable either feature independently.
+pub(crate) fn snappy_msvc_bmi2_define(target_features: &[impl AsRef<str>]) -> Option<&'static str> {
+    target_features
+        .iter()
+        .any(|feature| feature.as_ref() == "bmi2")
+        .then_some("SNAPPY_HAVE_BMI2")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn avx2_without_bmi2_keeps_snappys_bmi2_path_off() {
+        assert_eq!(snappy_msvc_bmi2_define(&["avx2"]), None);
+    }
+
+    #[test]
+    fn bmi2_enables_snappys_bmi2_path_without_avx2() {
+        assert_eq!(snappy_msvc_bmi2_define(&["bmi2"]), Some("SNAPPY_HAVE_BMI2"));
+    }
+}

--- a/librocksdb-sys/build_support/x86.rs
+++ b/librocksdb-sys/build_support/x86.rs
@@ -9,6 +9,30 @@ pub(crate) fn snappy_msvc_bmi2_define(target_features: &[impl AsRef<str>]) -> Op
         .then_some("SNAPPY_HAVE_BMI2")
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum MacroDumpStyle {
+    GnuLike,
+    ClangCl,
+}
+
+/// Arguments that dump the predefined macros for an empty C++ input.
+pub(crate) fn pclmul_macro_dump_args(style: MacroDumpStyle) -> [&'static str; 5] {
+    let dump_macros = match style {
+        MacroDumpStyle::GnuLike => "-dM",
+        MacroDumpStyle::ClangCl => "/clang:-dM",
+    };
+    [dump_macros, "-E", "-x", "c++", "-"]
+}
+
+/// Whether RocksDB must compile out its three-way x86 CRC32C implementation.
+pub(crate) fn should_disable_three_way_crc(
+    pointer_width: u32,
+    rust_has_pclmul: bool,
+    compiler_has_pclmul: bool,
+) -> bool {
+    pointer_width != 64 || !(rust_has_pclmul || compiler_has_pclmul)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -21,5 +45,41 @@ mod tests {
     #[test]
     fn bmi2_enables_snappys_bmi2_path_without_avx2() {
         assert_eq!(snappy_msvc_bmi2_define(&["bmi2"]), Some("SNAPPY_HAVE_BMI2"));
+    }
+
+    #[test]
+    fn clang_cl_escapes_the_macro_dump_option() {
+        assert_eq!(
+            pclmul_macro_dump_args(MacroDumpStyle::ClangCl),
+            ["/clang:-dM", "-E", "-x", "c++", "-"]
+        );
+    }
+
+    #[test]
+    fn gnu_like_compilers_take_the_plain_macro_dump_option() {
+        assert_eq!(
+            pclmul_macro_dump_args(MacroDumpStyle::GnuLike),
+            ["-dM", "-E", "-x", "c++", "-"]
+        );
+    }
+
+    #[test]
+    fn three_way_crc_requires_a_64_bit_target() {
+        assert!(should_disable_three_way_crc(32, true, true));
+    }
+
+    #[test]
+    fn x64_without_pclmul_disables_three_way_crc() {
+        assert!(should_disable_three_way_crc(64, false, false));
+    }
+
+    #[test]
+    fn rust_pclmul_enables_three_way_crc_on_x64() {
+        assert!(!should_disable_three_way_crc(64, true, false));
+    }
+
+    #[test]
+    fn compiler_pclmul_enables_three_way_crc_on_x64() {
+        assert!(!should_disable_three_way_crc(64, false, true));
     }
 }

--- a/librocksdb-sys/tests/build_cpu.rs
+++ b/librocksdb-sys/tests/build_cpu.rs
@@ -1,0 +1,2 @@
+#[path = "../build_support/x86.rs"]
+mod x86;

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -139,17 +139,23 @@ impl Cache {
     /// faster on a large cache, where walking and freeing every entry costs
     /// real time and nothing is going to reuse the memory anyway.
     ///
-    /// The cache keeps working normally after this call, so this is only worth
-    /// doing shortly before the process exits. Anything that would have reused
-    /// the memory later cannot, because it is leaked for the remaining lifetime
-    /// of the process.
-    ///
     /// [`Cache`] is a reference-counted handle, so this affects the shared cache
     /// and every other clone of it, not just this handle.
     ///
     /// Under ASAN or valgrind RocksDB ignores the request and frees the entries
     /// as usual, so the leak is not reported there.
-    pub fn disown_data(&mut self) {
+    ///
+    /// # Safety
+    ///
+    /// Every database and every other user of this cache must be dropped
+    /// before this call — RocksDB's contract is: "Always delete the DB object
+    /// before calling this method!" (`advanced_cache.h`). Nothing may read
+    /// from or write to the cache after this call; RocksDB documents any use
+    /// after disowning as unsupported. Anything that would have reused the
+    /// memory later cannot, because it is leaked for the remaining lifetime of
+    /// the process, which makes this call worth doing only shortly before the
+    /// process exits.
+    pub unsafe fn disown_data(&mut self) {
         unsafe {
             ffi::rocksdb_cache_disown_data(self.0.inner.as_ptr());
         }

--- a/src/compaction_service.rs
+++ b/src/compaction_service.rs
@@ -138,16 +138,18 @@ pub enum EnvPriority {
 
 impl EnvPriority {
     /// Reads a raw `Env::Priority`, or `None` for a value this crate does not
-    /// name.
+    /// name. The discriminant is the raw value — `env.h`,
+    /// `enum Priority { BOTTOM, LOW, HIGH, USER, TOTAL }` — so the enum is the
+    /// only place the mapping is written down and TOTAL reads back as `None`.
     fn try_from_raw(raw: c_int) -> Option<Self> {
-        // env.h:441, `enum Priority { BOTTOM, LOW, HIGH, USER, TOTAL }`.
-        match raw {
-            0 => Some(EnvPriority::Bottom),
-            1 => Some(EnvPriority::Low),
-            2 => Some(EnvPriority::High),
-            3 => Some(EnvPriority::User),
-            _ => None,
-        }
+        [
+            EnvPriority::Bottom,
+            EnvPriority::Low,
+            EnvPriority::High,
+            EnvPriority::User,
+        ]
+        .into_iter()
+        .find(|&candidate| raw == candidate as c_int)
     }
 }
 

--- a/src/db_options.rs
+++ b/src/db_options.rs
@@ -506,21 +506,13 @@ unsafe fn borrowed_string(ptr: *const c_char, len: usize) -> String {
 /// on any value above `kBlobFile`. [`FileType::CompactionProgressFile`] and
 /// [`FileType::Unknown`] sit above it and have no representation in the set.
 fn checksum_handoff_file_type_raw(file_type: FileType) -> Option<c_int> {
-    let raw = match file_type {
-        FileType::WalFile => 0,
-        FileType::DBLockFile => 1,
-        FileType::TableFile => 2,
-        FileType::DescriptorFile => 3,
-        FileType::CurrentFile => 4,
-        FileType::TempFile => 5,
-        FileType::InfoLogFile => 6,
-        FileType::MetaDatabase => 7,
-        FileType::IdentityFile => 8,
-        FileType::OptionsFile => 9,
-        FileType::BlobFile => 10,
-        FileType::CompactionProgressFile | FileType::Unknown => return None,
-    };
-    Some(raw)
+    // Variants below `kBlobFile` are their own `rocksdb::FileType` value, so
+    // the discriminant is the raw int; the enum is the only place the mapping
+    // is written down.
+    match file_type {
+        FileType::CompactionProgressFile | FileType::Unknown => None,
+        representable => Some(representable as c_int),
+    }
 }
 
 impl BlockBasedOptions {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -421,21 +421,25 @@ pub enum FileType {
 
 impl From<i32> for FileType {
     fn from(value: i32) -> Self {
-        match value {
-            0 => FileType::WalFile,
-            1 => FileType::DBLockFile,
-            2 => FileType::TableFile,
-            3 => FileType::DescriptorFile,
-            4 => FileType::CurrentFile,
-            5 => FileType::TempFile,
-            6 => FileType::InfoLogFile,
-            7 => FileType::MetaDatabase,
-            8 => FileType::IdentityFile,
-            9 => FileType::OptionsFile,
-            10 => FileType::BlobFile,
-            11 => FileType::CompactionProgressFile,
-            _ => FileType::Unknown,
+        for candidate in [
+            FileType::WalFile,
+            FileType::DBLockFile,
+            FileType::TableFile,
+            FileType::DescriptorFile,
+            FileType::CurrentFile,
+            FileType::TempFile,
+            FileType::InfoLogFile,
+            FileType::MetaDatabase,
+            FileType::IdentityFile,
+            FileType::OptionsFile,
+            FileType::BlobFile,
+            FileType::CompactionProgressFile,
+        ] {
+            if value == candidate as i32 {
+                return candidate;
+            }
         }
+        FileType::Unknown
     }
 }
 

--- a/tests/test_enum_drift.rs
+++ b/tests/test_enum_drift.rs
@@ -34,6 +34,7 @@ use rust_rocksdb::event_listener::{
 };
 use rust_rocksdb::perf::PerfStatsLevel;
 use rust_rocksdb::statistics::StatsLevel;
+use rust_rocksdb::{EnvPriority, FileType};
 
 /// One entry of a C++ enum, with its computed value.
 #[derive(Debug, PartialEq, Eq)]
@@ -235,6 +236,56 @@ fn status_severity_matches_the_cpp_header() {
 }
 
 #[test]
+fn env_priority_matches_the_cpp_header() {
+    let Some(header) = read_header("include/rocksdb/env.h") else {
+        return;
+    };
+    let cpp = parse_cpp_enum(&header, "enum Priority");
+
+    // TOTAL counts the pools rather than naming one, so a pool inserted
+    // anywhere shifts it, exactly like the count sentinels above.
+    assert_value(&cpp, "BOTTOM", EnvPriority::Bottom as i64);
+    assert_value(&cpp, "LOW", EnvPriority::Low as i64);
+    assert_value(&cpp, "HIGH", EnvPriority::High as i64);
+    assert_value(&cpp, "USER", EnvPriority::User as i64);
+    assert_value(&cpp, "TOTAL", EnvPriority::User as i64 + 1);
+}
+
+#[test]
+fn file_type_matches_the_cpp_header() {
+    let Some(header) = read_header("include/rocksdb/types.h") else {
+        return;
+    };
+    let cpp = parse_cpp_enum(&header, "enum FileType");
+
+    // Check every mapping. A reorder in the middle can leave a few anchors and
+    // the highest value unchanged while still breaking raw-value decoding.
+    assert_value(&cpp, "kWalFile", FileType::WalFile as i64);
+    assert_value(&cpp, "kDBLockFile", FileType::DBLockFile as i64);
+    assert_value(&cpp, "kTableFile", FileType::TableFile as i64);
+    assert_value(&cpp, "kDescriptorFile", FileType::DescriptorFile as i64);
+    assert_value(&cpp, "kCurrentFile", FileType::CurrentFile as i64);
+    assert_value(&cpp, "kTempFile", FileType::TempFile as i64);
+    assert_value(&cpp, "kInfoLogFile", FileType::InfoLogFile as i64);
+    assert_value(&cpp, "kMetaDatabase", FileType::MetaDatabase as i64);
+    assert_value(&cpp, "kIdentityFile", FileType::IdentityFile as i64);
+    assert_value(&cpp, "kOptionsFile", FileType::OptionsFile as i64);
+    assert_value(&cpp, "kBlobFile", FileType::BlobFile as i64);
+    assert_value(
+        &cpp,
+        "kCompactionProgressFile",
+        FileType::CompactionProgressFile as i64,
+    );
+    // FileType has no count sentinel, so also catch an appended variant.
+    let highest = cpp.iter().map(|e| e.value).max().expect("no entries");
+    assert_eq!(
+        FileType::CompactionProgressFile as i64,
+        highest,
+        "upstream FileType now goes up to {highest}, past what this crate names"
+    );
+}
+
+#[test]
 fn stats_level_matches_the_cpp_header() {
     let Some(header) = read_header("include/rocksdb/statistics.h") else {
         return;
@@ -373,4 +424,32 @@ fn flush_reason_decodes_every_variant() {
             "raw {raw} should decode to {reason:?}"
         );
     }
+}
+
+#[test]
+fn file_type_decodes_every_variant() {
+    let all = [
+        FileType::WalFile,
+        FileType::DBLockFile,
+        FileType::TableFile,
+        FileType::DescriptorFile,
+        FileType::CurrentFile,
+        FileType::TempFile,
+        FileType::InfoLogFile,
+        FileType::MetaDatabase,
+        FileType::IdentityFile,
+        FileType::OptionsFile,
+        FileType::BlobFile,
+        FileType::CompactionProgressFile,
+    ];
+    for file_type in all {
+        let raw = file_type as i32;
+        assert_eq!(
+            FileType::from(raw),
+            file_type,
+            "raw {raw} should decode to {file_type:?}"
+        );
+    }
+    // Anything past the last upstream value falls into the catch-all.
+    assert_eq!(FileType::from(FileType::Unknown as i32), FileType::Unknown);
 }


### PR DESCRIPTION
Fixes four defects found while reviewing `master` since v0.52.0. Each fix is kept in its own commit.

### Cache shutdown contract (`31119ca1`)

[RocksDB requires](https://github.com/facebook/rocksdb/blob/abeebd9630f11bd08c28b7bd43c7bdfc62050654/include/rocksdb/advanced_cache.h#L393-L397) every database using a cache to be destroyed before `DisownData`, with no cache access afterward. The Rust wrapper exposed this as a safe method and said the cache kept working.

`Cache::disown_data` is now `unsafe`, and its `# Safety` section states the shutdown contract. The crate has no call sites to migrate.

### Raw enum decoding (`4d95f10c`)

`EnvPriority` and `FileType` crossed the C API as integers, but their values were copied into three separate literal mappings and were absent from the enum drift test.

The decoders now use the Rust enum discriminants. The drift test checks `EnvPriority` against `env.h`, checks all 12 `FileType` mappings against `types.h`, detects appended file types, and exercises every raw `FileType` decode.

### Snappy BMI2 selection on MSVC (`e73d02cb`)

[Snappy treats MSVC AVX2 as a proxy for BMI2](https://github.com/google/snappy/blob/6af9287fbdb913f0794d0148c6aa43b58e63c8e3/snappy.cc#L32-L45), then calls `_bzhi_u32` when that path is enabled. Rust exposes AVX2 and BMI2 independently, so `+avx2,-bmi2` is valid and must not select the BMI2 path.

The build script now defines `SNAPPY_HAVE_BMI2` from Rust's `bmi2` target feature and does not raise Snappy's broader `/arch:` baseline. [Snappy's own MSVC probe](https://github.com/google/snappy/blob/6af9287fbdb913f0794d0148c6aa43b58e63c8e3/CMakeLists.txt#L201-L205) checks `_bzhi_u32` without adding an AVX or AVX2 compiler flag.

### PCLMUL detection (`1fcda45e`)

`NO_PCLMUL` previously depended only on Rust target features. That disabled RocksDB's three-way CRC32C implementation for GCC and Clang builds tuned through flags such as `CXXFLAGS=-march=native`.

GCC and Clang builds now query the compiler's predefined macros under the configured flags. clang-cl uses `/clang:-dM`, since it ignores a bare `-dM` while returning success.

cl.exe stays conservative. An MSVC `/arch:AVX*` level is not treated as PCLMUL support because [RocksDB derives `__PCLMUL__` from `__AVX__`](https://github.com/facebook/rocksdb/blob/abeebd9630f11bd08c28b7bd43c7bdfc62050654/port/lang.h#L82-L92) and [does not runtime-dispatch this x86 implementation](https://github.com/facebook/rocksdb/blob/abeebd9630f11bd08c28b7bd43c7bdfc62050654/util/crc32c.cc#L1111-L1126). The three-way implementation stays disabled unless Rust explicitly enables `pclmulqdq`, and it always stays disabled on 32-bit x86 because `_mm_crc32_u64` is unavailable there.

Android now follows the same compiler probe. NDK Clang defines `__PCLMUL__` when `-mpclmul` is enabled, so it does not need a separate carve-out.

## Verification

- `cargo test --all`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `cargo test --test test_enum_drift`: 13 passed
- `cargo test -p rust-librocksdb-sys --test build_cpu`: 8 passed
- clang-cl 20.1.8 macro probes confirmed that `/clang:-dM` reports PCLMUL for `-march=haswell` and does not report it for `-march=x86-64-v3`

## Remaining validation gaps

The rewritten head has not run on a VM that masks PCLMUL or BMI2, and it has not had a complete tuned cl.exe build.
