### PR TITLE
Release 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 ## 0.53.0 (2026-09-05)
 
-This release closes the usable gaps between the safe wrapper and the bundled
-RocksDB 11.8.1 C API. It also adds reusable prefix probes and fixes native CPU
-feature selection. Read the breaking changes before upgrading.
+This release adds broad safe-wrapper coverage for the bundled RocksDB 11.8.1 C
+API. It also adds reusable prefix probes and fixes native CPU feature selection.
+Read the breaking changes before upgrading.
 
 `rust-librocksdb-sys` moves to 0.48.1+11.8.1 to publish the native build fixes.
 The bundled RocksDB version stays at 11.8.1.
@@ -28,6 +28,10 @@ The bundled RocksDB version stays at 11.8.1.
   concurrent background use. Closures that capture non-thread-safe state must
   move that state behind a thread-safe type.
   ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
+- feat!: system-linked builds now require RocksDB 11.8.x headers and library.
+  New option wrappers bind C functions introduced in 11.8, so RocksDB 11.6 and
+  11.7 no longer compile. Vendored builds still use RocksDB 11.8.1.
+  ([#266](https://github.com/zaidoon1/rust-rocksdb/pull/266))
 
 ### New APIs
 
@@ -59,17 +63,6 @@ The bundled RocksDB version stays at 11.8.1.
 - feat: expose `Cache::disown_data` as an unsafe operation. Every database using
   the cache must be destroyed before the call, and the cache must not be used
   afterward. ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268),
-  [#284](https://github.com/zaidoon1/rust-rocksdb/pull/284))
-
-### Correctness
-
-- fix: initialize the table factory in `CompactionServiceOptionsOverride`.
-  Remote compaction dereferenced the previous null factory and crashed.
-  ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
-- fix: derive C API enum values from the generated bindings where possible and
-  check the remaining mappings against the vendored headers. This prevents a
-  RocksDB update from silently decoding a new value as the wrong Rust variant.
-  ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268),
   [#284](https://github.com/zaidoon1/rust-rocksdb/pull/284))
 
 ### Native build fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,110 @@
 # Changelog
 
+## 0.53.0 (2026-09-05)
+
+This release closes the usable gaps between the safe wrapper and the bundled
+RocksDB 11.8.1 C API. It also adds reusable prefix probes and fixes native CPU
+feature selection. Read the breaking changes before upgrading.
+
+`rust-librocksdb-sys` moves to 0.48.1+11.8.1 to publish the native build fixes.
+The bundled RocksDB version stays at 11.8.1.
+
+### Breaking changes
+
+- fix!: `StatsLevel` now matches RocksDB. Its representation changes from `u8`
+  to `u32`, and the values from `ExceptHistogramOrTimers` through `All` move
+  from `2..=6` to `1..=5`. The four intermediate variants previously selected
+  the next more detailed level. `All` still selected `All` because the C API
+  clamped its old value. Migrate any stored, transmitted, or cast numeric values.
+  ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
+- fix!: `DBCompactionReason` adds `KReadTriggered`, moving `KNumOfReasons` from
+  20 to 21. `DBFlushReason` adds `KMemtableMaxRangeDeletions`, moving `KUnknown`
+  from 15 to 16. Add arms to exhaustive matches and migrate persisted sentinel
+  values. ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
+- feat!: `BackupEngineInfo` adds `app_metadata: Vec<u8>`. Struct literals must
+  initialize the new field.
+  ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
+- fix!: comparator callbacks now require `Send + Sync`, matching RocksDB's
+  concurrent background use. Closures that capture non-thread-safe state must
+  move that state behind a thread-safe type.
+  ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
+
+### New APIs
+
+- feat: add 307 missing option methods across the existing database, column
+  family, table, read, write, transaction, backup, restore, flush, ingest,
+  compact, and wait option types.
+  ([#266](https://github.com/zaidoon1/rust-rocksdb/pull/266))
+- feat: add 203 accessors across 21 existing types. Event listeners can now
+  read blob file counts, thread and job IDs, aborted state, ingest sequence
+  numbers, and other flush, compaction, and ingest details.
+  ([#267](https://github.com/zaidoon1/rust-rocksdb/pull/267))
+- feat: add typed APIs for explicit file compaction, remote compaction services,
+  `open_and_compact`, column family creation with TTL, background work control,
+  checksum verification, and manual compaction control.
+  ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
+- feat: add backup metadata and callbacks, optimistic transaction checkpoints,
+  timestamp-aware gets and multi-gets, history trimming, optimistic concurrency
+  options, transaction multi-get-for-update, and write batch savepoints and
+  range operations. ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
+- feat: add typed access to live file and column family metadata, table
+  properties, WAL files and filters, query, I/O, and block cache tracing, trace
+  replay, `EnvOptions`, file checksum factories, SST partitioners, cache
+  allocators, and cache configuration.
+  ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
+- feat: add `PrefixProber::refresh` and `OwnedPrefixProber` for cached probes
+  that can advance to the latest committed sequence and keep their database
+  alive. `exists` now makes one iterator validity call instead of two.
+  ([#276](https://github.com/zaidoon1/rust-rocksdb/pull/276))
+- feat: expose `Cache::disown_data` as an unsafe operation. Every database using
+  the cache must be destroyed before the call, and the cache must not be used
+  afterward. ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268),
+  [#284](https://github.com/zaidoon1/rust-rocksdb/pull/284))
+
+### Correctness
+
+- fix: initialize the table factory in `CompactionServiceOptionsOverride`.
+  Remote compaction dereferenced the previous null factory and crashed.
+  ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268))
+- fix: derive C API enum values from the generated bindings where possible and
+  check the remaining mappings against the vendored headers. This prevents a
+  RocksDB update from silently decoding a new value as the wrong Rust variant.
+  ([#268](https://github.com/zaidoon1/rust-rocksdb/pull/268),
+  [#284](https://github.com/zaidoon1/rust-rocksdb/pull/284))
+
+### Native build fixes
+
+- fix: match RocksDB and Snappy CPU features to the Rust target and active C++
+  compiler. This fixes `x86-64-v3`, `x86-64-v4`, and 32-bit x86 builds, enables
+  supported MSVC paths, and handles clang-cl separately from `cl.exe`.
+  ([#278](https://github.com/zaidoon1/rust-rocksdb/pull/278))
+- fix: honor PCLMUL enabled through GCC or Clang `CXXFLAGS`. For `cl.exe`, use
+  Rust's explicit `pclmulqdq` feature because `/arch:AVX*` does not prove
+  PCLMUL support. Enable Snappy's BMI2 path only when Rust enables `bmi2`.
+  ([#284](https://github.com/zaidoon1/rust-rocksdb/pull/284))
+- fix: apply the MinGW configuration to every MinGW target and support
+  `malloc-usable-size` on Android and FreeBSD.
+  ([#278](https://github.com/zaidoon1/rust-rocksdb/pull/278))
+
+### Packaging and documentation
+
+- fix: stop publishing integration tests, the benchmark, and stale repository
+  files in the root crate. The package drops from 123 files to 62.
+  ([#269](https://github.com/zaidoon1/rust-rocksdb/pull/269))
+- fix: express the `rust-librocksdb-sys` license as valid SPDX,
+  `MIT OR Apache-2.0 OR BSD-3-Clause`. This keeps the existing choice of
+  licenses while fixing the package metadata.
+  ([#269](https://github.com/zaidoon1/rust-rocksdb/pull/269))
+- docs: add private vulnerability reporting instructions and document which
+  safe wrapper failures belong in a security report.
+  ([#269](https://github.com/zaidoon1/rust-rocksdb/pull/269))
+- docs: fix the docs.rs build on current nightly by removing a redundant
+  explicit rustdoc link target.
+  ([#283](https://github.com/zaidoon1/rust-rocksdb/pull/283))
+- docs: remove the obsolete `delete_range` warning from
+  `PrefixProber::refresh`. Bundled RocksDB has contained the upstream range
+  tombstone refresh fix since 2022.
+
 ## 0.52.0 (2026-08-08)
 
 This release contains breaking API changes, marked `fix!` and `feat!`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -648,7 +648,7 @@ checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
 name = "rust-librocksdb-sys"
-version = "0.48.0+11.8.1"
+version = "0.48.1+11.8.1"
 dependencies = [
  "bindgen",
  "bzip2-sys",
@@ -667,7 +667,7 @@ dependencies = [
 
 [[package]]
 name = "rust-rocksdb"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "criterion",
  "libc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-rocksdb"
 description = "Rust wrapper for Facebook's RocksDB embeddable database"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2024"
 rust-version = "1.91.0"
 authors = [
@@ -75,7 +75,7 @@ raw-ptr = []
 
 [dependencies]
 libc = "0.2"
-rust-librocksdb-sys = { path = "librocksdb-sys", version = "0.48.0", default-features = false, features = [
+rust-librocksdb-sys = { path = "librocksdb-sys", version = "0.48.1", default-features = false, features = [
     "static",
 ] }
 serde = { version = "1", features = ["derive"], optional = true }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-rust-rocksdb = "0.43"
+rust-rocksdb = "0.53"
 ```
 
 ### Basic Example

--- a/librocksdb-sys/Cargo.toml
+++ b/librocksdb-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-librocksdb-sys"
-version = "0.48.0+11.8.1"
+version = "0.48.1+11.8.1"
 edition = "2024"
 rust-version = "1.91.0"
 authors = [

--- a/src/compaction_service.rs
+++ b/src/compaction_service.rs
@@ -155,16 +155,32 @@ impl EnvPriority {
 
 /// Reads a raw `rocksdb::CompactionReason`.
 ///
-/// `None` covers `kReadTriggered`, which [`DBCompactionReason`] has no variant
-/// for, the `kNumOfReasons` count sentinel, and anything a newer RocksDB adds.
+/// `None` covers the `kNumOfReasons` count sentinel and anything a newer
+/// RocksDB adds.
 fn compaction_reason_from_raw(raw: c_int) -> Option<DBCompactionReason> {
-    // `DBCompactionReason` stops at `KRefitLevel`, which is 19 in
-    // `listener.h:113`, and its own `From<u32>` reads 20 as the count sentinel
-    // rather than as `kReadTriggered`. Only the range both agree on is mapped.
-    if !(0..=19).contains(&raw) {
+    if !(DBCompactionReason::KUnknown as c_int..DBCompactionReason::KNumOfReasons as c_int)
+        .contains(&raw)
+    {
         return None;
     }
     Some(DBCompactionReason::from(raw as u32))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_triggered_is_a_named_compaction_reason() {
+        assert_eq!(
+            compaction_reason_from_raw(DBCompactionReason::KReadTriggered as c_int),
+            Some(DBCompactionReason::KReadTriggered)
+        );
+        assert_eq!(
+            compaction_reason_from_raw(DBCompactionReason::KNumOfReasons as c_int),
+            None
+        );
+    }
 }
 
 /// Builds a slice from a pointer and length pair borrowed from C++.

--- a/src/db.rs
+++ b/src/db.rs
@@ -342,8 +342,7 @@ impl<D: DBAccess + 'static> OwnedPrefixProber<D> {
 
     /// Moves the probe to the latest committed state of the database.
     ///
-    /// See [`PrefixProber::refresh`], including its warning about
-    /// `delete_range`.
+    /// See [`PrefixProber::refresh`].
     ///
     /// # Errors
     ///

--- a/src/db.rs
+++ b/src/db.rs
@@ -243,11 +243,6 @@ impl<D: DBAccess> PrefixProber<'_, D> {
     /// cached prober that is never refreshed holds them for as long as it
     /// lives, so pool them on a timer rather than on request arrival.
     ///
-    /// Do not use this against a database that issues `delete_range`. RocksDB
-    /// does not refresh range tombstones correctly, so a refreshed probe can
-    /// report a deleted prefix as still present. See facebook/rocksdb#9255 and
-    /// facebook/rocksdb#7212, both open.
-    ///
     /// # Errors
     ///
     /// Returns the RocksDB error if the refresh failed.


### PR DESCRIPTION
## Versions

- `rust-rocksdb`: 0.52.0 -> **0.53.0**
- `rust-librocksdb-sys`: 0.48.0+11.8.1 -> **0.48.1+11.8.1**

This release has breaking API changes. The changes most likely to need migration work are:

- `StatsLevel` now uses RocksDB's representation and discriminants. The four intermediate levels previously selected the next more detailed level.
- `DBCompactionReason` and `DBFlushReason` gained variants, which moved their count or unknown sentinels.
- `BackupEngineInfo` gained the public `app_metadata` field.
- Comparator callbacks now require `Send + Sync`.
- System-linked builds now require RocksDB 11.8.x headers and library. Vendored builds still use RocksDB 11.8.1.

## What is in this release

Full notes are in `CHANGELOG.md`.

### APIs

- Adds 307 option methods and 203 accessors across the existing wrapper types.
- Adds typed APIs for remote and explicit compaction, backup metadata and callbacks, timestamp-aware reads, transaction checkpoints, history trimming, table and live-file metadata, tracing, cache configuration, and other RocksDB 11.8.1 capabilities.
- Adds `PrefixProber::refresh` and `OwnedPrefixProber` for reusable cached prefix probes.

### Fixes and packaging

- Matches RocksDB and Snappy CPU features to the Rust target and active C++ compiler, including x86-64-v3, x86-64-v4, 32-bit x86, MSVC, clang-cl, MinGW, Android, and FreeBSD cases.
- Preserves `KReadTriggered` when remote compaction job information is converted to the public enum.
- Publishes 62 root-crate files instead of 123, fixes the sys crate SPDX license expression, and fixes the docs.rs nightly build.
- Updates the README dependency example and removes an obsolete `PrefixProber::refresh` warning.

## Publishing note

Publish `rust-librocksdb-sys` 0.48.1+11.8.1 first, then `rust-rocksdb` 0.53.0. The root manifest requires sys 0.48.1, so its registry package cannot resolve until the sys crate is on crates.io.

After this PR merges, put the lightweight `v0.53.0` tag on the final `master` merge commit and create the GitHub release from that tag.

## Verifications run

- `git diff --check` passes.
- `cargo metadata --no-deps --format-version 1 --locked` passes.
- `cargo fmt --all -- --check` passes.
- `cargo check --locked` passes.
- `cargo test --locked --lib` passes 29 tests.
- `cargo test --locked --doc` passes 116 tests with 2 ignored.
- `cargo clippy --locked --lib --tests -- -D warnings` passes.
- `cargo publish --dry-run --locked -p rust-librocksdb-sys` packages 1,126 files, 18.3 MiB uncompressed and 3.7 MiB compressed, then compiles the package successfully.
- `cargo publish --dry-run --locked -p rust-rocksdb` reaches the expected ordering block because crates.io does not have `rust-librocksdb-sys ^0.48.1` yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected compaction reason reporting so read-triggered compactions are identified correctly.
  - Added coverage for recognized and sentinel compaction reasons.

- **Documentation**
  - Updated the README dependency example to the latest release version.
  - Simplified prefix prober refresh documentation by removing an outdated warning.

- **Release Updates**
  - Updated the library and underlying RocksDB bindings to their latest patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->